### PR TITLE
chore: enable UI rereview via aireview team

### DIFF
--- a/.kodiai.yml
+++ b/.kodiai.yml
@@ -1,0 +1,3 @@
+review:
+  uiRereviewTeam: aireview
+  requestUiRereviewTeamOnOpen: true


### PR DESCRIPTION
## Issues
- Want UI-only rereview trigger (no comment) via a requested-reviewer team.

## Fix
- Add .kodiai.yml enabling uiRereviewTeam=aireview and auto-request on open.

## Notes
- Team must exist and have repo access (aireview).
