### PR TITLE
fix: polish plan-only replies and PR reaction behavior

### DIFF
--- a/src/execution/mention-prompt.test.ts
+++ b/src/execution/mention-prompt.test.ts
@@ -36,5 +36,7 @@ describe("buildMentionPrompt", () => {
     expect(prompt).toContain("Issues:");
     expect(prompt).toContain("Issues: none");
     expect(prompt).toContain("path/to/file.ts");
+    expect(prompt).toContain("Prefix first line with: 'Plan only:'");
+    expect(prompt).toContain("Do NOT claim any edits were made");
   });
 });

--- a/src/execution/mention-prompt.ts
+++ b/src/execution/mention-prompt.ts
@@ -124,9 +124,11 @@ export function buildMentionPrompt(params: {
 
   lines.push("- If the user is asking for a plan (e.g. they used `plan:`), respond with:");
   lines.push(
+    "  - Prefix first line with: 'Plan only:'",
     "  - One sentence intent",
     "  - Files: <1-6 paths>",
     "  - Steps: 3-7 steps",
+    "  - Do NOT claim any edits were made, and do NOT use words like 'Done', 'Implemented', or 'Appended'",
     "  - End with: 'Reply with apply: <same request> to implement.'",
   );
 

--- a/src/handlers/mention.ts
+++ b/src/handlers/mention.ts
@@ -616,6 +616,8 @@ export function createMentionHandler(deps: {
               "- Do NOT edit files.",
               "- Do NOT run git commands.",
               "- Do NOT propose opening a PR.",
+              "- Do NOT claim any change was completed.",
+              "- Never use status phrases like: 'Done', 'Implemented', 'Updated', or 'Appended'.",
               "Return a concise plan with 3-7 steps and a list of files you would touch.",
               "End by asking the user to proceed with `apply:` if they want you to implement it.",
             ].join("\n")


### PR DESCRIPTION
## Summary
- tighten plan-only mention instructions so responses avoid implementation-claim wording (e.g. Done/Appended)
- keep explicit plan structure guidance clear and deterministic for `plan:` requests
- only add eyes reaction in review handler for explicit `review_requested` events, not on PR opened/ready states

## Verification
- bun test
- bunx tsc --noEmit