### PR TITLE
Fix: accept aireview as UI rereview team

### DIFF
--- a/docs/runbooks/review-requested-debug.md
+++ b/docs/runbooks/review-requested-debug.md
@@ -4,7 +4,7 @@ Use this runbook when manual re-requesting kodiai on a PR does not trigger a rev
 
 ## UI-based Re-review (Team Request)
 
-If you want a UI-only retrigger (no comment), request review from the team `ai-review`.
+If you want a UI-only retrigger (no comment), request review from the team `ai-review` (or `aireview`).
 Kodiai treats `pull_request.review_requested` for that team as a re-review trigger.
 
 ## 1) Confirm webhook delivery exists in GitHub
@@ -68,7 +68,7 @@ Expected outcomes:
 
 If skip reason is `non-kodiai-reviewer`, confirm the re-request target is the app reviewer (`kodiai` or `kodiai[bot]`).
 
-If using team-based UI retrigger, confirm the requested team is `ai-review`.
+If using team-based UI retrigger, confirm the requested team is `ai-review` or `aireview`.
 
 ## 4) Verify queue lifecycle for same delivery
 

--- a/src/handlers/review.ts
+++ b/src/handlers/review.ts
@@ -44,7 +44,8 @@ function normalizeReviewerLogin(login: string): string {
  *
  * Trigger model: initial review events plus explicit re-request only.
  * Re-requested reviews run only when kodiai itself is the requested reviewer.
- * Additionally, a team-based re-request is supported for the special team slug/name "ai-review"
+ * Additionally, a team-based re-request is supported for a special rereview team
+ * ("ai-review" / "aireview") to enable UI-only re-review without a comment.
  * to enable UI-only re-review without a comment.
  * Clones the repo, builds a review prompt, runs Claude via the executor,
  * and optionally submits a silent approval if no issues were found.
@@ -59,7 +60,7 @@ export function createReviewHandler(deps: {
 }): void {
   const { eventRouter, jobQueue, workspaceManager, githubApp, executor, logger } = deps;
 
-  const rereviewTeamSlugs = new Set(["ai-review"]);
+  const rereviewTeamSlugs = new Set(["ai-review", "aireview"]);
 
   async function ensureUiRereviewTeamRequested(options: {
     octokit: Awaited<ReturnType<GitHubApp["getInstallationOctokit"]>>;


### PR DESCRIPTION
## Issues
- Team created as aireview (no hyphen) so team-based rereview trigger did not match ai-review.

## Fix
- Accept both ai-review and aireview as valid rereview team slugs/names.

## Tests
- bun test