### PR TITLE
fix: make rereview team requests resilient

### DIFF
--- a/src/handlers/mention.test.ts
+++ b/src/handlers/mention.test.ts
@@ -1319,6 +1319,7 @@ describe("createMentionHandler rereview command", () => {
               base: { ref: "main" },
             },
           }),
+          listRequestedReviewers: async () => ({ data: { users: [], teams: [] } }),
           requestReviewers: async (params: { team_reviewers: string[] }) => {
             requestedTeams = params.team_reviewers;
             return { data: {} };

--- a/src/handlers/rereview-team.test.ts
+++ b/src/handlers/rereview-team.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import type { Logger } from "pino";
+import {
+  buildRereviewTeamCandidates,
+  requestRereviewTeamBestEffort,
+} from "./rereview-team.ts";
+
+function createNoopLogger(): Logger {
+  return {
+    fatal: () => undefined,
+    error: () => undefined,
+    warn: () => undefined,
+    info: () => undefined,
+    debug: () => undefined,
+    trace: () => undefined,
+    silent: () => undefined,
+  } as unknown as Logger;
+}
+
+describe("rereview-team helpers", () => {
+  test("buildRereviewTeamCandidates normalizes owner/team input and adds alias", () => {
+    expect(buildRereviewTeamCandidates("xbmc/aireview")).toEqual(["aireview", "ai-review"]);
+    expect(buildRereviewTeamCandidates("ai-review")).toEqual(["ai-review", "aireview"]);
+  });
+
+  test("requestRereviewTeamBestEffort skips request when team already present", async () => {
+    let requestCalls = 0;
+    const result = await requestRereviewTeamBestEffort({
+      octokit: {
+        rest: {
+          pulls: {
+            listRequestedReviewers: async () => ({
+              data: { users: [], teams: [{ slug: "aireview", name: "aireview" }] },
+            }),
+            requestReviewers: async () => {
+              requestCalls += 1;
+              return { data: {} };
+            },
+          },
+        },
+      },
+      owner: "xbmc",
+      repo: "kodiai",
+      prNumber: 1,
+      configuredTeam: "aireview",
+      logger: createNoopLogger(),
+    });
+
+    expect(result.alreadyRequested).toBe(true);
+    expect(result.requestedTeam).toBeUndefined();
+    expect(requestCalls).toBe(0);
+  });
+
+  test("requestRereviewTeamBestEffort falls back from aireview to ai-review on 422", async () => {
+    const attempted: string[] = [];
+
+    const result = await requestRereviewTeamBestEffort({
+      octokit: {
+        rest: {
+          pulls: {
+            listRequestedReviewers: async () => ({ data: { users: [], teams: [] } }),
+            requestReviewers: async (params: { team_reviewers: string[] }) => {
+              const slug = params.team_reviewers[0] ?? "";
+              attempted.push(slug);
+              if (slug === "aireview") {
+                const err = new Error("Validation failed") as Error & { status: number };
+                err.status = 422;
+                throw err;
+              }
+              return { data: {} };
+            },
+          },
+        },
+      },
+      owner: "xbmc",
+      repo: "kodiai",
+      prNumber: 2,
+      configuredTeam: "aireview",
+      logger: createNoopLogger(),
+    });
+
+    expect(attempted).toEqual(["aireview", "ai-review"]);
+    expect(result.requestedTeam).toBe("ai-review");
+    expect(result.alreadyRequested).toBe(false);
+  });
+});

--- a/src/handlers/rereview-team.ts
+++ b/src/handlers/rereview-team.ts
@@ -1,0 +1,104 @@
+import type { Logger } from "pino";
+
+function normalizeConfiguredTeam(team: string): string {
+  const trimmed = team.trim().toLowerCase();
+  if (trimmed.length === 0) return "";
+  const lastSlash = trimmed.lastIndexOf("/");
+  return lastSlash >= 0 ? trimmed.slice(lastSlash + 1) : trimmed;
+}
+
+export function buildRereviewTeamCandidates(team: string): string[] {
+  const primary = normalizeConfiguredTeam(team);
+  if (primary.length === 0) return [];
+
+  const candidates = new Set<string>([primary]);
+  if (primary === "ai-review") candidates.add("aireview");
+  if (primary === "aireview") candidates.add("ai-review");
+  return Array.from(candidates);
+}
+
+function getStatusCode(err: unknown): number | undefined {
+  if (typeof err !== "object" || err === null) return undefined;
+  const value = (err as { status?: unknown }).status;
+  return typeof value === "number" ? value : undefined;
+}
+
+export async function requestRereviewTeamBestEffort(options: {
+  octokit: {
+    rest: {
+      pulls: {
+        listRequestedReviewers: (params: {
+          owner: string;
+          repo: string;
+          pull_number: number;
+        }) => Promise<{ data: { teams?: Array<{ slug?: string | null; name?: string | null }> } }>;
+        requestReviewers: (params: {
+          owner: string;
+          repo: string;
+          pull_number: number;
+          team_reviewers: string[];
+        }) => Promise<unknown>;
+      };
+    };
+  };
+  owner: string;
+  repo: string;
+  prNumber: number;
+  configuredTeam: string;
+  logger: Logger;
+}): Promise<{ requestedTeam?: string; alreadyRequested: boolean }> {
+  const { octokit, owner, repo, prNumber, configuredTeam, logger } = options;
+  const candidates = buildRereviewTeamCandidates(configuredTeam);
+  if (candidates.length === 0) return { alreadyRequested: false };
+
+  try {
+    const requested = await octokit.rest.pulls.listRequestedReviewers({
+      owner,
+      repo,
+      pull_number: prNumber,
+    });
+
+    const already = (requested.data.teams ?? []).some((team) => {
+      const slug = (team.slug ?? "").trim().toLowerCase();
+      const name = (team.name ?? "").trim().toLowerCase();
+      return candidates.includes(slug) || candidates.includes(name);
+    });
+    if (already) return { alreadyRequested: true };
+  } catch (err) {
+    logger.warn(
+      { err, owner, repo, prNumber, configuredTeam },
+      "Failed to list requested reviewers; attempting rereview request anyway",
+    );
+  }
+
+  for (const candidate of candidates) {
+    try {
+      await octokit.rest.pulls.requestReviewers({
+        owner,
+        repo,
+        pull_number: prNumber,
+        team_reviewers: [candidate],
+      });
+      return { requestedTeam: candidate, alreadyRequested: false };
+    } catch (err) {
+      const status = getStatusCode(err);
+      const canFallback = status === 422 && candidate !== candidates[candidates.length - 1];
+      logger.warn(
+        {
+          err,
+          owner,
+          repo,
+          prNumber,
+          configuredTeam,
+          candidate,
+          status,
+          fallbackRemaining: canFallback,
+        },
+        "Failed to request rereview team candidate",
+      );
+      if (!canFallback) break;
+    }
+  }
+
+  return { alreadyRequested: false };
+}


### PR DESCRIPTION
## Summary
- add a shared rereview-team helper that normalizes configured team values and supports owner/slug input
- retry team reviewer requests with `aireview`/`ai-review` alias fallback when GitHub returns 422
- reuse helper in both review and mention handlers; add unit coverage for fallback and already-requested behavior

## Verification
- bun test
- bunx tsc --noEmit