### PR TITLE
fix: recognize /gsd:quick wrapped issue write requests

### DIFF
--- a/src/handlers/mention.ts
+++ b/src/handlers/mention.ts
@@ -210,6 +210,8 @@ export function createMentionHandler(deps: {
       normalized = normalized
         .replace(/^(?:>+\s*)+/, "")
         .replace(/^(?:[-*+]\s+|\d+[.)]\s+)/, "")
+        .replace(/^\/[a-z0-9._:-]+(?:\s+|$)/i, "")
+        .replace(/^https?:\/\/\S+(?:\s+|$)/i, "")
         .replace(/^[`'"([{]+/, "")
         .replace(/^[,.;:!?\-\s]+/, "")
         .replace(/^(?:hey|hi|hello|quick question|question|fyi|context)[,\-:]\s+/i, "")


### PR DESCRIPTION
## Summary
- strip leading slash-command wrappers (for example `/gsd:quick`) and leading URLs before implicit issue write-intent detection
- ensure messages like `@kodiai /gsd:quick https://... fix this so you can open up a PR` route into write-intent handling instead of read-only/manual-command fallback
- add regression coverage for the exact linked issue-comment pattern

## Why
Kodiai missed implicit write intent when issue requests were prefixed by wrapper commands and URLs, which caused read-only behavior and responses like "can't create PR directly" instead of running the trusted write workflow.

## Validation
- bun test src/handlers/mention.test.ts --timeout 30000