### PR TITLE
fix: fallback to app reviewer for rereview triggers

### DIFF
--- a/src/handlers/mention.ts
+++ b/src/handlers/mention.ts
@@ -588,6 +588,7 @@ export function createMentionHandler(deps: {
             repo: mention.repo,
             prNumber: mention.prNumber,
             configuredTeam,
+            fallbackReviewer: githubApp.getAppSlug(),
             logger,
           });
 

--- a/src/handlers/rereview-team.test.ts
+++ b/src/handlers/rereview-team.test.ts
@@ -59,8 +59,8 @@ describe("rereview-team helpers", () => {
         rest: {
           pulls: {
             listRequestedReviewers: async () => ({ data: { users: [], teams: [] } }),
-            requestReviewers: async (params: { team_reviewers: string[] }) => {
-              const slug = params.team_reviewers[0] ?? "";
+            requestReviewers: async (params: { team_reviewers: string[]; reviewers?: string[] }) => {
+              const slug = params.team_reviewers[0] ?? params.reviewers?.[0] ?? "";
               attempted.push(slug);
               if (slug === "aireview") {
                 const err = new Error("Validation failed") as Error & { status: number };
@@ -82,5 +82,39 @@ describe("rereview-team helpers", () => {
     expect(attempted).toEqual(["aireview", "ai-review"]);
     expect(result.requestedTeam).toBe("ai-review");
     expect(result.alreadyRequested).toBe(false);
+  });
+
+  test("requestRereviewTeamBestEffort requests fallback reviewer when teams fail", async () => {
+    const attemptedTeams: string[] = [];
+    let fallbackReviewer: string | undefined;
+
+    await requestRereviewTeamBestEffort({
+      octokit: {
+        rest: {
+          pulls: {
+            listRequestedReviewers: async () => ({ data: { users: [], teams: [] } }),
+            requestReviewers: async (params: { team_reviewers: string[]; reviewers?: string[] }) => {
+              if (params.team_reviewers.length > 0) {
+                attemptedTeams.push(params.team_reviewers[0] ?? "");
+                const err = new Error("team failed") as Error & { status: number };
+                err.status = 422;
+                throw err;
+              }
+              fallbackReviewer = params.reviewers?.[0];
+              return { data: {} };
+            },
+          },
+        },
+      },
+      owner: "xbmc",
+      repo: "kodiai",
+      prNumber: 3,
+      configuredTeam: "aireview",
+      fallbackReviewer: "kodiai",
+      logger: createNoopLogger(),
+    });
+
+    expect(attemptedTeams).toEqual(["aireview", "ai-review"]);
+    expect(fallbackReviewer).toBe("kodiai");
   });
 });

--- a/src/handlers/review.ts
+++ b/src/handlers/review.ts
@@ -296,6 +296,7 @@ export function createReviewHandler(deps: {
             repo: apiRepo,
             prNumber: pr.number,
             configuredTeam: config.review.uiRereviewTeam,
+            fallbackReviewer: githubApp.getAppSlug(),
             logger,
           });
         }


### PR DESCRIPTION
## Summary
- keep team-based rereview requests as primary (`aireview` + alias fallback)
- when team requests fail, request the app reviewer as a fallback to keep `@kodiai recheck` effective
- add unit coverage for fallback reviewer request behavior

## Verification
- bun test
- bunx tsc --noEmit