### PR TITLE
Prevent stuck review work from blocking explicit @kodiai review

### DIFF
--- a/docs/runbooks/mentions.md
+++ b/docs/runbooks/mentions.md
@@ -83,6 +83,59 @@ If the ingress log is missing for a real delivery, suspect:
 - Signature verification failed (look for `Webhook signature verification failed`)
 - Delivery deduplicated (look for `Duplicate delivery skipped`)
 
+## Queue Lane Model and Explicit Review Stale-Work Signals
+
+The per-installation queue now has three operator-visible lanes. For mention debugging,
+check the queue logs before assuming the worker never ran:
+
+- `interactive-review` — explicit `@kodiai review` requests on a PR. These should enqueue from the mention handler with:
+  - `lane=interactive-review`
+  - `jobType=mention`
+  - `key=<owner>/<repo>#<pr-number>`
+- `review` — automatic PR review jobs (`pull_request.opened`, `pull_request.review_requested`, `pull_request.synchronize`, and related full-review triggers).
+- `sync` — background work that is not the main automatic review lane, including non-review mention requests plus follow-up jobs such as `feedback-sync`, `review-comment-sync`, and similar auxiliary work. These share the installation queue but are not the main review worker.
+
+For any suspected explicit review issue, look at these fields first on `Enqueuing job for installation`, `Job execution started`, and the stale-predecessor telemetry line when it exists:
+
+- `lane`
+- `key`
+- `phase`
+- `predecessorPhase`
+- `predecessorAgeMs`
+
+What those fields mean:
+
+- `lane` tells you whether the request actually went onto the explicit review lane (`interactive-review`) or was routed somewhere else.
+- `key` is the PR-family queue key. For explicit reviews it should be the stable PR key (`owner/repo#pr`), not a comment-specific value.
+- `phase` on the queue logs is the coarse queue lifecycle state:
+  - `queued` on `Enqueuing job for installation`
+  - `running` on `Job execution started`
+- `predecessorPhase` and `predecessorAgeMs` only appear when an explicit review claim discovers an older same-PR review-family attempt.
+  - For explicit mention-review attempts, the review-family phases currently move through `claimed` and `executor-dispatch`; some mention-handler approval/fallback publish paths also promote the attempt to `publish`.
+  - For older automatic review attempts observed as predecessors, `predecessorPhase` can report the finer pre-executor checkpoints that persist across awaits (`workspace-create`, `incremental-diff`) before the executor runs.
+
+### Explicit Review Predecessor Telemetry
+
+When `@kodiai review` successfully claims the interactive-review lane but detects an older same-PR review-family attempt, the mention handler logs:
+
+- `Explicit review claim found a stale predecessor attempt`
+
+Important fields on that log line:
+
+- `reviewFamilyKey`
+- `reviewWorkAttemptId`
+- `predecessorAttemptId`
+- `predecessorPhase`
+- `predecessorAgeMs`
+
+Interpretation:
+
+- `predecessorAttemptId` identifies the older automatic or explicit review-family attempt.
+- `predecessorPhase` tells you the last review-family phase that older attempt reached.
+- `predecessorAgeMs` tells you how long that predecessor had been idle when the explicit claim was made.
+
+This is the main stale-review signal for explicit review mentions: it proves the new same-PR review-family claim was made while an older review-family attempt still existed. It does **not** by itself prove the interactive-review lane started running — use `Enqueuing job for installation` / `Job execution started` for queue acceptance.
+
 ## Evidence Bundle (Write-Mode)
 
 When write-mode is enabled and an `apply:` / `change:` mention creates or reuses a PR, the handler emits a single structured log line:

--- a/docs/runbooks/review-requested-debug.md
+++ b/docs/runbooks/review-requested-debug.md
@@ -3,7 +3,7 @@
 Use this runbook when a manual Kodiai re-review does not trigger correctly. It covers both operator-visible lanes:
 
 - UI re-request via `pull_request.review_requested`
-- Explicit PR comment trigger via `@kodiai review`
+- Explicit PR-scoped mention trigger via `@kodiai review`
 
 ## UI-based Re-review (Team Request)
 
@@ -15,7 +15,10 @@ Kodiai treats `pull_request.review_requested` for that team as a re-review trigg
 There are two valid manual trigger shapes. Verify the one you actually used:
 
 - **UI re-request:** `pull_request` with action `review_requested`
-- **Explicit comment lane:** `issue_comment` with action `created` on the PR, and the comment body contains `@kodiai review`
+- **Explicit review lane:** one of the PR-scoped mention surfaces that can carry `@kodiai review`:
+  - `issue_comment` with action `created` on the PR top-level thread
+  - `pull_request_review_comment` with action `created` on an inline diff thread
+  - `pull_request_review` with action `submitted` when the review body itself contains the trigger
 
 ```sh
 gh api repos/<owner>/<repo>/hooks --jq '.[].id'
@@ -39,7 +42,7 @@ ContainerAppConsoleLogs_CL
 | order by TimeGenerated asc
 ```
 
-If you need to prove the request stayed on the full-review lane, run the adjacent router query:
+If you need to prove the request stayed on the full-review execution path, use the delivery-linked queue/handler logs first, then use the adjacent router query to confirm there was a nearby `taskType=review.full` executor start in the same time window:
 
 ```sh
 # Azure Log Analytics query: router resolution for taskType=review.full
@@ -51,11 +54,46 @@ ContainerAppConsoleLogs_CL
 | order by TimeGenerated asc
 ```
 
-Expected log chain includes:
+Expected early log chain includes:
 - `Webhook accepted and queued for dispatch`
 - `Router evaluated dispatch keys`
-- `Task router resolved model` with `taskType=review.full` for a real review lane
 - Either `Dispatched to ... handler(s)` or an explicit filtered/no-handler skip reason
+
+If the handler actually proceeds into review execution, a later nearby log should show:
+- `Task router resolved model` with `taskType=review.full`
+
+Note: `taskType=review.full` proves the execution path, not the queue lane, and it is not directly keyed by `deliveryId`. Use the delivery-linked queue logs to establish the time window first, then confirm the executor-start log in that same window. To distinguish `lane=review` from `lane=interactive-review`, use the queue logs described below.
+
+## Lane-State and Stale-Job Triage
+
+The queue is installation-scoped and lane-aware. For review debugging, always compare the
+queue logs before assuming the trigger never reached a worker.
+
+Current operator-visible lanes:
+
+- `review` — automatic PR review jobs, including `pull_request.review_requested`
+- `interactive-review` — explicit PR-scoped mention requests via `@kodiai review`
+- `sync` — non-review mention work plus follow-up jobs such as `feedback-sync`, `review-comment-sync`, and other auxiliary work
+
+For the same installation and PR-family key (`owner/repo#pr`), compare these signals in order:
+
+1. `Enqueuing job for installation`
+   - Confirms the job entered the queue.
+   - Check `lane`, `key`, `jobType`, `phase`, `laneQueueSize`, and `lanePendingCount`.
+2. `Job execution started`
+   - Confirms that lane actually acquired a worker.
+   - If enqueue exists but this log never appears for the same `jobId` / `lane` / `key`, the job is still waiting behind another job on that installation lane.
+3. Latest visible `phase`
+   - Queue logs provide the coarse job lifecycle state:
+     - `phase=queued` on `Enqueuing job for installation`
+     - `phase=running` on `Job execution started`
+   - For an explicit `@kodiai review` that is escaping an older automatic review, use `predecessorPhase` from `Explicit review claim found a stale predecessor attempt` to see the last known review-family checkpoint of that older run.
+   - For completed automatic-review runs on the `review` lane, use `Review phase timing summary` to inspect the higher-level timing phases emitted by the review handler (`queue wait`, `workspace preparation`, `retrieval/context assembly`, `executor handoff`, `remote runtime`, `publication`).
+   - For completed explicit `@kodiai review` runs on the `interactive-review` lane, use `Mention execution completed` together with the publish-resolution / idempotency logs instead; the mention handler does not emit `Review phase timing summary`.
+4. Whether another same-installation job is holding the `review` lane
+   - Automatic review_requested runs serialize on `lane=review`.
+   - If a new automatic review is queued but not started, search the same installation for an older active `lane=review` job with the same or different PR key.
+   - Explicit `@kodiai review` runs should use `lane=interactive-review`; if they are blocked, verify they were not misrouted onto `lane=review` or `lane=sync`.
 
 ## Evidence Bundle (Review)
 
@@ -75,19 +113,43 @@ When review output is published or an approval is submitted, the handler emits a
 
 On a PR comment, `@kodiai review` is handled by the mention handler as an explicit review request. The executor still runs on `taskType=review.full`, but the mention handler owns the GitHub approval publish bridge and the publish-resolution logs.
 
-Use the same delivery ID and search for `reviewOutputKey` / publish-resolution evidence:
+If the explicit review looks like it is escaping a stale automatic review, also search for the stale-predecessor telemetry line:
+
+- `Explicit review claim found a stale predecessor attempt`
+
+Key fields on that log line:
+
+- `predecessorAttemptId`
+- `predecessorPhase`
+- `predecessorAgeMs`
+
+Use them like this:
+
+- `predecessorAttemptId` identifies the older same-PR review-family attempt.
+- `predecessorPhase` tells you the last review-family phase that predecessor reached.
+- `predecessorAgeMs` tells you how long that predecessor had been idle when the explicit interactive-review claim succeeded.
+
+That log proves the same-PR review-family claim happened. It does **not** prove the interactive-review lane actually started running yet — use `Enqueuing job for installation` and `Job execution started` for queue acceptance.
+
+Compare those fields with the queue lane-state signals above. If the predecessor was on the same installation and another `lane=review` job is still active, that older automatic run is the likely reason the manual re-review appeared stale.
+
+Start with the delivery-linked logs to discover the `reviewOutputKey`, then pivot to that key (and the same time window) for the mention publish-resolution / completion logs:
 
 ```sh
 ContainerAppConsoleLogs_CL
 | where TimeGenerated > ago(24h)
-| where Log_s has "<delivery-id>"
-| where Log_s has "reviewOutputKey"
+| where Log_s has "<delivery-id>" or Log_s has "<review-output-key>"
 | project TimeGenerated, Log_s
 | order by TimeGenerated asc
 ```
 
 Expected success and recovery outcomes:
 
+- **Executor already published visible review output**
+  - `Mention execution completed` with:
+    - `explicitReviewRequest=true`
+    - `publishResolution=executor`
+    - `reviewOutputKey=<key>`
 - **Fresh approval publish**
   - `Explicit mention review idempotency check passed`
   - `Submitted approval review for explicit mention request`
@@ -129,14 +191,24 @@ If skip reason is `non-kodiai-reviewer`, confirm the re-request target is the ap
 
 If using team-based UI retrigger, confirm the requested team is `ai-review` or `aireview`.
 
-## 5) Verify queue lifecycle for same delivery
+## 5) Verify queue lifecycle
+
+### Automatic review_requested lane (`lane=review`)
 
 Look for queue logs with the same `deliveryId`:
 - `Review enqueue started`
-- `ACA Job start request prepared`
 - `Job execution started`
 - `Job execution completed` (or `Job execution failed`)
 - `Review enqueue completed`
+
+### Explicit `@kodiai review` lane (`lane=interactive-review`)
+
+Use the mention-handler queue logs instead:
+- `Enqueuing job for installation`
+- `Job execution started`
+- `Mention execution completed` (or explicit publish-failure / fallback logs)
+
+`ACA Job start request prepared` is still a useful adjacent signal, but it does not carry `deliveryId` today. Correlate it by time window plus `workspaceDir` (derived from the delivery identity) rather than expecting an exact delivery-ID match.
 
 If `ACA Job start request rejected` appears, inspect the structured fields on that log line:
 - `specImage`

--- a/src/handlers/addon-check.test.ts
+++ b/src/handlers/addon-check.test.ts
@@ -5,7 +5,8 @@ import type { EventRouter, WebhookEvent, EventHandler } from "../webhook/types.t
 import type { Logger } from "pino";
 import type { GitHubApp } from "../auth/github-app.ts";
 import type { AppConfig } from "../config.ts";
-import type { WorkspaceManager, JobQueue, Workspace } from "../jobs/types.ts";
+import type { WorkspaceManager, JobQueue, JobQueueRunMetadata, Workspace } from "../jobs/types.ts";
+import { createQueueRunMetadata, getEmptyActiveJobs } from "../jobs/queue.test-helpers.ts";
 
 // ── Test helpers ──────────────────────────────────────────────────────────
 
@@ -58,6 +59,7 @@ function createMockLoggerWithArrays(
   };
   return logger as unknown as Logger;
 }
+
 
 type CapturedRegistration = { key: string; handler: EventHandler };
 
@@ -185,10 +187,11 @@ function createMockJobQueue(): {
   const queue: JobQueue = {
     enqueue: async (installationId, fn) => {
       enqueueArgs.push({ installationId });
-      return fn();
+      return fn(createQueueRunMetadata());
     },
     getQueueSize: () => 0,
     getPendingCount: () => 0,
+    getActiveJobs: getEmptyActiveJobs,
   };
   return { queue, enqueueArgs };
 }

--- a/src/handlers/addon-check.ts
+++ b/src/handlers/addon-check.ts
@@ -276,6 +276,8 @@ export function createAddonCheckHandler(deps: {
         {
           deliveryId: event.id,
           eventName: "pull_request",
+          lane: "sync",
+          key: `${repo.trim().toLowerCase()}#${prNumber}`,
           jobType: "addon-check",
           prNumber,
         },

--- a/src/handlers/ci-failure.ts
+++ b/src/handlers/ci-failure.ts
@@ -53,6 +53,10 @@ export function createCIFailureHandler(deps: {
     }
 
     const fullRepo = `${owner}/${repoName}`;
+    const queueKey = `${fullRepo.trim().toLowerCase()}#${pullRequests
+      .map((pr) => pr.number)
+      .sort((left, right) => left - right)
+      .join(",")}`;
 
     await jobQueue.enqueue(
       event.installationId,
@@ -248,7 +252,10 @@ export function createCIFailureHandler(deps: {
         deliveryId: event.id,
         eventName: "check_suite",
         action: "completed",
+        lane: "sync",
+        key: queueKey,
         jobType: "ci-failure-analysis",
+        prNumber: pullRequests[0]?.number,
       },
     );
   }

--- a/src/handlers/dep-bump-merge-history.test.ts
+++ b/src/handlers/dep-bump-merge-history.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, test } from "bun:test";
 import type { Logger } from "pino";
 import { createDepBumpMergeHistoryHandler } from "./dep-bump-merge-history.ts";
 import type { EventRouter, WebhookEvent } from "../webhook/types.ts";
-import type { JobQueue } from "../jobs/types.ts";
+import type { JobQueue, JobQueueRunMetadata } from "../jobs/types.ts";
+import { createQueueRunMetadata, getEmptyActiveJobs } from "../jobs/queue.test-helpers.ts";
 import type { GitHubApp } from "../auth/github-app.ts";
 
 function createNoopLogger(): Logger {
@@ -17,6 +18,7 @@ function createNoopLogger(): Logger {
     child: () => createNoopLogger(),
   } as unknown as Logger;
 }
+
 
 function buildPullRequestClosedEvent(params: {
   merged: boolean;
@@ -61,9 +63,10 @@ describe("createDepBumpMergeHistoryHandler", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const githubApp: GitHubApp = {
@@ -123,9 +126,10 @@ describe("createDepBumpMergeHistoryHandler", () => {
         dispatch: async () => undefined,
       },
       jobQueue: {
-        enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+        enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
         getQueueSize: () => 0,
         getPendingCount: () => 0,
+        getActiveJobs: getEmptyActiveJobs,
       },
       githubApp: {
         initialize: async () => undefined,

--- a/src/handlers/dep-bump-merge-history.ts
+++ b/src/handlers/dep-bump-merge-history.ts
@@ -186,6 +186,8 @@ export function createDepBumpMergeHistoryHandler(deps: {
       deliveryId: event.id,
       eventName: event.name,
       action: (payload as unknown as { action?: string }).action,
+      lane: "sync",
+      key: `${owner.trim().toLowerCase()}/${repo.trim().toLowerCase()}#${pr.number}`,
       jobType: "dep-bump-merge-history",
       prNumber: pr.number,
     });

--- a/src/handlers/feedback-sync.test.ts
+++ b/src/handlers/feedback-sync.test.ts
@@ -3,7 +3,8 @@ import type { Logger } from "pino";
 import { createFeedbackSyncHandler } from "./feedback-sync.ts";
 import type { GitHubApp } from "../auth/github-app.ts";
 import type { EventRouter, WebhookEvent } from "../webhook/types.ts";
-import type { JobQueue } from "../jobs/types.ts";
+import type { JobQueue, JobQueueRunMetadata } from "../jobs/types.ts";
+import { createQueueRunMetadata, getEmptyActiveJobs } from "../jobs/queue.test-helpers.ts";
 import type { FeedbackReaction, FindingCommentCandidate, KnowledgeStore } from "../knowledge/types.ts";
 
 function createNoopLogger(): Logger {
@@ -18,6 +19,7 @@ function createNoopLogger(): Logger {
     child: () => createNoopLogger(),
   } as unknown as Logger;
 }
+
 
 function buildPullRequestOpenedEvent(): WebhookEvent {
   return {
@@ -118,9 +120,10 @@ function createHarness(opts: {
   };
 
   const jobQueue: JobQueue = {
-    enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+    enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
     getQueueSize: () => 0,
     getPendingCount: () => 0,
+    getActiveJobs: getEmptyActiveJobs,
   };
 
   const githubApp: GitHubApp = {

--- a/src/handlers/feedback-sync.ts
+++ b/src/handlers/feedback-sync.ts
@@ -78,6 +78,21 @@ function parseRepoFromEventPayload(event: WebhookEvent): string | undefined {
   return `${owner}/${repo}`;
 }
 
+function parsePullRequestNumberFromEvent(event: WebhookEvent): number | undefined {
+  const payload = event.payload as Record<string, unknown>;
+  if (event.name === "issue_comment") {
+    const issue = payload.issue as { number?: number; pull_request?: unknown } | undefined;
+    return issue?.pull_request ? issue.number : undefined;
+  }
+
+  const pullRequest = payload.pull_request as { number?: number } | undefined;
+  return pullRequest?.number;
+}
+
+function buildSyncQueueKey(repo: string, prNumber: number): string {
+  return `${repo.trim().toLowerCase()}#${prNumber}`;
+}
+
 function eventTargetsPullRequest(event: WebhookEvent): boolean {
   if (event.name === "pull_request") return true;
   if (event.name === "pull_request_review_comment") return true;
@@ -113,6 +128,9 @@ export function createFeedbackSyncHandler(deps: {
 
     const repo = parseRepoFromEventPayload(event);
     if (!repo) return;
+
+    const prNumber = parsePullRequestNumberFromEvent(event);
+    if (prNumber === undefined) return;
 
     await jobQueue.enqueue(event.installationId, async () => {
       const appSlug = githubApp.getAppSlug();
@@ -190,9 +208,10 @@ export function createFeedbackSyncHandler(deps: {
       deliveryId: event.id,
       eventName: event.name,
       action: (event.payload as Record<string, unknown>).action as string | undefined,
+      lane: "sync",
+      key: buildSyncQueueKey(repo, prNumber),
       jobType: "feedback-sync",
-      prNumber: ((event.payload as Record<string, unknown>).pull_request as { number?: number } | undefined)
-        ?.number,
+      prNumber,
     });
   }
 

--- a/src/handlers/issue-opened.test.ts
+++ b/src/handlers/issue-opened.test.ts
@@ -6,8 +6,8 @@ import type { EmbeddingProvider, EmbeddingResult } from "../knowledge/types.ts";
 import type { Logger } from "pino";
 import type { Sql } from "../db/client.ts";
 import type { GitHubApp } from "../auth/github-app.ts";
-import type { JobQueue } from "../jobs/types.ts";
-import type { WorkspaceManager } from "../jobs/types.ts";
+import type { JobQueue, JobQueueRunMetadata, WorkspaceManager } from "../jobs/types.ts";
+import { createQueueRunMetadata, getEmptyActiveJobs } from "../jobs/queue.test-helpers.ts";
 import type { RepoConfig } from "../execution/config.ts";
 
 // ── Test helpers ──────────────────────────────────────────────────────────
@@ -21,6 +21,7 @@ function createMockLogger(): Logger {
     child: () => createMockLogger(),
   } as unknown as Logger;
 }
+
 
 type CapturedHandler = { key: string; handler: EventHandler };
 
@@ -37,9 +38,10 @@ function createMockEventRouter(): EventRouter & { captured: CapturedHandler[] } 
 
 function createMockJobQueue(): JobQueue {
   return {
-    enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+    enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
     getQueueSize: () => 0,
     getPendingCount: () => 0,
+    getActiveJobs: getEmptyActiveJobs,
   };
 }
 

--- a/src/handlers/mention.test.ts
+++ b/src/handlers/mention.test.ts
@@ -6973,6 +6973,170 @@ describe("createMentionHandler review command", () => {
     await workspaceFixture.cleanup();
   });
 
+  test("explicit review mentions advance through truthful pre-executor phases", async () => {
+    const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
+    const prNumber = 103;
+    const reviewFamilyKey = buildReviewFamilyKey("acme", "repo", prNumber);
+    const workspaceFixture = await createWorkspaceFixture(
+      [
+        "mention:",
+        "  enabled: true",
+        "review:",
+        "  enabled: true",
+        "  autoApprove: true",
+        "  onSynchronize: true",
+        "",
+      ].join("\n"),
+    );
+
+    const featureSha = (await $`git -C ${workspaceFixture.dir} rev-parse feature`.quiet())
+      .text()
+      .trim();
+    await $`git --git-dir ${workspaceFixture.remoteDir} update-ref refs/pull/${prNumber}/head ${featureSha}`.quiet();
+
+    const phaseTransitions: string[] = [];
+    let phaseAtWorkspaceCreate: string | undefined;
+    let phaseAtConfigWarning: string | undefined;
+    let phasesSeenAtExecutor: string[] = [];
+    const coordinator = createReviewWorkCoordinator({
+      nowFn: (() => {
+        let nowMs = 21_000;
+        return () => ++nowMs;
+      })(),
+    });
+    const reviewWorkCoordinator = {
+      claim: (claim: Parameters<typeof coordinator.claim>[0]) => coordinator.claim(claim),
+      canPublish: (attemptId: Parameters<typeof coordinator.canPublish>[0]) => coordinator.canPublish(attemptId),
+      setPhase: (
+        attemptId: Parameters<typeof coordinator.setPhase>[0],
+        phase: Parameters<NonNullable<typeof coordinator.setPhase>>[1],
+      ) => {
+        phaseTransitions.push(phase);
+        return coordinator.setPhase(attemptId, phase);
+      },
+      getSnapshot: (familyKey: Parameters<typeof coordinator.getSnapshot>[0]) => coordinator.getSnapshot(familyKey),
+      release: (attemptId: Parameters<typeof coordinator.release>[0]) => coordinator.release(attemptId),
+      complete: (attemptId: Parameters<typeof coordinator.complete>[0]) => coordinator.complete(attemptId),
+    };
+
+    const logger = {
+      info: () => undefined,
+      warn: (_bindings: Record<string, unknown>, message: string) => {
+        if (message === "Config warning detected") {
+          phaseAtConfigWarning = coordinator.getSnapshot(reviewFamilyKey)?.attempts[0]?.phase;
+        }
+      },
+      error: () => undefined,
+      debug: () => undefined,
+      trace: () => undefined,
+      fatal: () => undefined,
+      child: () => logger,
+    } as unknown as Logger;
+
+    const eventRouter: EventRouter = {
+      register: (eventKey, handler) => {
+        handlers.set(eventKey, handler);
+      },
+      dispatch: async () => undefined,
+    };
+
+    const jobQueue: JobQueue = {
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
+      getQueueSize: () => 0,
+      getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
+    };
+
+    const workspaceManager: WorkspaceManager = {
+      create: async (_installationId: number, options: CloneOptions) => {
+        phaseAtWorkspaceCreate = coordinator.getSnapshot(reviewFamilyKey)?.attempts[0]?.phase;
+        await $`git -C ${workspaceFixture.dir} checkout ${options.ref}`.quiet();
+        return { dir: workspaceFixture.dir, cleanup: async () => undefined };
+      },
+      cleanupStale: async () => 0,
+    };
+
+    const octokit = {
+      rest: {
+        reactions: {
+          createForIssueComment: async () => ({ data: {} }),
+          createForPullRequestReviewComment: async () => ({ data: {} }),
+        },
+        pulls: {
+          get: async () => ({
+            data: {
+              title: "Test PR",
+              body: "",
+              user: { login: "octocat" },
+              draft: false,
+              labels: [],
+              head: { ref: "feature" },
+              base: { ref: "main" },
+            },
+          }),
+          list: async () => ({ data: [] }),
+          listReviews: async () => ({ data: [] }),
+          listReviewComments: async () => ({ data: [] }),
+          createReplyForReviewComment: async () => ({ data: {} }),
+          createReview: async () => ({ data: {} }),
+        },
+        issues: {
+          listComments: async () => ({ data: [] }),
+          createComment: async () => ({ data: {} }),
+        },
+      },
+    };
+
+    createMentionHandler({
+      eventRouter,
+      jobQueue,
+      workspaceManager,
+      githubApp: {
+        getAppSlug: () => "kodiai",
+        getInstallationOctokit: async () => octokit as never,
+      } as unknown as GitHubApp,
+      executor: {
+        execute: async () => {
+          phasesSeenAtExecutor = [...phaseTransitions];
+          return {
+            conclusion: "success",
+            published: false,
+            resultText: "No issues found.",
+            usedRepoInspectionTools: true,
+            costUsd: 0,
+            numTurns: 1,
+            durationMs: 1,
+            sessionId: "session-mention-phase-checkpoints",
+          };
+        },
+      } as never,
+      telemetryStore: noopTelemetryStore,
+      reviewWorkCoordinator,
+      logger,
+    });
+
+    const handler = handlers.get("issue_comment.created");
+    expect(handler).toBeDefined();
+
+    await handler!(
+      buildPrIssueCommentMentionEvent({
+        prNumber,
+        commentBody: "@kodiai review",
+      }),
+    );
+
+    expect(phaseAtWorkspaceCreate).toBe("workspace-create");
+    expect(phaseAtConfigWarning).toBe("load-config");
+    expect(phasesSeenAtExecutor).toEqual([
+      "workspace-create",
+      "load-config",
+      "prompt-build",
+      "executor-dispatch",
+    ]);
+
+    await workspaceFixture.cleanup();
+  });
+
   test("explicit PR review mention does not submit approval review without inspection evidence", async () => {
     const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
     const workspaceFixture = await createWorkspaceFixture("mention:\n  enabled: true\nreview:\n  autoApprove: true\n");

--- a/src/handlers/mention.test.ts
+++ b/src/handlers/mention.test.ts
@@ -10,7 +10,12 @@ import { scanLinesForFabricatedContent } from "../lib/mention-utils.ts";
 import { createRetriever } from "../knowledge/retrieval.ts";
 import type { EventRouter, WebhookEvent } from "../webhook/types.ts";
 import type { GitHubApp } from "../auth/github-app.ts";
-import type { JobQueue, WorkspaceManager, CloneOptions } from "../jobs/types.ts";
+import type { JobQueue, JobQueueContext, JobQueueRunMetadata, WorkspaceManager, CloneOptions } from "../jobs/types.ts";
+import { createQueueRunMetadata, getEmptyActiveJobs } from "../jobs/queue.test-helpers.ts";
+import {
+  buildReviewFamilyKey,
+  createReviewWorkCoordinator,
+} from "../jobs/review-work-coordinator.ts";
 
 function createNoopLogger(): Logger {
   const noop = () => undefined;
@@ -24,6 +29,7 @@ function createNoopLogger(): Logger {
     child: () => createNoopLogger(),
   } as unknown as Logger;
 }
+
 
 type LogCall = { bindings: Record<string, unknown>; message: string };
 
@@ -61,6 +67,258 @@ function createMockLoggerWithArrays(
     child: () => createMockLoggerWithArrays(infoCalls, warnCalls, errorCalls),
   } as unknown as Logger;
 }
+
+describe("createMentionHandler coordinator wiring", () => {
+  test("logs when the mention handler falls back to a private coordinator", () => {
+    const { logger, warnCalls } = createMockLogger();
+
+    createMentionHandler({
+      eventRouter: {
+        register: () => undefined,
+        dispatch: async () => undefined,
+      },
+      jobQueue: {
+        enqueue: async () => {
+          throw new Error("not used");
+        },
+        getQueueSize: () => 0,
+        getPendingCount: () => 0,
+        getActiveJobs: getEmptyActiveJobs,
+      } as unknown as JobQueue,
+      workspaceManager: {
+        create: async () => {
+          throw new Error("not used");
+        },
+        cleanupStale: async () => 0,
+      } as unknown as WorkspaceManager,
+      githubApp: {
+        getAppSlug: () => "kodiai",
+        getInstallationOctokit: async () => {
+          throw new Error("not used");
+        },
+      } as unknown as GitHubApp,
+      executor: {
+        execute: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      telemetryStore: noopTelemetryStore,
+      logger: logger as never,
+    });
+
+    const fallbackLog = warnCalls.find(
+      (entry) =>
+        entry.message ===
+        "Review work coordinator not injected; using a private handler-local fallback (cross-handler coordination disabled)",
+    );
+
+    expect(fallbackLog?.bindings.gate).toBe("review-family-coordinator");
+    expect(fallbackLog?.bindings.gateResult).toBe("private-fallback");
+    expect(fallbackLog?.bindings.coordinationScope).toBe("handler-local");
+  });
+});
+
+describe("createMentionHandler queued-claim cleanup", () => {
+  test("releases a pre-enqueue explicit-review claim when the request aborts before execution", async () => {
+    const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
+    const workspaceFixture = await createWorkspaceFixture("mention:\n  enabled: true\n  acceptClaudeAlias: false\n");
+    const coordinator = createReviewWorkCoordinator({
+      nowFn: (() => {
+        let nowMs = 3_000;
+        return () => ++nowMs;
+      })(),
+    });
+    const familyKey = buildReviewFamilyKey("acme", "repo", 104);
+    const olderAutomaticAttempt = coordinator.claim({
+      familyKey,
+      source: "automatic-review",
+      lane: "review",
+      deliveryId: "delivery-auto-older",
+      phase: "claimed",
+    });
+    coordinator.setPhase(olderAutomaticAttempt.attemptId, "executor-dispatch");
+
+    createMentionHandler({
+      eventRouter: {
+        register: (eventKey, handler) => {
+          handlers.set(eventKey, handler);
+        },
+        dispatch: async () => undefined,
+      },
+      jobQueue: {
+        enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
+        getQueueSize: () => 0,
+        getPendingCount: () => 0,
+        getActiveJobs: getEmptyActiveJobs,
+      },
+      workspaceManager: {
+        create: async (_installationId: number, options: CloneOptions) => {
+          await $`git -C ${workspaceFixture.dir} checkout ${options.ref}`.quiet();
+          return { dir: workspaceFixture.dir, cleanup: async () => undefined };
+        },
+        cleanupStale: async () => 0,
+      },
+      githubApp: {
+        getAppSlug: () => "kodiai",
+        getInstallationOctokit: async () => ({
+          rest: {
+            pulls: {
+              get: async () => ({
+                data: {
+                  title: "Test PR",
+                  body: "",
+                  user: { login: "octocat" },
+                  head: { ref: "feature" },
+                  base: { ref: "main" },
+                },
+              }),
+            },
+            reactions: {
+              createForIssueComment: async () => ({ data: {} }),
+            },
+          },
+        }) as never,
+      } as unknown as GitHubApp,
+      executor: {
+        execute: async () => {
+          throw new Error("explicit review should have aborted before executor");
+        },
+      } as never,
+      telemetryStore: noopTelemetryStore,
+      reviewWorkCoordinator: coordinator,
+      logger: createNoopLogger() as never,
+    });
+
+    const handler = handlers.get("issue_comment.created");
+    expect(handler).toBeDefined();
+
+    await handler!(
+      buildPrIssueCommentMentionEvent({
+        prNumber: 104,
+        commentBody: "@claude review",
+      }),
+    );
+
+    expect(coordinator.canPublish(olderAutomaticAttempt.attemptId)).toBeTrue();
+    expect(coordinator.getSnapshot(familyKey)?.attempts.map((attempt) => attempt.attemptId)).toEqual([
+      olderAutomaticAttempt.attemptId,
+    ]);
+
+    await workspaceFixture.cleanup();
+  });
+});
+
+describe("createMentionHandler enqueue routing", () => {
+  test("explicit review mentions enqueue onto the interactive-review lane with a stable PR key", async () => {
+    const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
+    const enqueuedContexts: Array<{ lane?: string; key?: string }> = [];
+
+    createMentionHandler({
+      eventRouter: {
+        register: (eventKey, handler) => {
+          handlers.set(eventKey, handler);
+        },
+        dispatch: async () => undefined,
+      },
+      jobQueue: {
+        enqueue: async <T>(
+          _installationId: number,
+          _fn: (metadata: JobQueueRunMetadata) => Promise<T>,
+          context?: JobQueueContext,
+        ) => {
+          enqueuedContexts.push({ lane: context?.lane, key: context?.key });
+          return undefined as T;
+        },
+        getQueueSize: () => 0,
+        getPendingCount: () => 0,
+        getActiveJobs: getEmptyActiveJobs,
+      },
+      workspaceManager: {} as WorkspaceManager,
+      githubApp: {
+        getAppSlug: () => "kodiai",
+        getInstallationOctokit: async () => {
+          throw new Error("not used");
+        },
+      } as unknown as GitHubApp,
+      executor: {
+        execute: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      telemetryStore: noopTelemetryStore,
+      logger: createNoopLogger() as never,
+    });
+
+    const handler = handlers.get("issue_comment.created");
+    expect(handler).toBeDefined();
+
+    await handler!(
+      buildPrIssueCommentMentionEvent({
+        prNumber: 102,
+        commentBody: "@kodiai review",
+      }),
+    );
+
+    expect(enqueuedContexts).toEqual([
+      { lane: "interactive-review", key: "acme/repo#102" },
+    ]);
+  });
+
+  test("non-review issue mentions enqueue onto the sync lane with a stable issue key", async () => {
+    const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
+    const enqueuedContexts: Array<{ lane?: string; key?: string }> = [];
+
+    createMentionHandler({
+      eventRouter: {
+        register: (eventKey, handler) => {
+          handlers.set(eventKey, handler);
+        },
+        dispatch: async () => undefined,
+      },
+      jobQueue: {
+        enqueue: async <T>(
+          _installationId: number,
+          _fn: (metadata: JobQueueRunMetadata) => Promise<T>,
+          context?: JobQueueContext,
+        ) => {
+          enqueuedContexts.push({ lane: context?.lane, key: context?.key });
+          return undefined as T;
+        },
+        getQueueSize: () => 0,
+        getPendingCount: () => 0,
+        getActiveJobs: getEmptyActiveJobs,
+      },
+      workspaceManager: {} as WorkspaceManager,
+      githubApp: {
+        getAppSlug: () => "kodiai",
+        getInstallationOctokit: async () => {
+          throw new Error("not used");
+        },
+      } as unknown as GitHubApp,
+      executor: {
+        execute: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      telemetryStore: noopTelemetryStore,
+      logger: createNoopLogger() as never,
+    });
+
+    const handler = handlers.get("issue_comment.created");
+    expect(handler).toBeDefined();
+
+    await handler!(
+      buildIssueCommentMentionEvent({
+        issueNumber: 77,
+        commentBody: "@kodiai what does this do?",
+      }),
+    );
+
+    expect(enqueuedContexts).toEqual([
+      { lane: "sync", key: "acme/repo#77" },
+    ]);
+  });
+});
 
 const noopTelemetryStore = { record: async () => {}, purgeOlderThan: async () => 0, checkpoint: () => {}, close: () => {} } as never;
 
@@ -262,9 +520,10 @@ describe("createMentionHandler fork PR workspace strategy", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -373,9 +632,10 @@ describe("createMentionHandler conversational review wiring", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -459,9 +719,10 @@ describe("createMentionHandler conversational review wiring", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -558,9 +819,10 @@ describe("createMentionHandler conversational review wiring", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -671,9 +933,10 @@ describe("createMentionHandler conversational review wiring", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -790,9 +1053,10 @@ describe("createMentionHandler conversational review wiring", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -894,9 +1158,10 @@ describe("createMentionHandler conversational review wiring", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -1018,9 +1283,10 @@ describe("createMentionHandler conversational review wiring", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -1177,9 +1443,10 @@ describe("createMentionHandler conversational review wiring", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -1314,9 +1581,10 @@ describe("createMentionHandler conversational review wiring", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -1431,9 +1699,10 @@ describe("createMentionHandler conversational review wiring", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -1541,9 +1810,10 @@ describe("createMentionHandler conversational review wiring", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -1625,12 +1895,13 @@ describe("createMentionHandler conversational review wiring", () => {
         dispatch: async () => undefined,
       },
       jobQueue: {
-        enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => {
+        enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => {
           enqueueCalled = true;
-          return fn();
+          return fn(createQueueRunMetadata());
         },
         getQueueSize: () => 0,
         getPendingCount: () => 0,
+        getActiveJobs: getEmptyActiveJobs,
       },
       workspaceManager: {
         create: async () => {
@@ -1693,9 +1964,10 @@ describe("createMentionHandler conversational review wiring", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -1817,9 +2089,10 @@ describe("createMentionHandler conversational review wiring", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -1952,9 +2225,10 @@ describe("createMentionHandler conversational review wiring", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -2098,9 +2372,10 @@ describe("createMentionHandler conversational review wiring", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -2210,9 +2485,10 @@ describe("createMentionHandler write intent gating", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -2315,9 +2591,10 @@ describe("createMentionHandler write intent gating", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -2410,9 +2687,10 @@ describe("createMentionHandler write intent gating", () => {
       };
 
       const jobQueue: JobQueue = {
-        enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+        enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
         getQueueSize: () => 0,
         getPendingCount: () => 0,
+        getActiveJobs: getEmptyActiveJobs,
       };
 
       const workspaceManager: WorkspaceManager = {
@@ -2516,9 +2794,10 @@ describe("createMentionHandler write intent gating", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -2606,9 +2885,10 @@ describe("createMentionHandler write intent gating", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -2709,9 +2989,10 @@ describe("createMentionHandler write intent gating", () => {
       };
 
       const jobQueue: JobQueue = {
-        enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+        enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
         getQueueSize: () => 0,
         getPendingCount: () => 0,
+        getActiveJobs: getEmptyActiveJobs,
       };
 
       const workspaceManager: WorkspaceManager = {
@@ -2808,9 +3089,10 @@ describe("createMentionHandler write intent gating", () => {
       };
 
       const jobQueue: JobQueue = {
-        enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+        enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
         getQueueSize: () => 0,
         getPendingCount: () => 0,
+        getActiveJobs: getEmptyActiveJobs,
       };
 
       const workspaceManager: WorkspaceManager = {
@@ -2896,9 +3178,10 @@ describe("createMentionHandler write intent gating", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -2987,9 +3270,10 @@ describe("createMentionHandler write intent gating", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -3079,9 +3363,10 @@ describe("createMentionHandler write intent gating", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -3171,9 +3456,10 @@ describe("createMentionHandler write intent gating", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -3269,9 +3555,10 @@ describe("createMentionHandler write intent gating", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -3395,9 +3682,10 @@ describe("createMentionHandler write intent gating", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -3493,9 +3781,10 @@ describe("createMentionHandler write intent gating", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -3600,9 +3889,10 @@ describe("createMentionHandler write intent gating", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -3715,9 +4005,10 @@ describe("createMentionHandler write intent gating", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -3820,9 +4111,10 @@ describe("createMentionHandler write intent gating", () => {
       };
 
       const jobQueue: JobQueue = {
-        enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+        enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
         getQueueSize: () => 0,
         getPendingCount: () => 0,
+        getActiveJobs: getEmptyActiveJobs,
       };
 
       const workspaceManager: WorkspaceManager = {
@@ -3927,9 +4219,10 @@ describe("createMentionHandler write intent gating", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -4045,9 +4338,10 @@ describe("createMentionHandler write intent gating", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -4145,9 +4439,10 @@ describe("createMentionHandler write intent gating", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -4257,9 +4552,10 @@ describe("createMentionHandler write intent gating", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -4369,9 +4665,10 @@ describe("createMentionHandler write intent gating", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -4470,9 +4767,10 @@ describe("createMentionHandler write intent gating", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -4570,9 +4868,10 @@ describe("createMentionHandler write intent gating", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -4673,9 +4972,10 @@ describe("createMentionHandler write intent gating", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -4784,9 +5084,10 @@ describe("createMentionHandler write intent gating", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -4900,9 +5201,10 @@ describe("createMentionHandler write intent gating", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -5025,9 +5327,10 @@ describe("createMentionHandler write intent gating", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -5150,9 +5453,10 @@ describe("createMentionHandler write intent gating", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -5261,9 +5565,10 @@ describe("createMentionHandler write intent gating", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -5373,9 +5678,10 @@ describe("createMentionHandler write intent gating", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -5489,9 +5795,10 @@ describe("createMentionHandler write intent gating", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -5606,9 +5913,10 @@ describe("createMentionHandler write intent gating", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -5735,9 +6043,10 @@ describe("createMentionHandler write intent gating", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -5853,9 +6162,10 @@ describe("createMentionHandler write intent gating", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -5967,9 +6277,10 @@ describe("createMentionHandler multi-query retrieval context (RET-07)", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -6146,9 +6457,10 @@ describe("createMentionHandler multi-query retrieval context (RET-07)", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -6297,9 +6609,10 @@ describe("createMentionHandler multi-query retrieval context (RET-07)", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -6467,9 +6780,10 @@ describe("createMentionHandler review command", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -6569,9 +6883,10 @@ describe("createMentionHandler review command", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -6680,9 +6995,10 @@ describe("createMentionHandler review command", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -6807,9 +7123,10 @@ describe("createMentionHandler review command", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -6946,9 +7263,10 @@ describe("createMentionHandler review command", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -7094,9 +7412,10 @@ describe("createMentionHandler review command", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -7247,9 +7566,10 @@ describe("createMentionHandler review command", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -7385,9 +7705,10 @@ describe("createMentionHandler review command", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -7535,9 +7856,10 @@ describe("createMentionHandler review command", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -7659,6 +7981,520 @@ describe("createMentionHandler review command", () => {
     await workspaceFixture.cleanup();
   });
 
+  test("logs stale predecessor telemetry when an explicit review claim finds an older family attempt", async () => {
+    const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
+    const { logger, infoCalls } = createMockLogger();
+
+    createMentionHandler({
+      eventRouter: {
+        register: (eventKey, handler) => {
+          handlers.set(eventKey, handler);
+        },
+        dispatch: async () => undefined,
+      },
+      jobQueue: {
+        enqueue: async <T>() => undefined as T,
+        getQueueSize: () => 0,
+        getPendingCount: () => 0,
+        getActiveJobs: getEmptyActiveJobs,
+      },
+      workspaceManager: {} as WorkspaceManager,
+      githubApp: {
+        getAppSlug: () => "kodiai",
+        getInstallationOctokit: async () => {
+          throw new Error("not used");
+        },
+      } as unknown as GitHubApp,
+      executor: {
+        execute: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      telemetryStore: noopTelemetryStore,
+      reviewWorkCoordinator: {
+        claim: (claim: Record<string, unknown>) => ({
+          attemptId: "attempt-explicit-claim",
+          familyKey: claim.familyKey as string,
+          source: claim.source as "explicit-review",
+          lane: claim.lane as "interactive-review",
+          deliveryId: claim.deliveryId as string,
+          phase: claim.phase as "claimed",
+          claimedAtMs: 200,
+          lastProgressAtMs: 200,
+        }),
+        canPublish: () => false,
+        setPhase: () => null,
+        getSnapshot: (familyKey: string) => ({
+          familyKey,
+          attempts: [
+            {
+              attemptId: "attempt-automatic-older",
+              familyKey,
+              source: "automatic-review",
+              lane: "review",
+              deliveryId: "delivery-automatic-older",
+              phase: "incremental-diff",
+              claimedAtMs: 100,
+              lastProgressAtMs: 150,
+              supersededByAttemptId: "attempt-explicit-claim",
+            },
+            {
+              attemptId: "attempt-explicit-claim",
+              familyKey,
+              source: "explicit-review",
+              lane: "interactive-review",
+              deliveryId: "delivery-pr-issue-comment-mention",
+              phase: "claimed",
+              claimedAtMs: 200,
+              lastProgressAtMs: 200,
+            },
+          ],
+        }),
+        release: () => undefined,
+        complete: () => undefined,
+      } as never,
+      logger,
+    });
+
+    const handler = handlers.get("issue_comment.created");
+    expect(handler).toBeDefined();
+
+    await handler!(
+      buildPrIssueCommentMentionEvent({
+        prNumber: 104,
+        commentBody: "@kodiai review",
+      }),
+    );
+
+    const predecessorLog = infoCalls.find((entry) =>
+      entry.message === "Explicit review claim found a stale predecessor attempt",
+    );
+    expect(predecessorLog).toBeDefined();
+    expect(predecessorLog?.bindings.reviewFamilyKey).toBe("acme/repo#104");
+    expect(predecessorLog?.bindings.reviewWorkAttemptId).toBe("attempt-explicit-claim");
+    expect(predecessorLog?.bindings.predecessorAttemptId).toBe("attempt-automatic-older");
+    expect(predecessorLog?.bindings.predecessorPhase).toBe("incremental-diff");
+    expect(predecessorLog?.bindings.predecessorAgeMs).toBe(50);
+  });
+
+  test("explicit PR review mention suppresses approval bridge when publish rights were superseded", async () => {
+    const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
+    const workspaceFixture = await createWorkspaceFixture("mention:\n  enabled: true\nreview:\n  autoApprove: true\n");
+
+    const prNumber = 104;
+    const featureSha = (await $`git -C ${workspaceFixture.dir} rev-parse feature`.quiet())
+      .text()
+      .trim();
+    await $`git --git-dir ${workspaceFixture.remoteDir} update-ref refs/pull/${prNumber}/head ${featureSha}`.quiet();
+
+    const { logger, infoCalls } = createMockLogger();
+    const claimedFamilies: Array<Record<string, unknown>> = [];
+    const completedAttemptIds: string[] = [];
+    let createReviewCalls = 0;
+    const issueReplies: string[] = [];
+
+    const eventRouter: EventRouter = {
+      register: (eventKey, handler) => {
+        handlers.set(eventKey, handler);
+      },
+      dispatch: async () => undefined,
+    };
+
+    const jobQueue: JobQueue = {
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
+      getQueueSize: () => 0,
+      getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
+    };
+
+    const workspaceManager: WorkspaceManager = {
+      create: async (_installationId: number, options: CloneOptions) => {
+        await $`git -C ${workspaceFixture.dir} checkout ${options.ref}`.quiet();
+        return { dir: workspaceFixture.dir, cleanup: async () => undefined };
+      },
+      cleanupStale: async () => 0,
+    };
+
+    const octokit = {
+      rest: {
+        reactions: {
+          createForIssueComment: async () => ({ data: {} }),
+          createForPullRequestReviewComment: async () => ({ data: {} }),
+        },
+        pulls: {
+          get: async () => ({
+            data: {
+              title: "Test PR",
+              body: "",
+              user: { login: "octocat" },
+              head: { ref: "feature" },
+              base: { ref: "main" },
+            },
+          }),
+          list: async () => ({ data: [] }),
+          listReviews: async () => ({ data: [] }),
+          listReviewComments: async () => ({ data: [] }),
+          createReplyForReviewComment: async () => ({ data: {} }),
+          createReview: async () => {
+            createReviewCalls++;
+            return { data: {} };
+          },
+        },
+        issues: {
+          listComments: async () => ({ data: [] }),
+          createComment: async ({ body }: { body: string }) => {
+            issueReplies.push(body);
+            return { data: {} };
+          },
+        },
+      },
+    };
+
+    createMentionHandler({
+      eventRouter,
+      jobQueue,
+      workspaceManager,
+      githubApp: {
+        getAppSlug: () => "kodiai",
+        getInstallationOctokit: async () => octokit as never,
+      } as unknown as GitHubApp,
+      executor: {
+        execute: async () => ({
+          conclusion: "success",
+          published: false,
+          costUsd: 0,
+          numTurns: 3,
+          durationMs: 1,
+          sessionId: "session-mention-superseded",
+          model: "claude-sonnet-4-5-20250929",
+          inputTokens: 1,
+          outputTokens: 1,
+          cacheReadTokens: 0,
+          cacheCreationTokens: 0,
+          stopReason: "end_turn",
+          toolUseNames: ["Glob", "Read"],
+          usedRepoInspectionTools: true,
+        }),
+      } as never,
+      telemetryStore: noopTelemetryStore,
+      reviewWorkCoordinator: {
+        claim: (claim: Record<string, unknown>) => {
+          claimedFamilies.push(claim);
+          return {
+            attemptId: "attempt-explicit-1",
+            familyKey: claim.familyKey,
+            source: claim.source,
+            lane: claim.lane,
+            deliveryId: claim.deliveryId,
+            phase: claim.phase,
+            claimedAtMs: 100,
+            lastProgressAtMs: 100,
+          };
+        },
+        canPublish: () => false,
+        setPhase: () => null,
+        getSnapshot: () => null,
+        release: () => undefined,
+        complete: (attemptId: string) => {
+          completedAttemptIds.push(attemptId);
+        },
+      } as never,
+      logger,
+    });
+
+    const handler = handlers.get("issue_comment.created");
+    expect(handler).toBeDefined();
+
+    await handler!(
+      buildPrIssueCommentMentionEvent({
+        prNumber,
+        commentBody: "@kodiai review",
+      }),
+    );
+
+    expect(createReviewCalls).toBe(0);
+    expect(issueReplies).toHaveLength(0);
+    expect(claimedFamilies).toEqual([
+      {
+        familyKey: "acme/repo#104",
+        source: "explicit-review",
+        lane: "interactive-review",
+        deliveryId: "delivery-pr-issue-comment-mention",
+        phase: "claimed",
+      },
+    ]);
+    expect(completedAttemptIds).toEqual(["attempt-explicit-1"]);
+
+    const skipLog = infoCalls.find((entry) =>
+      entry.message === "Skipping explicit mention review publish because publish rights were superseded",
+    );
+    expect(skipLog?.bindings.reviewOutputKey).toBeString();
+
+    const completionLog = infoCalls.find((entry) => entry.message === "Mention execution completed");
+    expect(completionLog?.bindings.explicitReviewRequest).toBe(true);
+    expect(completionLog?.bindings.published).toBe(false);
+    expect(completionLog?.bindings.publishResolution).toBe("none");
+
+    await workspaceFixture.cleanup();
+  });
+
+  async function runSupersededExplicitReviewLatePublish(options: {
+    prNumber: number;
+    executorResult?: {
+      conclusion: "success" | "error" | "failure";
+      published: boolean;
+      costUsd: number;
+      numTurns: number;
+      durationMs: number;
+      sessionId: string;
+      model?: string;
+      inputTokens?: number;
+      outputTokens?: number;
+      cacheReadTokens?: number;
+      cacheCreationTokens?: number;
+      stopReason?: string;
+      toolUseNames?: string[];
+      usedRepoInspectionTools?: boolean;
+      errorMessage?: string;
+      isTimeout?: boolean;
+      resultText?: string;
+    };
+    executorError?: Error;
+  }) {
+    const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
+    const workspaceFixture = await createWorkspaceFixture("mention:\n  enabled: true\nreview:\n  autoApprove: true\n");
+
+    const featureSha = (await $`git -C ${workspaceFixture.dir} rev-parse feature`.quiet())
+      .text()
+      .trim();
+    await $`git --git-dir ${workspaceFixture.remoteDir} update-ref refs/pull/${options.prNumber}/head ${featureSha}`.quiet();
+
+    const { logger, infoCalls, errorCalls } = createMockLogger();
+    const completedAttemptIds: string[] = [];
+    const issueReplies: string[] = [];
+    const reviewThreadReplies: string[] = [];
+    let updateCommentCalls = 0;
+    let createReviewCalls = 0;
+
+    const eventRouter: EventRouter = {
+      register: (eventKey, handler) => {
+        handlers.set(eventKey, handler);
+      },
+      dispatch: async () => undefined,
+    };
+
+    const jobQueue: JobQueue = {
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
+      getQueueSize: () => 0,
+      getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
+    };
+
+    const workspaceManager: WorkspaceManager = {
+      create: async (_installationId: number, options: CloneOptions) => {
+        await $`git -C ${workspaceFixture.dir} checkout ${options.ref}`.quiet();
+        return { dir: workspaceFixture.dir, cleanup: async () => undefined };
+      },
+      cleanupStale: async () => 0,
+    };
+
+    const octokit = {
+      rest: {
+        reactions: {
+          createForIssueComment: async () => ({ data: {} }),
+          createForPullRequestReviewComment: async () => ({ data: {} }),
+        },
+        pulls: {
+          get: async () => ({
+            data: {
+              title: "Test PR",
+              body: "",
+              user: { login: "octocat" },
+              head: { ref: "feature" },
+              base: { ref: "main" },
+            },
+          }),
+          list: async () => ({ data: [] }),
+          listReviews: async () => ({ data: [] }),
+          listReviewComments: async () => ({ data: [] }),
+          createReplyForReviewComment: async ({ body }: { body: string }) => {
+            reviewThreadReplies.push(body);
+            return { data: {} };
+          },
+          createReview: async () => {
+            createReviewCalls += 1;
+            return { data: {} };
+          },
+        },
+        issues: {
+          listComments: async () => ({ data: [] }),
+          createComment: async ({ body }: { body: string }) => {
+            issueReplies.push(body);
+            return { data: { id: issueReplies.length } };
+          },
+          updateComment: async () => {
+            updateCommentCalls += 1;
+            return { data: {} };
+          },
+        },
+      },
+    };
+
+    createMentionHandler({
+      eventRouter,
+      jobQueue,
+      workspaceManager,
+      githubApp: {
+        getAppSlug: () => "kodiai",
+        getInstallationOctokit: async () => octokit as never,
+      } as unknown as GitHubApp,
+      executor: options.executorError
+        ? {
+            execute: async () => {
+              throw options.executorError;
+            },
+          } as never
+        : {
+            execute: async () => options.executorResult!,
+          } as never,
+      telemetryStore: noopTelemetryStore,
+      reviewWorkCoordinator: {
+        claim: (claim: Record<string, unknown>) => ({
+          attemptId: "attempt-explicit-late-1",
+          familyKey: claim.familyKey as string,
+          source: claim.source as "explicit-review",
+          lane: claim.lane as "interactive-review",
+          deliveryId: claim.deliveryId as string,
+          phase: claim.phase as "claimed",
+          claimedAtMs: 100,
+          lastProgressAtMs: 100,
+        }),
+        canPublish: () => false,
+        setPhase: () => null,
+        getSnapshot: () => null,
+        release: () => undefined,
+        complete: (attemptId: string) => {
+          completedAttemptIds.push(attemptId);
+        },
+      } as never,
+      logger,
+    });
+
+    const handler = handlers.get("issue_comment.created");
+    expect(handler).toBeDefined();
+
+    await handler!(
+      buildPrIssueCommentMentionEvent({
+        prNumber: options.prNumber,
+        commentBody: "@kodiai review",
+      }),
+    );
+
+    await workspaceFixture.cleanup();
+
+    return {
+      infoCalls,
+      errorCalls,
+      issueReplies,
+      reviewThreadReplies,
+      updateCommentCalls,
+      createReviewCalls,
+      completedAttemptIds,
+    };
+  }
+
+  test("explicit PR review mention suppresses fallback reply when publish rights were superseded", async () => {
+    const result = await runSupersededExplicitReviewLatePublish({
+      prNumber: 106,
+      executorResult: {
+        conclusion: "success",
+        published: false,
+        costUsd: 0,
+        numTurns: 1,
+        durationMs: 1,
+        sessionId: "session-explicit-late-reply",
+        toolUseNames: ["Read"],
+        usedRepoInspectionTools: false,
+        stopReason: "end_turn",
+      },
+    });
+
+    expect(result.createReviewCalls).toBe(0);
+    expect(result.issueReplies).toHaveLength(0);
+    expect(result.reviewThreadReplies).toHaveLength(0);
+    expect(result.updateCommentCalls).toBe(0);
+    expect(result.completedAttemptIds).toEqual(["attempt-explicit-late-1"]);
+    expect(
+      result.infoCalls.some((entry) => entry.message === "Skipping explicit mention review fallback reply because publish rights were superseded"),
+    ).toBeTrue();
+  });
+
+  test("explicit PR review mention suppresses error fallback when publish rights were superseded", async () => {
+    const result = await runSupersededExplicitReviewLatePublish({
+      prNumber: 107,
+      executorResult: {
+        conclusion: "error",
+        published: false,
+        costUsd: 0,
+        numTurns: 1,
+        durationMs: 1,
+        sessionId: "session-explicit-late-error",
+        toolUseNames: ["Read"],
+        usedRepoInspectionTools: false,
+        errorMessage: "review run failed",
+      },
+    });
+
+    expect(result.createReviewCalls).toBe(0);
+    expect(result.issueReplies).toHaveLength(0);
+    expect(result.reviewThreadReplies).toHaveLength(0);
+    expect(result.updateCommentCalls).toBe(0);
+    expect(result.completedAttemptIds).toEqual(["attempt-explicit-late-1"]);
+    expect(
+      result.infoCalls.some((entry) => entry.message === "Skipping explicit mention review error fallback because publish rights were superseded"),
+    ).toBeTrue();
+  });
+
+  test("explicit PR review mention suppresses failure fallback when publish rights were superseded", async () => {
+    const result = await runSupersededExplicitReviewLatePublish({
+      prNumber: 108,
+      executorResult: {
+        conclusion: "failure",
+        published: false,
+        costUsd: 0,
+        numTurns: 1,
+        durationMs: 1,
+        sessionId: "session-explicit-late-failure",
+        toolUseNames: ["Read"],
+        usedRepoInspectionTools: false,
+        errorMessage: "publish fallback failed",
+        stopReason: "end_turn",
+      },
+    });
+
+    expect(result.createReviewCalls).toBe(0);
+    expect(result.issueReplies).toHaveLength(0);
+    expect(result.reviewThreadReplies).toHaveLength(0);
+    expect(result.updateCommentCalls).toBe(0);
+    expect(result.completedAttemptIds).toEqual(["attempt-explicit-late-1"]);
+    expect(
+      result.infoCalls.some((entry) => entry.message === "Skipping explicit mention review failure fallback because publish rights were superseded"),
+    ).toBeTrue();
+  });
+
+  test("explicit PR review mention suppresses handler failure comment when publish rights were superseded", async () => {
+    const result = await runSupersededExplicitReviewLatePublish({
+      prNumber: 109,
+      executorError: new Error("executor exploded"),
+    });
+
+    expect(result.createReviewCalls).toBe(0);
+    expect(result.issueReplies).toHaveLength(0);
+    expect(result.reviewThreadReplies).toHaveLength(0);
+    expect(result.updateCommentCalls).toBe(0);
+    expect(result.completedAttemptIds).toEqual(["attempt-explicit-late-1"]);
+  });
+
   test("explicit PR review mention logs idempotency skip when review output already exists", async () => {
     const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
     const workspaceFixture = await createWorkspaceFixture("mention:\n  enabled: true\nreview:\n  autoApprove: true\n");
@@ -7691,9 +8527,10 @@ describe("createMentionHandler review command", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -7829,9 +8666,10 @@ describe("createMentionHandler review command", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -7971,9 +8809,10 @@ describe("createMentionHandler review command", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -8112,9 +8951,10 @@ describe("createMentionHandler review command", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -8242,9 +9082,10 @@ describe("createMentionHandler review command", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -8351,9 +9192,10 @@ describe("createMentionHandler review command", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -8496,9 +9338,10 @@ describe("createMentionHandler review command", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -8604,9 +9447,10 @@ describe("createMentionHandler review command", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -8712,9 +9556,10 @@ describe("createMentionHandler review command", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -8819,9 +9664,10 @@ describe("createMentionHandler allowedUsers gating (CONFIG-07)", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -8925,9 +9771,10 @@ describe("createMentionHandler allowedUsers gating (CONFIG-07)", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -9031,9 +9878,10 @@ describe("createMentionHandler allowedUsers gating (CONFIG-07)", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -9143,9 +9991,10 @@ describe("createMentionHandler telemetry opt-out (CONFIG-10)", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -9244,9 +10093,10 @@ describe("createMentionHandler cost warning (CONFIG-11)", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -9329,6 +10179,142 @@ describe("createMentionHandler cost warning (CONFIG-11)", () => {
     expect(costWarningBody!).toContain("$1.00");
   });
 
+  test("explicit PR review mention suppresses cost warning comment when publish rights were superseded", async () => {
+    const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
+    const workspaceFixture = await createWorkspaceFixture(
+      "mention:\n  enabled: true\ntelemetry:\n  enabled: true\n  costWarningUsd: 1.0\nreview:\n  autoApprove: true\n",
+    );
+
+    const prNumber = 110;
+    const featureSha = (await $`git -C ${workspaceFixture.dir} rev-parse feature`.quiet())
+      .text()
+      .trim();
+    await $`git --git-dir ${workspaceFixture.remoteDir} update-ref refs/pull/${prNumber}/head ${featureSha}`.quiet();
+
+    const { logger, infoCalls } = createMockLogger();
+    const completedAttemptIds: string[] = [];
+    const issueReplies: string[] = [];
+    let createReviewCalls = 0;
+
+    const eventRouter: EventRouter = {
+      register: (eventKey, handler) => { handlers.set(eventKey, handler); },
+      dispatch: async () => undefined,
+    };
+
+    const jobQueue: JobQueue = {
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
+      getQueueSize: () => 0,
+      getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
+    };
+
+    const workspaceManager: WorkspaceManager = {
+      create: async (_installationId: number, options: CloneOptions) => {
+        await $`git -C ${workspaceFixture.dir} checkout ${options.ref}`.quiet();
+        return { dir: workspaceFixture.dir, cleanup: async () => undefined };
+      },
+      cleanupStale: async () => 0,
+    };
+
+    const octokit = {
+      rest: {
+        reactions: {
+          createForIssueComment: async () => ({ data: {} }),
+          createForPullRequestReviewComment: async () => ({ data: {} }),
+        },
+        pulls: {
+          get: async () => ({
+            data: {
+              title: "Test PR",
+              body: "",
+              user: { login: "octocat" },
+              head: { ref: "feature" },
+              base: { ref: "main" },
+            },
+          }),
+          list: async () => ({ data: [] }),
+          listReviews: async () => ({ data: [] }),
+          listReviewComments: async () => ({ data: [] }),
+          createReplyForReviewComment: async () => ({ data: {} }),
+          createReview: async () => {
+            createReviewCalls += 1;
+            return { data: {} };
+          },
+        },
+        issues: {
+          listComments: async () => ({ data: [] }),
+          createComment: async ({ body }: { body: string }) => {
+            issueReplies.push(body);
+            return { data: { id: issueReplies.length } };
+          },
+        },
+      },
+    };
+
+    createMentionHandler({
+      eventRouter,
+      jobQueue,
+      workspaceManager,
+      githubApp: {
+        getAppSlug: () => "kodiai",
+        getInstallationOctokit: async () => octokit as never,
+      } as unknown as GitHubApp,
+      executor: {
+        execute: async () => ({
+          conclusion: "success",
+          published: false,
+          costUsd: 3.5,
+          numTurns: 1,
+          durationMs: 1,
+          sessionId: "session-explicit-cost-warning-superseded",
+          toolUseNames: ["Read"],
+          usedRepoInspectionTools: false,
+          stopReason: "end_turn",
+        }),
+      } as never,
+      telemetryStore: noopTelemetryStore,
+      reviewWorkCoordinator: {
+        claim: (claim: Record<string, unknown>) => ({
+          attemptId: "attempt-explicit-cost-warning-1",
+          familyKey: claim.familyKey as string,
+          source: claim.source as "explicit-review",
+          lane: claim.lane as "interactive-review",
+          deliveryId: claim.deliveryId as string,
+          phase: claim.phase as "claimed",
+          claimedAtMs: 100,
+          lastProgressAtMs: 100,
+        }),
+        canPublish: () => false,
+        setPhase: () => null,
+        getSnapshot: () => null,
+        release: () => undefined,
+        complete: (attemptId: string) => {
+          completedAttemptIds.push(attemptId);
+        },
+      } as never,
+      logger,
+    });
+
+    const handler = handlers.get("issue_comment.created");
+    expect(handler).toBeDefined();
+
+    await handler!(
+      buildPrIssueCommentMentionEvent({
+        prNumber,
+        commentBody: "@kodiai review",
+      }),
+    );
+
+    expect(createReviewCalls).toBe(0);
+    expect(issueReplies).toHaveLength(0);
+    expect(completedAttemptIds).toEqual(["attempt-explicit-cost-warning-1"]);
+    expect(
+      infoCalls.some((entry) => entry.message === "Skipping explicit mention review cost warning comment because publish rights were superseded"),
+    ).toBeTrue();
+
+    await workspaceFixture.cleanup();
+  });
+
   test("no cost warning when telemetry disabled", async () => {
     const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
     const workspaceFixture = await createWorkspaceFixture(
@@ -9356,9 +10342,10 @@ describe("createMentionHandler cost warning (CONFIG-11)", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -9495,9 +10482,10 @@ describe("PR surface implicit write intent detection", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -9604,9 +10592,10 @@ describe("PR surface implicit write intent detection", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -9713,9 +10702,10 @@ describe("PR surface implicit write intent detection", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -9822,9 +10812,10 @@ describe("PR surface implicit write intent detection", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -9931,9 +10922,10 @@ describe("PR surface implicit write intent detection", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {

--- a/src/handlers/mention.ts
+++ b/src/handlers/mention.ts
@@ -1186,6 +1186,11 @@ export function createMentionHandler(deps: {
       let reviewPublishRightsLost = false;
       let explicitReviewRequest = false;
       let reviewOutputKey: string | undefined;
+      const explicitReviewUsesCanonicalHandle =
+        reviewWorkAttempt !== undefined && (
+          mention.commentBody.toLowerCase().includes(`@${appSlug.toLowerCase()}`)
+          || mention.commentBody.toLowerCase().includes("@kodai")
+        );
 
       function setReviewWorkPhase(phase: ReviewWorkPhase): void {
         if (!reviewWorkAttempt) {
@@ -1433,6 +1438,9 @@ export function createMentionHandler(deps: {
         }
 
         // Clone workspace
+        if (explicitReviewUsesCanonicalHandle) {
+          setReviewWorkPhase("workspace-create");
+        }
         workspace = await workspaceManager.create(event.installationId, {
           owner: cloneOwner,
           repo: cloneRepo,
@@ -1458,6 +1466,9 @@ export function createMentionHandler(deps: {
           }
         }
 
+        if (explicitReviewUsesCanonicalHandle) {
+          setReviewWorkPhase("load-config");
+        }
         // Load repo config
         const { config, warnings } = await loadRepoConfig(workspace.dir);
         for (const w of warnings) {
@@ -2156,6 +2167,7 @@ export function createMentionHandler(deps: {
           }
         }
 
+        setReviewWorkPhase("prompt-build");
         let prompt: string;
         let explicitReviewPromptFileCount: number | undefined;
         if (explicitReviewRequest && mention.prNumber !== undefined) {

--- a/src/handlers/mention.ts
+++ b/src/handlers/mention.ts
@@ -8,6 +8,7 @@ import { $ } from "bun";
 import { createHash } from "node:crypto";
 import type { EventRouter, WebhookEvent } from "../webhook/types.ts";
 import type { JobQueue, WorkspaceManager, Workspace } from "../jobs/types.ts";
+import type { ReviewWorkCoordinator } from "../jobs/review-work-coordinator.ts";
 import type { GitHubApp } from "../auth/github-app.ts";
 import type { createExecutor } from "../execution/executor.ts";
 import type { TelemetryStore } from "../telemetry/types.ts";
@@ -27,6 +28,11 @@ import {
 } from "../jobs/workspace.ts";
 import type { ForkManager } from "../jobs/fork-manager.ts";
 import type { GistPublisher } from "../jobs/gist-publisher.ts";
+import {
+  buildReviewFamilyKey,
+  createReviewWorkCoordinator,
+  type ReviewWorkPhase,
+} from "../jobs/review-work-coordinator.ts";
 import {
   type MentionEvent,
   normalizeIssueComment,
@@ -100,6 +106,27 @@ type MentionErrorPostResult = {
 
 const MENTION_RETRIEVAL_MAX_CONTEXT_CHARS = 1200;
 
+function buildMentionQueueKey(owner: string, repo: string, issueOrPrNumber: number): string {
+  return `${owner.trim().toLowerCase()}/${repo.trim().toLowerCase()}#${issueOrPrNumber}`;
+}
+
+function findLatestReviewPredecessor(
+  snapshot: ReturnType<ReviewWorkCoordinator["getSnapshot"]>,
+  currentAttemptId: string,
+) {
+  if (!snapshot) {
+    return null;
+  }
+
+  return snapshot.attempts
+    .filter((attempt) => attempt.attemptId !== currentAttemptId)
+    .sort((left, right) => {
+      if (right.lastProgressAtMs !== left.lastProgressAtMs) {
+        return right.lastProgressAtMs - left.lastProgressAtMs;
+      }
+      return right.claimedAtMs - left.claimedAtMs;
+    })[0] ?? null;
+}
 
 
 
@@ -127,6 +154,8 @@ export function createMentionHandler(deps: {
   gistPublisher?: GistPublisher;
   /** Optional SQL client for guardrail audit logging (GUARD-06). */
   sql?: import("../db/client.ts").Sql;
+  /** Optional in-memory coordinator for same-PR review-family publish rights. */
+  reviewWorkCoordinator?: ReviewWorkCoordinator;
   logger: Logger;
 }): void {
   const {
@@ -140,10 +169,23 @@ export function createMentionHandler(deps: {
     forkManager,
     gistPublisher,
     sql,
+    reviewWorkCoordinator: injectedReviewWorkCoordinator,
     logger,
   } = deps;
 
   const guardrailAuditStore = sql ? createGuardrailAuditStore(sql) : undefined;
+  const reviewWorkCoordinator = injectedReviewWorkCoordinator ?? createReviewWorkCoordinator();
+  if (!injectedReviewWorkCoordinator) {
+    logger.warn(
+      {
+        gate: "review-family-coordinator",
+        gateResult: "private-fallback",
+        coordinationScope: "handler-local",
+        handler: "mention",
+      },
+      "Review work coordinator not injected; using a private handler-local fallback (cross-handler coordination disabled)",
+    );
+  }
 
   // Basic in-memory rate limiter for write-mode requests.
   // Keyed by installation+repo; resets on process restart.
@@ -1074,9 +1116,117 @@ export function createMentionHandler(deps: {
     // No tracking comment. Tracking is via eyes reaction only.
     // The response will be posted as a new comment.
 
-    await jobQueue.enqueue(event.installationId, async () => {
+    const provisionalUserQuestion = stripMention(mention.commentBody, possibleHandles);
+    const reviewPrNumber = mention.prNumber;
+    const isExplicitReviewRequest =
+      reviewPrNumber !== undefined && isReviewRequest(provisionalUserQuestion);
+    const mentionQueueKey = buildMentionQueueKey(
+      mention.owner,
+      mention.repo,
+      reviewPrNumber ?? mention.issueNumber,
+    );
+    const queuedReviewWorkAttempt = reviewPrNumber !== undefined && isExplicitReviewRequest
+      ? reviewWorkCoordinator.claim({
+          familyKey: buildReviewFamilyKey(mention.owner, mention.repo, reviewPrNumber),
+          source: "explicit-review",
+          lane: "interactive-review",
+          deliveryId: event.id,
+          phase: "claimed",
+        })
+      : undefined;
+    if (queuedReviewWorkAttempt) {
+      const predecessor = findLatestReviewPredecessor(
+        reviewWorkCoordinator.getSnapshot(queuedReviewWorkAttempt.familyKey),
+        queuedReviewWorkAttempt.attemptId,
+      );
+      if (predecessor) {
+        logger.info(
+          {
+            surface: mention.surface,
+            owner: mention.owner,
+            repo: mention.repo,
+            prNumber: reviewPrNumber,
+            gate: "review-family-coordinator",
+            gateResult: "claimed-with-predecessor",
+            reviewFamilyKey: queuedReviewWorkAttempt.familyKey,
+            reviewWorkAttemptId: queuedReviewWorkAttempt.attemptId,
+            predecessorAttemptId: predecessor.attemptId,
+            predecessorPhase: predecessor.phase,
+            predecessorAgeMs: Math.max(
+              0,
+              queuedReviewWorkAttempt.claimedAtMs - predecessor.lastProgressAtMs,
+            ),
+          },
+          "Explicit review claim found a stale predecessor attempt",
+        );
+      }
+    }
+    let reviewWorkAttemptCommitted = false;
+    let reviewWorkAttemptFinalized = false;
+
+    function finalizeQueuedReviewWorkAttempt(): void {
+      if (!queuedReviewWorkAttempt || reviewWorkAttemptFinalized) {
+        return;
+      }
+
+      reviewWorkAttemptFinalized = true;
+      if (reviewWorkAttemptCommitted) {
+        reviewWorkCoordinator.complete(queuedReviewWorkAttempt.attemptId);
+        return;
+      }
+
+      reviewWorkCoordinator.release(queuedReviewWorkAttempt.attemptId);
+    }
+
+    try {
+      await jobQueue.enqueue(event.installationId, async () => {
       let workspace: Workspace | undefined;
       let acquiredWriteKey: string | undefined;
+      const reviewWorkAttempt = queuedReviewWorkAttempt;
+      let reviewPublishRightsLost = false;
+      let explicitReviewRequest = false;
+      let reviewOutputKey: string | undefined;
+
+      function setReviewWorkPhase(phase: ReviewWorkPhase): void {
+        if (!reviewWorkAttempt) {
+          return;
+        }
+        reviewWorkAttemptCommitted = true;
+        reviewWorkCoordinator.setPhase(reviewWorkAttempt.attemptId, phase);
+      }
+
+      function canPublishExplicitReviewOutput(outputLabel: string, reviewOutputKey?: string): boolean {
+        if (!reviewWorkAttempt) {
+          return true;
+        }
+        const attempt = reviewWorkAttempt;
+        if (reviewWorkCoordinator.canPublish(attempt.attemptId)) {
+          return true;
+        }
+
+        reviewPublishRightsLost = true;
+        const currentAttempt = reviewWorkCoordinator
+          .getSnapshot(attempt.familyKey)
+          ?.attempts.find((candidateAttempt) => candidateAttempt.attemptId === attempt.attemptId);
+        logger.info(
+          {
+            surface: mention.surface,
+            owner: mention.owner,
+            repo: mention.repo,
+            prNumber: mention.prNumber,
+            gate: "review-family-coordinator",
+            gateResult: "skipped",
+            skipReason: "publish-rights-lost",
+            reviewOutputKey: reviewOutputKey ?? null,
+            reviewFamilyKey: attempt.familyKey,
+            reviewWorkAttemptId: attempt.attemptId,
+            supersededByAttemptId: currentAttempt?.supersededByAttemptId ?? null,
+          },
+          `Skipping ${outputLabel} because publish rights were superseded`,
+        );
+        return false;
+      }
+
       try {
         const octokit = await githubApp.getInstallationOctokit(event.installationId);
 
@@ -1397,7 +1547,7 @@ export function createMentionHandler(deps: {
 
         const isIssueThreadComment = event.name === "issue_comment" && mention.prNumber === undefined;
         const isPrSurface = mention.prNumber !== undefined;
-        const explicitReviewRequest = isPrSurface && isReviewRequest(userQuestion);
+        explicitReviewRequest = isPrSurface && isReviewRequest(userQuestion);
         const parsedWriteIntent = parseWriteIntent(userQuestion);
 
         // Issue surfaces: broad implicit intent detection (existing behavior)
@@ -2133,7 +2283,7 @@ export function createMentionHandler(deps: {
               ? (prDiffContext !== undefined ? 12 : 20)
               : undefined; // undefined → falls through to config.maxTurns
 
-        const reviewOutputKey = explicitReviewRequest && mention.prNumber !== undefined
+        reviewOutputKey = explicitReviewRequest && mention.prNumber !== undefined
           ? buildReviewOutputKey({
               installationId: event.installationId,
               owner: mention.owner,
@@ -2146,6 +2296,9 @@ export function createMentionHandler(deps: {
           : undefined;
 
         // Execute via Claude
+        if (reviewWorkAttempt) {
+          setReviewWorkPhase("executor-dispatch");
+        }
         const result = await executor.execute({
           workspace,
           installationId: event.installationId,
@@ -2295,33 +2448,50 @@ export function createMentionHandler(deps: {
                   : null,
               ].filter((line): line is string => Boolean(line));
 
-              await publishOctokit.rest.pulls.createReview({
-                owner: mention.owner,
-                repo: mention.repo,
-                pull_number: mention.prNumber,
-                event: "APPROVE",
-                body: sanitizeOutgoingMentions(
-                  buildApprovedReviewBody({ reviewOutputKey, evidence: approvalEvidence }),
-                  [appSlug, "claude", "kodai"],
-                ),
-              });
-              mentionOutputPublished = true;
-              publishResolution = "approval-bridge";
-              logger.info(
-                {
-                  evidenceType: "review",
-                  outcome: "submitted-approval",
-                  deliveryId: event.id,
-                  installationId: event.installationId,
+              if (!canPublishExplicitReviewOutput("explicit mention review publish", reviewOutputKey)) {
+                logger.info(
+                  {
+                    surface: mention.surface,
+                    owner: mention.owner,
+                    repo: mention.repo,
+                    prNumber: mention.prNumber,
+                    gate: "explicit-review-publish",
+                    gateResult: "skipped",
+                    skipReason: "publish-rights-lost",
+                    reviewOutputKey,
+                  },
+                  "Skipping explicit mention review publish because publish rights were superseded",
+                );
+              } else {
+                setReviewWorkPhase("publish");
+                await publishOctokit.rest.pulls.createReview({
                   owner: mention.owner,
-                  repoName: mention.repo,
-                  repo: `${mention.owner}/${mention.repo}`,
-                  prNumber: mention.prNumber,
-                  reviewOutputKey,
-                  publishAttemptOutcome: "submitted-approval",
-                },
-                "Submitted approval review for explicit mention request",
-              );
+                  repo: mention.repo,
+                  pull_number: mention.prNumber,
+                  event: "APPROVE",
+                  body: sanitizeOutgoingMentions(
+                    buildApprovedReviewBody({ reviewOutputKey, evidence: approvalEvidence }),
+                    [appSlug, "claude", "kodai"],
+                  ),
+                });
+                mentionOutputPublished = true;
+                publishResolution = "approval-bridge";
+                logger.info(
+                  {
+                    evidenceType: "review",
+                    outcome: "submitted-approval",
+                    deliveryId: event.id,
+                    installationId: event.installationId,
+                    owner: mention.owner,
+                    repoName: mention.repo,
+                    repo: `${mention.owner}/${mention.repo}`,
+                    prNumber: mention.prNumber,
+                    reviewOutputKey,
+                    publishAttemptOutcome: "submitted-approval",
+                  },
+                  "Submitted approval review for explicit mention request",
+                );
+              }
             }
           } catch (publishErr) {
             publishFailureCategory = classifyError(publishErr, false);
@@ -2385,30 +2555,48 @@ export function createMentionHandler(deps: {
             }
 
             if (!outputDetectedAfterError) {
-              const fallbackResult = await postMentionError(
-                buildExplicitReviewPublishFailureBody(publishErr),
-              );
-              publishFallbackDelivery = fallbackResult.delivery;
-
-              if (fallbackResult.posted) {
-                mentionOutputPublished = true;
-                publishResolution = "publish-failure-fallback";
-              } else {
-                mentionOutputPublished = false;
-                publishResolution = "publish-failure-comment-failed";
-                logger.warn(
+              if (!canPublishExplicitReviewOutput("explicit mention review fallback comment", reviewOutputKey)) {
+                logger.info(
                   {
-                    deliveryId: event.id,
+                    surface: mention.surface,
                     owner: mention.owner,
                     repo: mention.repo,
                     prNumber: mention.prNumber,
+                    gate: "explicit-review-publish",
+                    gateResult: "skipped",
+                    skipReason: "publish-rights-lost",
                     reviewOutputKey,
-                    publishAttemptOutcome: "fallback-comment-failed",
                     publishFailureCategory,
-                    publishFallbackDelivery,
                   },
-                  "Explicit mention review publish fallback could not be delivered",
+                  "Skipping explicit mention review fallback because publish rights were superseded",
                 );
+              } else {
+                setReviewWorkPhase("publish");
+                const fallbackResult = await postMentionError(
+                  buildExplicitReviewPublishFailureBody(publishErr),
+                );
+                publishFallbackDelivery = fallbackResult.delivery;
+
+                if (fallbackResult.posted) {
+                  mentionOutputPublished = true;
+                  publishResolution = "publish-failure-fallback";
+                } else {
+                  mentionOutputPublished = false;
+                  publishResolution = "publish-failure-comment-failed";
+                  logger.warn(
+                    {
+                      deliveryId: event.id,
+                      owner: mention.owner,
+                      repo: mention.repo,
+                      prNumber: mention.prNumber,
+                      reviewOutputKey,
+                      publishAttemptOutcome: "fallback-comment-failed",
+                      publishFailureCategory,
+                      publishFallbackDelivery,
+                    },
+                    "Explicit mention review publish fallback could not be delivered",
+                  );
+                }
               }
             }
           }
@@ -2483,13 +2671,18 @@ export function createMentionHandler(deps: {
               "Execution cost exceeded warning threshold",
             );
             try {
-              const warnOctokit = await githubApp.getInstallationOctokit(event.installationId);
-              await warnOctokit.rest.issues.createComment({
-                owner: mention.owner,
-                repo: mention.repo,
-                issue_number: mention.issueNumber,
-                body: `> **Kodiai cost warning:** This execution cost \$${result.costUsd.toFixed(4)} USD, exceeding the configured threshold of \$${config.telemetry.costWarningUsd.toFixed(2)} USD.\n>\n> Configure in \`.kodiai.yml\`:\n> \`\`\`yml\n> telemetry:\n>   costWarningUsd: 5.0  # or 0 to disable\n> \`\`\``,
-              });
+              if (
+                !explicitReviewRequest ||
+                canPublishExplicitReviewOutput("explicit mention review cost warning comment", reviewOutputKey)
+              ) {
+                const warnOctokit = await githubApp.getInstallationOctokit(event.installationId);
+                await warnOctokit.rest.issues.createComment({
+                  owner: mention.owner,
+                  repo: mention.repo,
+                  issue_number: mention.issueNumber,
+                  body: `> **Kodiai cost warning:** This execution cost \$${result.costUsd.toFixed(4)} USD, exceeding the configured threshold of \$${config.telemetry.costWarningUsd.toFixed(2)} USD.\n>\n> Configure in \`.kodiai.yml\`:\n> \`\`\`yml\n> telemetry:\n>   costWarningUsd: 5.0  # or 0 to disable\n> \`\`\``,
+                });
+              }
             } catch (err) {
               logger.warn({ err }, "Failed to post cost warning comment (non-blocking)");
             }
@@ -3235,7 +3428,8 @@ export function createMentionHandler(deps: {
           !writeEnabled &&
           result.conclusion === "success" &&
           !mentionOutputPublished &&
-          publishResolution !== "publish-failure-comment-failed"
+          publishResolution !== "publish-failure-comment-failed" &&
+          !reviewPublishRightsLost
         ) {
           const fallbackLines = explicitReviewRequest
             ? explicitReviewResultFindingLines.length > 0
@@ -3261,27 +3455,32 @@ export function createMentionHandler(deps: {
           );
           const sanitizedFallbackBody = sanitizeOutgoingMentions(fallbackBody, possibleHandles);
 
-          const replyOctokit = await githubApp.getInstallationOctokit(event.installationId);
-          if (mention.surface === "pr_review_comment" && mention.prNumber !== undefined) {
-            await replyOctokit.rest.pulls.createReplyForReviewComment({
-              owner: mention.owner,
-              repo: mention.repo,
-              pull_number: mention.prNumber,
-              comment_id: mention.commentId,
-              body: sanitizedFallbackBody,
-            });
-          } else {
-            await replyOctokit.rest.issues.createComment({
-              owner: mention.owner,
-              repo: mention.repo,
-              issue_number: mention.issueNumber,
-              body: sanitizedFallbackBody,
-            });
+          if (
+            !explicitReviewRequest
+            || canPublishExplicitReviewOutput("explicit mention review fallback reply", reviewOutputKey)
+          ) {
+            const replyOctokit = await githubApp.getInstallationOctokit(event.installationId);
+            if (mention.surface === "pr_review_comment" && mention.prNumber !== undefined) {
+              await replyOctokit.rest.pulls.createReplyForReviewComment({
+                owner: mention.owner,
+                repo: mention.repo,
+                pull_number: mention.prNumber,
+                comment_id: mention.commentId,
+                body: sanitizedFallbackBody,
+              });
+            } else {
+              await replyOctokit.rest.issues.createComment({
+                owner: mention.owner,
+                repo: mention.repo,
+                issue_number: mention.issueNumber,
+                body: sanitizedFallbackBody,
+              });
+            }
           }
         }
 
         // If execution errored, post or update error comment with classified message
-        if (result.conclusion === "error") {
+        if (result.conclusion === "error" && !reviewPublishRightsLost) {
           const category = result.isTimeout
             ? "timeout"
             : classifyError(new Error(result.errorMessage ?? "Unknown error"), false);
@@ -3292,13 +3491,18 @@ export function createMentionHandler(deps: {
             ),
             "Kodiai encountered an error",
           );
-          await postMentionError(errorBody);
+          if (
+            !explicitReviewRequest
+            || canPublishExplicitReviewOutput("explicit mention review error fallback", reviewOutputKey)
+          ) {
+            await postMentionError(errorBody);
+          }
         }
 
         // If execution failed without publishing, always post a user-visible fallback.
         // The SDK can return conclusion="failure" with stop reasons other than max_turns,
         // and previously those paths could finish silently.
-        if (result.conclusion === "failure" && !mentionOutputPublished) {
+        if (result.conclusion === "failure" && !mentionOutputPublished && !reviewPublishRightsLost) {
           if (result.stopReason === "max_turns") {
             const turnLimitBody = wrapInDetails(
               [
@@ -3311,7 +3515,12 @@ export function createMentionHandler(deps: {
               "kodiai response",
             );
             try {
-              await postMentionError(turnLimitBody);
+              if (
+                !explicitReviewRequest
+                || canPublishExplicitReviewOutput("explicit mention review failure fallback", reviewOutputKey)
+              ) {
+                await postMentionError(turnLimitBody);
+              }
             } catch (postErr) {
               logger.warn(
                 { err: postErr, surface: mention.surface, issueNumber: mention.issueNumber },
@@ -3334,7 +3543,12 @@ export function createMentionHandler(deps: {
             );
             const failureBody = wrapInDetails(detailLines.join("\n"), "kodiai response");
             try {
-              await postMentionError(failureBody);
+              if (
+                !explicitReviewRequest
+                || canPublishExplicitReviewOutput("explicit mention review failure fallback", reviewOutputKey)
+              ) {
+                await postMentionError(failureBody);
+              }
             } catch (postErr) {
               logger.warn(
                 { err: postErr, surface: mention.surface, issueNumber: mention.issueNumber, stopReason: result.stopReason },
@@ -3355,28 +3569,33 @@ export function createMentionHandler(deps: {
         const errorBody = wrapInDetails(formatErrorComment(category, detail), "Kodiai encountered an error");
         const sanitizedErrorBody = sanitizeOutgoingMentions(errorBody, possibleHandles);
         try {
-          // Prefer in-thread reply for inline review comments.
-          if (mention.surface === "pr_review_comment" && mention.prNumber !== undefined) {
-            const errOctokit = await githubApp.getInstallationOctokit(event.installationId);
-            await errOctokit.rest.pulls.createReplyForReviewComment({
-              owner: mention.owner,
-              repo: mention.repo,
-              pull_number: mention.prNumber,
-              comment_id: mention.commentId,
-              body: sanitizedErrorBody,
-            });
-          } else {
-            const errOctokit = await githubApp.getInstallationOctokit(event.installationId);
-            await postOrUpdateErrorComment(
-              errOctokit,
-              {
+          if (
+            !explicitReviewRequest
+            || canPublishExplicitReviewOutput("explicit mention review handler failure error comment", reviewOutputKey)
+          ) {
+            // Prefer in-thread reply for inline review comments.
+            if (mention.surface === "pr_review_comment" && mention.prNumber !== undefined) {
+              const errOctokit = await githubApp.getInstallationOctokit(event.installationId);
+              await errOctokit.rest.pulls.createReplyForReviewComment({
                 owner: mention.owner,
                 repo: mention.repo,
-                issueNumber: mention.issueNumber,
-              },
-              sanitizedErrorBody,
-              logger,
-            );
+                pull_number: mention.prNumber,
+                comment_id: mention.commentId,
+                body: sanitizedErrorBody,
+              });
+            } else {
+              const errOctokit = await githubApp.getInstallationOctokit(event.installationId);
+              await postOrUpdateErrorComment(
+                errOctokit,
+                {
+                  owner: mention.owner,
+                  repo: mention.repo,
+                  issueNumber: mention.issueNumber,
+                },
+                sanitizedErrorBody,
+                logger,
+              );
+            }
           }
         } catch (commentErr) {
           logger.error({ err: commentErr }, "Failed to post error comment");
@@ -3393,9 +3612,14 @@ export function createMentionHandler(deps: {
       deliveryId: event.id,
       eventName: event.name,
       action,
+      lane: isExplicitReviewRequest ? "interactive-review" : "sync",
+      key: mentionQueueKey,
       jobType: "mention",
       prNumber: mention.prNumber,
     });
+    } finally {
+      finalizeQueuedReviewWorkAttempt();
+    }
   }
 
   // Register for all three mention-triggering events

--- a/src/handlers/review-comment-sync.test.ts
+++ b/src/handlers/review-comment-sync.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, test } from "bun:test";
 import type { Logger } from "pino";
 import { createReviewCommentSyncHandler } from "./review-comment-sync.ts";
 import type { EventRouter, WebhookEvent } from "../webhook/types.ts";
-import type { JobQueue } from "../jobs/types.ts";
+import type { JobQueue, JobQueueRunMetadata } from "../jobs/types.ts";
+import { createQueueRunMetadata } from "../jobs/queue.test-helpers.ts";
 import type { ReviewCommentChunk, ReviewCommentStore } from "../knowledge/review-comment-types.ts";
 import type { EmbeddingProvider } from "../knowledge/types.ts";
 
@@ -18,6 +19,7 @@ function createNoopLogger(): Logger {
     child: () => createNoopLogger(),
   } as unknown as Logger;
 }
+
 
 function createMockStore(): ReviewCommentStore & {
   writtenChunks: ReviewCommentChunk[];
@@ -102,17 +104,20 @@ function createImmediateJobQueue(): JobQueue & { enqueuedCount: number } {
     enqueuedCount: 0,
     async enqueue<T>(
       _installationId: number,
-      fn: () => Promise<T>,
+      fn: (metadata: JobQueueRunMetadata) => Promise<T>,
       _context?: Record<string, unknown>,
     ): Promise<T> {
       queue.enqueuedCount++;
-      return fn();
+      return fn(createQueueRunMetadata());
     },
     getQueueSize() {
       return 0;
     },
     getPendingCount() {
       return 0;
+    },
+    getActiveJobs() {
+      return [];
     },
   };
   return queue;
@@ -127,10 +132,10 @@ function createCapturingJobQueue(): JobQueue & { capturedJobs: Array<() => Promi
     capturedJobs: captured,
     async enqueue<T>(
       _installationId: number,
-      fn: () => Promise<T>,
+      fn: (metadata: JobQueueRunMetadata) => Promise<T>,
       _context?: Record<string, unknown>,
     ): Promise<T> {
-      captured.push(fn as () => Promise<unknown>);
+      captured.push(() => fn(createQueueRunMetadata()));
       return undefined as T;
     },
     getQueueSize() {
@@ -138,6 +143,9 @@ function createCapturingJobQueue(): JobQueue & { capturedJobs: Array<() => Promi
     },
     getPendingCount() {
       return 0;
+    },
+    getActiveJobs() {
+      return [];
     },
   };
 }

--- a/src/handlers/review-comment-sync.ts
+++ b/src/handlers/review-comment-sync.ts
@@ -65,6 +65,10 @@ function commentPayloadToInput(
   };
 }
 
+function buildSyncQueueKey(repo: string, prNumber: number): string {
+  return `${repo.trim().toLowerCase()}#${prNumber}`;
+}
+
 /**
  * Embed chunks using the embedding provider (fail-open: null embeddings are skipped).
  * Returns chunks with embedding data attached for storage.
@@ -157,6 +161,8 @@ export function createReviewCommentSyncHandler(opts: {
       deliveryId: event.id,
       eventName: event.name,
       action: "created",
+      lane: "sync",
+      key: buildSyncQueueKey(fullName, prNumber),
       jobType: "review-comment-sync",
       prNumber,
     });
@@ -211,6 +217,8 @@ export function createReviewCommentSyncHandler(opts: {
       deliveryId: event.id,
       eventName: event.name,
       action: "edited",
+      lane: "sync",
+      key: buildSyncQueueKey(fullName, prNumber),
       jobType: "review-comment-sync",
       prNumber,
     });

--- a/src/handlers/review.test.ts
+++ b/src/handlers/review.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import type { Logger } from "pino";
 import { collectDiffContext, createReviewHandler, resolveAuthorTierFromSources } from "./review.ts";
+import { createMentionHandler } from "./mention.ts";
 import { buildReviewOutputKey, buildReviewOutputMarker, extractReviewOutputKey } from "./review-idempotency.ts";
 import { createRetriever } from "../knowledge/retrieval.ts";
 import type {
@@ -13,9 +14,14 @@ import type {
 } from "../contributor/types.ts";
 import { CURRENT_CONTRIBUTOR_PROFILE_TRUST_MARKER } from "../contributor/profile-trust.ts";
 import type { EventRouter, WebhookEvent } from "../webhook/types.ts";
-import type { JobQueue, WorkspaceManager, CloneOptions } from "../jobs/types.ts";
+import type { JobQueue, JobQueueContext, JobQueueRunMetadata, WorkspaceManager, CloneOptions } from "../jobs/types.ts";
+import { createQueueRunMetadata, getEmptyActiveJobs } from "../jobs/queue.test-helpers.ts";
 import type { GitHubApp } from "../auth/github-app.ts";
 import { createSearchCache } from "../lib/search-cache.ts";
+import {
+  buildReviewFamilyKey,
+  createReviewWorkCoordinator,
+} from "../jobs/review-work-coordinator.ts";
 
 function createNoopLogger(): Logger {
   const noop = () => undefined;
@@ -29,6 +35,7 @@ function createNoopLogger(): Logger {
     child: () => createNoopLogger(),
   } as unknown as Logger;
 }
+
 
 const noopTelemetryStore = {
   record: async () => {},
@@ -66,6 +73,355 @@ function createCaptureLogger() {
 
   return { logger, entries };
 }
+
+describe("createReviewHandler coordinator wiring", () => {
+  test("logs when the review handler falls back to a private coordinator", () => {
+    const { logger, entries } = createCaptureLogger();
+
+    createReviewHandler({
+      eventRouter: {
+        register: () => undefined,
+        dispatch: async () => undefined,
+      },
+      jobQueue: {
+        enqueue: async () => {
+          throw new Error("not used");
+        },
+        getQueueSize: () => 0,
+        getPendingCount: () => 0,
+        getActiveJobs: getEmptyActiveJobs,
+      } as unknown as JobQueue,
+      workspaceManager: {
+        create: async () => {
+          throw new Error("not used");
+        },
+        cleanupStale: async () => 0,
+      } as unknown as WorkspaceManager,
+      githubApp: {
+        getAppSlug: () => "kodiai",
+        getInstallationOctokit: async () => {
+          throw new Error("not used");
+        },
+      } as unknown as GitHubApp,
+      executor: {
+        execute: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      telemetryStore: noopTelemetryStore,
+      logger: logger as never,
+    });
+
+    const fallbackLog = entries.find(
+      (entry) =>
+        entry.message ===
+        "Review work coordinator not injected; using a private handler-local fallback (cross-handler coordination disabled)",
+    );
+
+    expect(fallbackLog?.data?.gate).toBe("review-family-coordinator");
+    expect(fallbackLog?.data?.gateResult).toBe("private-fallback");
+    expect(fallbackLog?.data?.coordinationScope).toBe("handler-local");
+  });
+});
+
+describe("createReviewHandler queued-claim cleanup", () => {
+  test("releases a pre-enqueue automatic claim when queueing fails", async () => {
+    const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
+    const coordinator = createReviewWorkCoordinator({
+      nowFn: (() => {
+        let nowMs = 2_000;
+        return () => ++nowMs;
+      })(),
+    });
+    const familyKey = buildReviewFamilyKey("acme", "repo", 101);
+    const olderAttempt = coordinator.claim({
+      familyKey,
+      source: "automatic-review",
+      lane: "review",
+      deliveryId: "delivery-older-auto",
+      phase: "claimed",
+    });
+    coordinator.setPhase(olderAttempt.attemptId, "executor-dispatch");
+
+    createReviewHandler({
+      eventRouter: {
+        register: (eventKey, handler) => {
+          handlers.set(eventKey, handler);
+        },
+        dispatch: async () => undefined,
+      },
+      jobQueue: {
+        enqueue: async () => {
+          throw new Error("queue unavailable");
+        },
+        getQueueSize: () => 0,
+        getPendingCount: () => 0,
+        getActiveJobs: getEmptyActiveJobs,
+      } as unknown as JobQueue,
+      workspaceManager: {} as WorkspaceManager,
+      githubApp: {
+        getAppSlug: () => "kodiai",
+        getInstallationOctokit: async () => {
+          throw new Error("not used");
+        },
+      } as unknown as GitHubApp,
+      executor: {
+        execute: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      telemetryStore: noopTelemetryStore,
+      reviewWorkCoordinator: coordinator,
+      logger: createNoopLogger() as never,
+    });
+
+    const handler = handlers.get("pull_request.review_requested");
+    expect(handler).toBeDefined();
+
+    await expect(
+      handler!(
+        buildReviewRequestedEvent(
+          { requested_reviewer: { login: "kodiai[bot]" } },
+          { id: "delivery-new-auto" },
+        ),
+      ),
+    ).rejects.toThrow("queue unavailable");
+
+    expect(coordinator.canPublish(olderAttempt.attemptId)).toBeTrue();
+    expect(coordinator.getSnapshot(familyKey)?.attempts.map((attempt) => attempt.attemptId)).toEqual([
+      olderAttempt.attemptId,
+    ]);
+  });
+
+  test("older queued automatic review stays suppressed after a newer explicit review finishes first", async () => {
+    const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
+    const workspaceFixture = await createWorkspaceFixture({ autoApprove: true });
+    const featureSha = (await $`git -C ${workspaceFixture.dir} rev-parse feature`.quiet()).text().trim();
+    await $`git -C ${workspaceFixture.dir} update-ref refs/pull/101/head ${featureSha}`.quiet();
+    await Bun.write(
+      join(workspaceFixture.dir, ".kodiai.yml"),
+      [
+        "review:",
+        "  enabled: true",
+        "  autoApprove: true",
+        "  requestUiRereviewTeamOnOpen: false",
+        "  triggers:",
+        "    onOpened: true",
+        "    onReadyForReview: true",
+        "    onReviewRequested: true",
+        "  skipAuthors: []",
+        "  skipPaths: []",
+        "mention:",
+        "  enabled: true",
+      ].join("\n") + "\n",
+    );
+
+    const { logger, entries } = createCaptureLogger();
+    const queueMetadata = createQueueRunMetadata();
+    const automaticQueued = Promise.withResolvers<void>();
+    const automaticCaptured = Promise.withResolvers<void>();
+    let queuedAutomaticJob:
+      | ((metadata: JobQueueRunMetadata) => Promise<unknown>)
+      | undefined;
+    const createdReviews: Array<{ event: string; body?: string }> = [];
+
+    const eventRouter: EventRouter = {
+      register: (eventKey, handler) => {
+        handlers.set(eventKey, handler);
+      },
+      dispatch: async () => undefined,
+    };
+
+    const jobQueue: JobQueue = {
+      enqueue: async <T>(
+        _installationId: number,
+        fn: (metadata: JobQueueRunMetadata) => Promise<T>,
+        context?: { jobType?: string },
+      ) => {
+        if (context?.jobType === "pull-request-review") {
+          queuedAutomaticJob = fn as (metadata: JobQueueRunMetadata) => Promise<unknown>;
+          automaticCaptured.resolve();
+          await automaticQueued.promise;
+          return undefined as T;
+        }
+        return fn(queueMetadata);
+      },
+      getQueueSize: () => 0,
+      getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
+    };
+
+    const workspaceManager: WorkspaceManager = {
+      create: async (_installationId: number, options?: CloneOptions) => {
+        if (options?.ref) {
+          await $`git -C ${workspaceFixture.dir} checkout ${options.ref}`.quiet();
+        }
+        return { dir: workspaceFixture.dir, cleanup: async () => undefined };
+      },
+      cleanupStale: async () => 0,
+    };
+
+    const octokit = {
+      rest: {
+        pulls: {
+          get: async () => ({
+            data: {
+              title: "Test PR",
+              body: "",
+              user: { login: "octocat" },
+              head: { ref: "feature" },
+              base: { ref: "main" },
+            },
+          }),
+          listReviewComments: async () => ({ data: [] }),
+          listReviews: async () => ({ data: [] }),
+          listCommits: async () => ({ data: [] }),
+          createReview: async ({ event, body }: { event: string; body?: string }) => {
+            createdReviews.push({ event, body });
+            return { data: {} };
+          },
+        },
+        issues: {
+          listComments: async () => ({ data: [] }),
+          createComment: async () => ({ data: {} }),
+        },
+        reactions: {
+          createForIssue: async () => ({ data: {} }),
+          createForIssueComment: async () => ({ data: {} }),
+          createForPullRequestReviewComment: async () => ({ data: {} }),
+        },
+      },
+    };
+
+    const reviewWorkCoordinator = createReviewWorkCoordinator({
+      nowFn: (() => {
+        let nowMs = 4_000;
+        return () => ++nowMs;
+      })(),
+    });
+
+    const githubApp = {
+      getAppSlug: () => "kodiai",
+      getInstallationOctokit: async () => octokit as never,
+      initialize: async () => undefined,
+      checkConnectivity: async () => true,
+      getInstallationToken: async () => "token",
+    } as unknown as GitHubApp;
+
+    createReviewHandler({
+      eventRouter,
+      jobQueue,
+      workspaceManager,
+      githubApp,
+      executor: {
+        execute: async (_context: { taskType: string }) => ({
+          conclusion: "success",
+          published: false,
+          costUsd: 0,
+          numTurns: 1,
+          durationMs: 1,
+          sessionId: "session-automatic-review",
+          model: "test-model",
+          inputTokens: 0,
+          outputTokens: 0,
+          cacheReadTokens: 0,
+          cacheCreationTokens: 0,
+          stopReason: "end_turn",
+        }),
+      } as never,
+      telemetryStore: noopTelemetryStore,
+      reviewWorkCoordinator,
+      logger: logger as never,
+    });
+
+    createMentionHandler({
+      eventRouter,
+      jobQueue,
+      workspaceManager,
+      githubApp,
+      executor: {
+        execute: async () => ({
+          conclusion: "success",
+          published: false,
+          costUsd: 0,
+          numTurns: 1,
+          durationMs: 1,
+          sessionId: "session-explicit-review",
+          model: "test-model",
+          inputTokens: 0,
+          outputTokens: 0,
+          cacheReadTokens: 0,
+          cacheCreationTokens: 0,
+          stopReason: "end_turn",
+          usedRepoInspectionTools: true,
+          toolUseNames: ["Glob", "Read"],
+        }),
+      } as never,
+      telemetryStore: noopTelemetryStore,
+      reviewWorkCoordinator,
+      logger: logger as never,
+    });
+
+    const automaticHandler = handlers.get("pull_request.review_requested");
+    const explicitHandler = handlers.get("issue_comment.created");
+    expect(automaticHandler).toBeDefined();
+    expect(explicitHandler).toBeDefined();
+
+    const automaticPromise = automaticHandler!(
+      buildReviewRequestedEvent(
+        {
+          requested_reviewer: { login: "kodiai[bot]" },
+          pull_request: {
+            number: 101,
+            draft: false,
+            title: "Queued automatic review",
+            body: "",
+            commits: 0,
+            additions: 1,
+            deletions: 0,
+            user: { login: "octocat" },
+            base: { ref: "main", sha: "mainsha" },
+            head: {
+              sha: "abcdef1234567890",
+              ref: "feature",
+              repo: {
+                full_name: "acme/repo",
+                name: "repo",
+                owner: { login: "acme" },
+              },
+            },
+            labels: [],
+          },
+        },
+        { id: "delivery-auto-older" },
+      ),
+    );
+
+    await automaticCaptured.promise;
+
+    await explicitHandler!(
+      buildPrIssueCommentMentionEvent({
+        prNumber: 101,
+        commentBody: "@kodiai review",
+      }),
+    );
+
+    expect(createdReviews).toHaveLength(1);
+    expect(createdReviews[0]?.event).toBe("APPROVE");
+
+    const automaticRunResult = await queuedAutomaticJob!(queueMetadata);
+    automaticQueued.resolve();
+    await automaticPromise;
+    void automaticRunResult;
+
+    expect(createdReviews).toHaveLength(1);
+    expect(
+      entries.some((entry) => entry.message === "Skipping auto-approval because publish rights were superseded"),
+    ).toBeTrue();
+
+    await workspaceFixture.cleanup();
+  });
+});
 
 function buildContributorProfileFixture(
   overrides: Partial<ContributorProfile> & { overallTier?: string } = {},
@@ -237,6 +593,86 @@ function buildReviewRequestedEvent(
   };
 }
 
+function buildPrIssueCommentMentionEvent(params: {
+  prNumber: number;
+  commentBody: string;
+  commentAuthor?: string;
+  commentId?: number;
+  defaultBranch?: string;
+}): WebhookEvent {
+  return {
+    id: "delivery-pr-issue-comment-mention",
+    name: "issue_comment",
+    installationId: 42,
+    payload: {
+      action: "created",
+      repository: {
+        name: "repo",
+        owner: { login: "acme" },
+        default_branch: params.defaultBranch ?? "main",
+      },
+      issue: {
+        number: params.prNumber,
+        pull_request: {
+          url: `https://api.github.com/repos/acme/repo/pulls/${params.prNumber}`,
+        },
+      },
+      comment: {
+        id: params.commentId ?? 779,
+        body: params.commentBody,
+        user: { login: params.commentAuthor ?? "alice" },
+        created_at: "2025-01-15T12:00:00Z",
+      },
+    } as unknown as WebhookEvent["payload"],
+  };
+}
+
+function buildReviewCommentMentionEvent(params: {
+  prNumber: number;
+  baseRef: string;
+  headRef: string;
+  headRepoOwner: string;
+  headRepoName: string;
+  commentBody: string;
+  commentAuthor?: string;
+  commentId?: number;
+  inReplyToId?: number;
+}): WebhookEvent {
+  return {
+    id: "delivery-review-comment-mention",
+    name: "pull_request_review_comment",
+    installationId: 42,
+    payload: {
+      action: "created",
+      repository: {
+        name: "repo",
+        owner: { login: "acme" },
+      },
+      pull_request: {
+        number: params.prNumber,
+        head: {
+          ref: params.headRef,
+          repo: {
+            name: params.headRepoName,
+            owner: { login: params.headRepoOwner },
+          },
+        },
+        base: { ref: params.baseRef },
+      },
+      comment: {
+        id: params.commentId ?? 555,
+        body: params.commentBody,
+        user: { login: params.commentAuthor ?? "alice" },
+        created_at: "2025-01-15T12:00:00Z",
+        diff_hunk: "@@ -1,1 +1,1\n- old\n+ new",
+        path: "README.md",
+        line: 1,
+        in_reply_to_id: params.inReplyToId,
+      },
+    },
+  };
+}
+
 describe("resolveAuthorTierFromSources", () => {
   test("prefers contributor profile tier ahead of cache and fallback", () => {
     expect(
@@ -298,6 +734,7 @@ describe("createReviewHandler review_requested gating", () => {
       },
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     createReviewHandler({
@@ -341,6 +778,7 @@ describe("createReviewHandler review_requested gating", () => {
       },
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     createReviewHandler({
@@ -380,6 +818,7 @@ describe("createReviewHandler review_requested gating", () => {
       },
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     createReviewHandler({
@@ -419,6 +858,7 @@ describe("createReviewHandler review_requested gating", () => {
       },
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     createReviewHandler({
@@ -462,6 +902,7 @@ describe("createReviewHandler review_requested gating", () => {
       },
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     createReviewHandler({
@@ -505,6 +946,7 @@ describe("createReviewHandler review_requested gating", () => {
       },
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     createReviewHandler({
@@ -578,9 +1020,10 @@ describe("createReviewHandler auto profile selection", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -912,9 +1355,10 @@ describe("createReviewHandler auto profile selection", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -1075,9 +1519,10 @@ describe("createReviewHandler UI rereview team request", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -1173,9 +1618,10 @@ describe("createReviewHandler review_requested idempotency", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -1270,9 +1716,10 @@ describe("createReviewHandler review_requested idempotency", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -1377,9 +1824,10 @@ describe("createReviewHandler review_requested idempotency", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -1507,9 +1955,10 @@ describe("createReviewHandler review_requested idempotency", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -1640,9 +2089,10 @@ describe("createReviewHandler review_requested idempotency", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -1712,6 +2162,476 @@ describe("createReviewHandler review_requested idempotency", () => {
 
     expect(approveCount).toBe(0);
   });
+
+  test("suppresses auto-approval when publish rights were superseded by newer same-PR review work", async () => {
+    const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
+    const workspaceFixture = await createWorkspaceFixture({ autoApprove: true });
+    const { logger, entries } = createCaptureLogger();
+
+    let approveCount = 0;
+    const claimedFamilies: Array<Record<string, unknown>> = [];
+    const completedAttemptIds: string[] = [];
+
+    const eventRouter: EventRouter = {
+      register: (eventKey, handler) => {
+        handlers.set(eventKey, handler);
+      },
+      dispatch: async () => undefined,
+    };
+
+    const jobQueue: JobQueue = {
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
+      getQueueSize: () => 0,
+      getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
+    };
+
+    const workspaceManager: WorkspaceManager = {
+      create: async () => ({
+        dir: workspaceFixture.dir,
+        cleanup: async () => undefined,
+      }),
+      cleanupStale: async () => 0,
+    };
+
+    const octokit = {
+      rest: {
+        pulls: {
+          listReviewComments: async () => ({ data: [] }),
+          listReviews: async () => ({ data: [] }),
+          createReview: async () => {
+            approveCount++;
+            return { data: {} };
+          },
+        },
+        reactions: {
+          createForIssue: async () => ({ data: {} }),
+        },
+        issues: {
+          listComments: async () => ({ data: [] }),
+        },
+      },
+    };
+
+    createReviewHandler({
+      eventRouter,
+      jobQueue,
+      workspaceManager,
+      githubApp: {
+        getAppSlug: () => "kodiai",
+        getInstallationOctokit: async () => octokit as never,
+        initialize: async () => undefined,
+        checkConnectivity: async () => true,
+        getInstallationToken: async () => "token",
+      } as unknown as GitHubApp,
+      executor: {
+        execute: async () => ({
+          conclusion: "success",
+          published: false,
+          costUsd: 0,
+          numTurns: 1,
+          durationMs: 1,
+          sessionId: "session-superseded-auto-approval",
+        }),
+      } as never,
+      telemetryStore: noopTelemetryStore,
+      reviewWorkCoordinator: {
+        claim: (claim: Record<string, unknown>) => {
+          claimedFamilies.push(claim);
+          return {
+            attemptId: "attempt-auto-1",
+            familyKey: claim.familyKey,
+            source: claim.source,
+            lane: claim.lane,
+            deliveryId: claim.deliveryId,
+            phase: claim.phase,
+            claimedAtMs: 100,
+            lastProgressAtMs: 100,
+          };
+        },
+        canPublish: () => false,
+        setPhase: () => null,
+        getSnapshot: () => null,
+        release: () => undefined,
+        complete: (attemptId: string) => {
+          completedAttemptIds.push(attemptId);
+        },
+      } as never,
+      logger: logger as never,
+    });
+
+    const handler = handlers.get("pull_request.review_requested");
+    expect(handler).toBeDefined();
+
+    await handler!(
+      buildReviewRequestedEvent({
+        requested_reviewer: { login: "kodiai[bot]" },
+      }),
+    );
+
+    await workspaceFixture.cleanup();
+
+    expect(approveCount).toBe(0);
+    expect(claimedFamilies).toEqual([
+      {
+        familyKey: "acme/repo#101",
+        source: "automatic-review",
+        lane: "review",
+        deliveryId: "delivery-123",
+        phase: "claimed",
+      },
+    ]);
+    expect(completedAttemptIds).toEqual(["attempt-auto-1"]);
+    expect(
+      entries.some((entry) => entry.message === "Skipping auto-approval because publish rights were superseded"),
+    ).toBeTrue();
+  });
+
+  test("publishes [depends] deep-review output when publish rights remain uncontested", async () => {
+    const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
+    const workspaceFixture = await createWorkspaceFixture();
+    const { logger } = createCaptureLogger();
+
+    let summaryCommentCount = 0;
+    let inlineReviewCount = 0;
+    let executorCalls = 0;
+    const completedAttemptIds: string[] = [];
+    const releasedAttemptIds: string[] = [];
+    const phaseTransitions: string[] = [];
+    const coordinator = createReviewWorkCoordinator({
+      nowFn: (() => {
+        let nowMs = 9_000;
+        return () => ++nowMs;
+      })(),
+    });
+    const reviewWorkCoordinator = {
+      claim: (claim: Parameters<typeof coordinator.claim>[0]) => coordinator.claim(claim),
+      canPublish: (attemptId: Parameters<typeof coordinator.canPublish>[0]) => coordinator.canPublish(attemptId),
+      setPhase: (
+        attemptId: Parameters<typeof coordinator.setPhase>[0],
+        phase: Parameters<NonNullable<typeof coordinator.setPhase>>[1],
+      ) => {
+        phaseTransitions.push(phase);
+        return coordinator.setPhase(attemptId, phase);
+      },
+      getSnapshot: (familyKey: Parameters<typeof coordinator.getSnapshot>[0]) => coordinator.getSnapshot(familyKey),
+      release: (attemptId: Parameters<typeof coordinator.release>[0]) => {
+        releasedAttemptIds.push(attemptId);
+        coordinator.release(attemptId);
+      },
+      complete: (attemptId: Parameters<typeof coordinator.complete>[0]) => {
+        completedAttemptIds.push(attemptId);
+        coordinator.complete(attemptId);
+      },
+    };
+
+    const eventRouter: EventRouter = {
+      register: (eventKey, handler) => {
+        handlers.set(eventKey, handler);
+      },
+      dispatch: async () => undefined,
+    };
+
+    const jobQueue: JobQueue = {
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
+      getQueueSize: () => 0,
+      getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
+    };
+
+    const workspaceManager: WorkspaceManager = {
+      create: async () => ({
+        dir: workspaceFixture.dir,
+        cleanup: async () => undefined,
+      }),
+      cleanupStale: async () => 0,
+    };
+
+    const octokit = {
+      rest: {
+        pulls: {
+          listReviewComments: async () => ({ data: [] }),
+          listReviews: async () => ({ data: [] }),
+          listFiles: async () => ({
+            data: [
+              {
+                filename: "tools/depends/target/zlib/VERSION",
+                status: "modified",
+                patch: [
+                  "@@ -1,2 +1,2 @@",
+                  "-VERSION=1.3.1",
+                  "+VERSION=1.3.2",
+                ].join("\n"),
+              },
+              {
+                filename: "tools/depends/target/zlib/patches/fix-build.patch",
+                status: "removed",
+              },
+            ],
+          }),
+          createReview: async () => {
+            inlineReviewCount += 1;
+            return { data: {} };
+          },
+        },
+        issues: {
+          listComments: async () => ({ data: [] }),
+          createComment: async () => {
+            summaryCommentCount += 1;
+            return { data: {} };
+          },
+        },
+        reactions: {
+          createForIssue: async () => ({ data: {} }),
+        },
+        repos: {
+          listReleases: async () => ({ data: [] }),
+          getContent: async () => {
+            throw new Error("cmake modules unavailable in test fixture");
+          },
+        },
+      },
+    };
+
+    createReviewHandler({
+      eventRouter,
+      jobQueue,
+      workspaceManager,
+      githubApp: {
+        getAppSlug: () => "kodiai",
+        getInstallationOctokit: async () => octokit as never,
+        initialize: async () => undefined,
+        checkConnectivity: async () => true,
+        getInstallationToken: async () => "token",
+      } as unknown as GitHubApp,
+      executor: {
+        execute: async () => {
+          executorCalls += 1;
+          return {
+            conclusion: "success",
+            published: false,
+            costUsd: 0,
+            numTurns: 1,
+            durationMs: 1,
+            sessionId: "session-should-not-run-for-depends",
+          };
+        },
+      } as never,
+      telemetryStore: noopTelemetryStore,
+      reviewWorkCoordinator,
+      logger: logger as never,
+    });
+
+    const handler = handlers.get("pull_request.review_requested");
+    expect(handler).toBeDefined();
+
+    await handler!(
+      buildReviewRequestedEvent({
+        requested_reviewer: { login: "kodiai[bot]" },
+        pull_request: {
+          number: 101,
+          draft: false,
+          title: "[depends] Bump zlib to 1.3.2",
+          body: "",
+          user: { login: "octocat" },
+          base: { ref: "main" },
+          head: {
+            sha: "abcdef1234567890",
+            ref: "feature",
+            repo: {
+              full_name: "acme/repo",
+              name: "repo",
+              owner: { login: "acme" },
+            },
+          },
+        },
+      }),
+    );
+
+    await workspaceFixture.cleanup();
+
+    expect(summaryCommentCount).toBe(1);
+    expect(inlineReviewCount).toBe(1);
+    expect(executorCalls).toBe(0);
+    expect(phaseTransitions).toEqual(expect.arrayContaining([
+      "workspace-create",
+      "load-config",
+      "incremental-diff",
+      "publish",
+    ]));
+    expect(completedAttemptIds).toHaveLength(1);
+    expect(releasedAttemptIds).toEqual([]);
+    expect(coordinator.getSnapshot(buildReviewFamilyKey("acme", "repo", 101))).toBeNull();
+  });
+
+  test("suppresses [depends] deep-review publication when publish rights were superseded", async () => {
+    const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
+    const workspaceFixture = await createWorkspaceFixture();
+    const { logger, entries } = createCaptureLogger();
+
+    let summaryCommentCount = 0;
+    let inlineReviewCount = 0;
+    let executorCalls = 0;
+    const completedAttemptIds: string[] = [];
+    const releasedAttemptIds: string[] = [];
+
+    const eventRouter: EventRouter = {
+      register: (eventKey, handler) => {
+        handlers.set(eventKey, handler);
+      },
+      dispatch: async () => undefined,
+    };
+
+    const jobQueue: JobQueue = {
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
+      getQueueSize: () => 0,
+      getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
+    };
+
+    const workspaceManager: WorkspaceManager = {
+      create: async () => ({
+        dir: workspaceFixture.dir,
+        cleanup: async () => undefined,
+      }),
+      cleanupStale: async () => 0,
+    };
+
+    const octokit = {
+      rest: {
+        pulls: {
+          listReviewComments: async () => ({ data: [] }),
+          listReviews: async () => ({ data: [] }),
+          listFiles: async () => ({
+            data: [
+              {
+                filename: "tools/depends/target/zlib/VERSION",
+                status: "modified",
+                patch: [
+                  "@@ -1,2 +1,2 @@",
+                  "-VERSION=1.3.1",
+                  "+VERSION=1.3.2",
+                ].join("\n"),
+              },
+              {
+                filename: "tools/depends/target/zlib/patches/fix-build.patch",
+                status: "removed",
+              },
+            ],
+          }),
+          createReview: async () => {
+            inlineReviewCount += 1;
+            return { data: {} };
+          },
+        },
+        issues: {
+          listComments: async () => ({ data: [] }),
+          createComment: async () => {
+            summaryCommentCount += 1;
+            return { data: {} };
+          },
+        },
+        reactions: {
+          createForIssue: async () => ({ data: {} }),
+        },
+        repos: {
+          listReleases: async () => ({ data: [] }),
+          getContent: async () => {
+            throw new Error("cmake modules unavailable in test fixture");
+          },
+        },
+      },
+    };
+
+    createReviewHandler({
+      eventRouter,
+      jobQueue,
+      workspaceManager,
+      githubApp: {
+        getAppSlug: () => "kodiai",
+        getInstallationOctokit: async () => octokit as never,
+        initialize: async () => undefined,
+        checkConnectivity: async () => true,
+        getInstallationToken: async () => "token",
+      } as unknown as GitHubApp,
+      executor: {
+        execute: async () => {
+          executorCalls += 1;
+          return {
+            conclusion: "success",
+            published: false,
+            costUsd: 0,
+            numTurns: 1,
+            durationMs: 1,
+            sessionId: "session-should-not-run-for-depends",
+          };
+        },
+      } as never,
+      telemetryStore: noopTelemetryStore,
+      reviewWorkCoordinator: {
+        claim: (claim: Record<string, unknown>) => ({
+          attemptId: "attempt-depends-1",
+          familyKey: claim.familyKey as string,
+          source: claim.source as "automatic-review",
+          lane: claim.lane as "review",
+          deliveryId: claim.deliveryId as string,
+          phase: claim.phase as "claimed",
+          claimedAtMs: 100,
+          lastProgressAtMs: 100,
+        }),
+        canPublish: () => false,
+        setPhase: () => null,
+        getSnapshot: () => null,
+        release: (attemptId: string) => {
+          releasedAttemptIds.push(attemptId);
+        },
+        complete: (attemptId: string) => {
+          completedAttemptIds.push(attemptId);
+        },
+      } as never,
+      logger: logger as never,
+    });
+
+    const handler = handlers.get("pull_request.review_requested");
+    expect(handler).toBeDefined();
+
+    await handler!(
+      buildReviewRequestedEvent({
+        requested_reviewer: { login: "kodiai[bot]" },
+        pull_request: {
+          number: 101,
+          draft: false,
+          title: "[depends] Bump zlib to 1.3.2",
+          body: "",
+          user: { login: "octocat" },
+          base: { ref: "main" },
+          head: {
+            sha: "abcdef1234567890",
+            ref: "feature",
+            repo: {
+              full_name: "acme/repo",
+              name: "repo",
+              owner: { login: "acme" },
+            },
+          },
+        },
+      }),
+    );
+
+    await workspaceFixture.cleanup();
+
+    expect(summaryCommentCount).toBe(0);
+    expect(inlineReviewCount).toBe(0);
+    expect(executorCalls).toBe(0);
+    expect(completedAttemptIds).toEqual(["attempt-depends-1"]);
+    expect(releasedAttemptIds).toEqual([]);
+    expect(
+      entries.some((entry) => entry.message === "Skipping [depends] deep review summary comment because publish rights were superseded"),
+    ).toBeTrue();
+    expect(
+      entries.some((entry) => entry.message === "Skipping [depends] deep review inline comments because publish rights were superseded"),
+    ).toBeTrue();
+  });
 });
 
 describe("createReviewHandler fork PR workspace strategy", () => {
@@ -1732,9 +2652,10 @@ describe("createReviewHandler fork PR workspace strategy", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -1848,9 +2769,10 @@ describe("createReviewHandler fork PR workspace strategy", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -1995,9 +2917,10 @@ describe("createReviewHandler picomatch skipPaths (CONFIG-04)", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -2088,9 +3011,10 @@ describe("createReviewHandler picomatch skipPaths (CONFIG-04)", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -2180,9 +3104,10 @@ describe("createReviewHandler picomatch skipPaths (CONFIG-04)", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -2354,9 +3279,10 @@ describe("createReviewHandler retrieval quality telemetry (RET-05)", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -2519,9 +3445,10 @@ describe("createReviewHandler retrieval quality telemetry (RET-05)", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -2633,9 +3560,10 @@ describe("createReviewHandler retrieval quality telemetry (RET-05)", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -2743,9 +3671,10 @@ describe("createReviewHandler telemetry opt-out (CONFIG-10)", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -2827,9 +3756,10 @@ describe("createReviewHandler telemetry opt-out (CONFIG-10)", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -2907,9 +3837,10 @@ describe("createReviewHandler cost warning (CONFIG-11)", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -2964,6 +3895,116 @@ describe("createReviewHandler cost warning (CONFIG-11)", () => {
     expect(costWarningBody!).toContain("$1.00");
   });
 
+  test("suppresses cost warning comment when publish rights were superseded", async () => {
+    const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
+    const dir = await mkdtemp(join(tmpdir(), "kodiai-review-handler-"));
+    const { logger, entries } = createCaptureLogger();
+    const completedAttemptIds: string[] = [];
+
+    await $`git -C ${dir} init --initial-branch=main`.quiet();
+    await $`git -C ${dir} config user.email test@example.com`.quiet();
+    await $`git -C ${dir} config user.name "Test User"`.quiet();
+
+    await Bun.write(join(dir, "README.md"), "base\n");
+    await Bun.write(
+      join(dir, ".kodiai.yml"),
+      "review:\n  enabled: true\n  autoApprove: false\n  requestUiRereviewTeamOnOpen: false\n  triggers:\n    onOpened: true\n    onReadyForReview: true\n    onReviewRequested: true\n  skipAuthors: []\n  skipPaths: []\ntelemetry:\n  enabled: true\n  costWarningUsd: 1.0\n",
+    );
+
+    await $`git -C ${dir} add README.md .kodiai.yml`.quiet();
+    await $`git -C ${dir} commit -m "base"`.quiet();
+    await $`git -C ${dir} checkout -b feature`.quiet();
+    await Bun.write(join(dir, "README.md"), "base\nfeature\n");
+    await $`git -C ${dir} add README.md`.quiet();
+    await $`git -C ${dir} commit -m "feature"`.quiet();
+    await $`git -C ${dir} remote add origin ${dir}`.quiet();
+
+    let createCommentCalls = 0;
+
+    const eventRouter: EventRouter = {
+      register: (eventKey, handler) => { handlers.set(eventKey, handler); },
+      dispatch: async () => undefined,
+    };
+
+    const jobQueue: JobQueue = {
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
+      getQueueSize: () => 0,
+      getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
+    };
+
+    const workspaceManager: WorkspaceManager = {
+      create: async () => ({ dir, cleanup: async () => undefined }),
+      cleanupStale: async () => 0,
+    };
+
+    const octokit = {
+      rest: {
+        pulls: { listReviewComments: async () => ({ data: [] }), listReviews: async () => ({ data: [] }) },
+        issues: {
+          listComments: async () => ({ data: [] }),
+          createComment: async () => {
+            createCommentCalls += 1;
+            return { data: {} };
+          },
+        },
+        reactions: { createForIssue: async () => ({ data: {} }) },
+      },
+    };
+
+    createReviewHandler({
+      eventRouter,
+      jobQueue,
+      workspaceManager,
+      githubApp: {
+        getAppSlug: () => "kodiai",
+        getInstallationOctokit: async () => octokit as never,
+      } as unknown as GitHubApp,
+      executor: {
+        execute: async () => ({
+          conclusion: "success",
+          published: false,
+          costUsd: 2.5,
+          numTurns: 1,
+          durationMs: 1,
+          sessionId: "session-cost-warning-superseded",
+        }),
+      } as never,
+      telemetryStore: noopTelemetryStore,
+      reviewWorkCoordinator: {
+        claim: (claim: Record<string, unknown>) => ({
+          attemptId: "attempt-cost-warning-1",
+          familyKey: claim.familyKey as string,
+          source: claim.source as "automatic-review",
+          lane: claim.lane as "review",
+          deliveryId: claim.deliveryId as string,
+          phase: claim.phase as "claimed",
+          claimedAtMs: 100,
+          lastProgressAtMs: 100,
+        }),
+        canPublish: () => false,
+        setPhase: () => null,
+        getSnapshot: () => null,
+        release: () => undefined,
+        complete: (attemptId: string) => {
+          completedAttemptIds.push(attemptId);
+        },
+      } as never,
+      logger: logger as never,
+    });
+
+    await handlers.get("pull_request.review_requested")!(
+      buildReviewRequestedEvent({ requested_reviewer: { login: "kodiai[bot]" } }),
+    );
+
+    await rm(dir, { recursive: true, force: true });
+    expect(createCommentCalls).toBe(0);
+    expect(completedAttemptIds).toEqual(["attempt-cost-warning-1"]);
+    expect(
+      entries.some((entry) => entry.message === "Skipping cost warning comment because publish rights were superseded"),
+    ).toBeTrue();
+  });
+
   test("no cost warning when costWarningUsd is 0 (default)", async () => {
     const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
     const dir = await mkdtemp(join(tmpdir(), "kodiai-review-handler-"));
@@ -2994,9 +4035,10 @@ describe("createReviewHandler cost warning (CONFIG-11)", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -3087,9 +4129,10 @@ describe("createReviewHandler cost warning (CONFIG-11)", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -3161,9 +4204,10 @@ describe("createReviewHandler diff collection resilience", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -3391,9 +4435,10 @@ describe("createReviewHandler diff collection resilience", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -3478,9 +4523,10 @@ describe("createReviewHandler finding extraction", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -3628,9 +4674,10 @@ describe("createReviewHandler finding extraction", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -3849,9 +4896,17 @@ describe("createReviewHandler finding extraction", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) =>
+        fn(
+          createQueueRunMetadata({
+            queuedAtMs: 1_000,
+            startedAtMs: 900,
+            waitMs: -100,
+          }),
+        ),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -4018,6 +5073,572 @@ describe("createReviewHandler finding extraction", () => {
 
     await workspaceFixture.cleanup();
   });
+
+  test("suppresses Review Details append when publish rights were superseded", async () => {
+    const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
+    const workspaceFixture = await createWorkspaceFixture();
+    const { logger, entries } = createCaptureLogger();
+
+    let updatedSummaryBody: string | undefined;
+    let createCommentCalls = 0;
+    let issueCommentListCalls = 0;
+    const completedAttemptIds: string[] = [];
+
+    const reviewOutputKey = buildReviewOutputKey({
+      installationId: 42,
+      owner: "acme",
+      repo: "repo",
+      prNumber: 101,
+      action: "review_requested",
+      deliveryId: "delivery-123",
+      headSha: "abcdef1234567890",
+    });
+
+    const summaryBody = [
+      "<details>",
+      "<summary>Review summary</summary>",
+      "",
+      "No inline findings were published.",
+      "",
+      "</details>",
+      "",
+      buildReviewOutputMarker(reviewOutputKey),
+    ].join("\n");
+
+    const eventRouter: EventRouter = {
+      register: (eventKey, handler) => {
+        handlers.set(eventKey, handler);
+      },
+      dispatch: async () => undefined,
+    };
+
+    const jobQueue: JobQueue = {
+      enqueue: async <T>(
+        _installationId: number,
+        fn: (metadata: JobQueueRunMetadata) => Promise<T>,
+      ) => fn(createQueueRunMetadata()),
+      getQueueSize: () => 0,
+      getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
+    };
+
+    const workspaceManager: WorkspaceManager = {
+      create: async () => ({
+        dir: workspaceFixture.dir,
+        cleanup: async () => undefined,
+      }),
+      cleanupStale: async () => 0,
+    };
+
+    const octokit = {
+      rest: {
+        pulls: {
+          listReviewComments: async () => ({ data: [] }),
+          listReviews: async () => ({ data: [] }),
+          listCommits: async () => ({ data: [] }),
+        },
+        issues: {
+          listComments: async () => {
+            issueCommentListCalls += 1;
+            return issueCommentListCalls === 1
+              ? { data: [] }
+              : { data: [{ id: 77, body: summaryBody }] };
+          },
+          createComment: async () => {
+            createCommentCalls += 1;
+            return { data: { id: 88 } };
+          },
+          updateComment: async (params: { body: string }) => {
+            updatedSummaryBody = params.body;
+            return { data: {} };
+          },
+        },
+        reactions: {
+          createForIssue: async () => ({ data: {} }),
+        },
+        search: {
+          issuesAndPullRequests: async () => ({ data: { total_count: 4 } }),
+        },
+      },
+    };
+
+    createReviewHandler({
+      eventRouter,
+      jobQueue,
+      workspaceManager,
+      githubApp: {
+        getAppSlug: () => "kodiai",
+        getInstallationOctokit: async () => octokit as never,
+      } as unknown as GitHubApp,
+      executor: {
+        execute: async () => ({
+          conclusion: "success",
+          published: true,
+          costUsd: 0,
+          numTurns: 1,
+          durationMs: 1,
+          sessionId: "session-review-details-append-superseded",
+          executorPhaseTimings: [
+            { name: "executor handoff", status: "completed", durationMs: 50 },
+            { name: "remote runtime", status: "completed", durationMs: 500 },
+          ],
+        }),
+      } as never,
+      telemetryStore: noopTelemetryStore,
+      reviewWorkCoordinator: {
+        claim: (claim: Record<string, unknown>) => ({
+          attemptId: "attempt-review-details-append-1",
+          familyKey: claim.familyKey as string,
+          source: claim.source as "automatic-review",
+          lane: claim.lane as "review",
+          deliveryId: claim.deliveryId as string,
+          phase: claim.phase as "claimed",
+          claimedAtMs: 100,
+          lastProgressAtMs: 100,
+        }),
+        canPublish: () => false,
+        setPhase: () => null,
+        getSnapshot: () => null,
+        release: () => undefined,
+        complete: (attemptId: string) => {
+          completedAttemptIds.push(attemptId);
+        },
+      } as never,
+      logger: logger as never,
+    });
+
+    const handler = handlers.get("pull_request.review_requested");
+    expect(handler).toBeDefined();
+
+    await handler!(
+      buildReviewRequestedEvent({
+        requested_reviewer: { login: "kodiai[bot]" },
+      }),
+    );
+
+    expect(updatedSummaryBody).toBeUndefined();
+    expect(createCommentCalls).toBe(0);
+    expect(completedAttemptIds).toEqual(["attempt-review-details-append-1"]);
+    expect(
+      entries.some((entry) => entry.message === "Skipping deterministic Review Details append because publish rights were superseded"),
+    ).toBeTrue();
+
+    await workspaceFixture.cleanup();
+  });
+
+  test("suppresses standalone Review Details publication when publish rights were superseded", async () => {
+    const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
+    const workspaceFixture = await createWorkspaceFixture();
+    const { logger, entries } = createCaptureLogger();
+
+    let createCommentCalls = 0;
+    let updateCommentCalls = 0;
+    const completedAttemptIds: string[] = [];
+
+    const eventRouter: EventRouter = {
+      register: (eventKey, handler) => {
+        handlers.set(eventKey, handler);
+      },
+      dispatch: async () => undefined,
+    };
+
+    const jobQueue: JobQueue = {
+      enqueue: async <T>(
+        _installationId: number,
+        fn: (metadata: JobQueueRunMetadata) => Promise<T>,
+      ) => fn(createQueueRunMetadata()),
+      getQueueSize: () => 0,
+      getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
+    };
+
+    const workspaceManager: WorkspaceManager = {
+      create: async () => ({
+        dir: workspaceFixture.dir,
+        cleanup: async () => undefined,
+      }),
+      cleanupStale: async () => 0,
+    };
+
+    const octokit = {
+      rest: {
+        pulls: {
+          listReviewComments: async () => ({ data: [] }),
+          listReviews: async () => ({ data: [] }),
+          listCommits: async () => ({ data: [] }),
+        },
+        issues: {
+          listComments: async () => ({ data: [] }),
+          createComment: async () => {
+            createCommentCalls += 1;
+            return { data: { id: 188 } };
+          },
+          updateComment: async () => {
+            updateCommentCalls += 1;
+            return { data: {} };
+          },
+        },
+        reactions: {
+          createForIssue: async () => ({ data: {} }),
+        },
+        search: {
+          issuesAndPullRequests: async () => ({ data: { total_count: 4 } }),
+        },
+      },
+    };
+
+    createReviewHandler({
+      eventRouter,
+      jobQueue,
+      workspaceManager,
+      githubApp: {
+        getAppSlug: () => "kodiai",
+        getInstallationOctokit: async () => octokit as never,
+      } as unknown as GitHubApp,
+      executor: {
+        execute: async () => ({
+          conclusion: "success",
+          published: false,
+          costUsd: 0,
+          numTurns: 1,
+          durationMs: 1,
+          sessionId: "session-review-details-standalone-superseded",
+          executorPhaseTimings: [
+            { name: "executor handoff", status: "completed", durationMs: 50 },
+            { name: "remote runtime", status: "completed", durationMs: 500 },
+          ],
+        }),
+      } as never,
+      telemetryStore: noopTelemetryStore,
+      reviewWorkCoordinator: {
+        claim: (claim: Record<string, unknown>) => ({
+          attemptId: "attempt-review-details-standalone-1",
+          familyKey: claim.familyKey as string,
+          source: claim.source as "automatic-review",
+          lane: claim.lane as "review",
+          deliveryId: claim.deliveryId as string,
+          phase: claim.phase as "claimed",
+          claimedAtMs: 100,
+          lastProgressAtMs: 100,
+        }),
+        canPublish: () => false,
+        setPhase: () => null,
+        getSnapshot: () => null,
+        release: () => undefined,
+        complete: (attemptId: string) => {
+          completedAttemptIds.push(attemptId);
+        },
+      } as never,
+      logger: logger as never,
+    });
+
+    const handler = handlers.get("pull_request.review_requested");
+    expect(handler).toBeDefined();
+
+    await handler!(
+      buildReviewRequestedEvent({
+        requested_reviewer: { login: "kodiai[bot]" },
+      }),
+    );
+
+    expect(createCommentCalls).toBe(0);
+    expect(updateCommentCalls).toBe(0);
+    expect(completedAttemptIds).toEqual(["attempt-review-details-standalone-1"]);
+    expect(
+      entries.some((entry) => entry.message === "Skipping deterministic Review Details standalone comment because publish rights were superseded"),
+    ).toBeTrue();
+
+    await workspaceFixture.cleanup();
+  });
+
+  test("rechecks Review Details append publish rights after summary lookup", async () => {
+    const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
+    const workspaceFixture = await createWorkspaceFixture();
+    const { logger, entries } = createCaptureLogger();
+
+    let updatedSummaryBody: string | undefined;
+    let createCommentCalls = 0;
+    let issueCommentListCalls = 0;
+    let allowPublish = true;
+    const completedAttemptIds: string[] = [];
+
+    const reviewOutputKey = buildReviewOutputKey({
+      installationId: 42,
+      owner: "acme",
+      repo: "repo",
+      prNumber: 101,
+      action: "review_requested",
+      deliveryId: "delivery-123",
+      headSha: "abcdef1234567890",
+    });
+
+    const summaryBody = [
+      "<details>",
+      "<summary>Review summary</summary>",
+      "",
+      "No inline findings were published.",
+      "",
+      "</details>",
+      "",
+      buildReviewOutputMarker(reviewOutputKey),
+    ].join("\n");
+
+    const eventRouter: EventRouter = {
+      register: (eventKey, handler) => {
+        handlers.set(eventKey, handler);
+      },
+      dispatch: async () => undefined,
+    };
+
+    const jobQueue: JobQueue = {
+      enqueue: async <T>(
+        _installationId: number,
+        fn: (metadata: JobQueueRunMetadata) => Promise<T>,
+      ) => fn(createQueueRunMetadata()),
+      getQueueSize: () => 0,
+      getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
+    };
+
+    const workspaceManager: WorkspaceManager = {
+      create: async () => ({
+        dir: workspaceFixture.dir,
+        cleanup: async () => undefined,
+      }),
+      cleanupStale: async () => 0,
+    };
+
+    const octokit = {
+      rest: {
+        pulls: {
+          listReviewComments: async () => ({ data: [] }),
+          listReviews: async () => ({ data: [] }),
+          listCommits: async () => ({ data: [] }),
+        },
+        issues: {
+          listComments: async () => {
+            issueCommentListCalls += 1;
+            if (issueCommentListCalls === 2) {
+              allowPublish = false;
+            }
+            return issueCommentListCalls === 1
+              ? { data: [] }
+              : { data: [{ id: 77, body: summaryBody }] };
+          },
+          createComment: async () => {
+            createCommentCalls += 1;
+            return { data: { id: 88 } };
+          },
+          updateComment: async (params: { body: string }) => {
+            updatedSummaryBody = params.body;
+            return { data: {} };
+          },
+        },
+        reactions: {
+          createForIssue: async () => ({ data: {} }),
+        },
+        search: {
+          issuesAndPullRequests: async () => ({ data: { total_count: 4 } }),
+        },
+      },
+    };
+
+    createReviewHandler({
+      eventRouter,
+      jobQueue,
+      workspaceManager,
+      githubApp: {
+        getAppSlug: () => "kodiai",
+        getInstallationOctokit: async () => octokit as never,
+      } as unknown as GitHubApp,
+      executor: {
+        execute: async () => ({
+          conclusion: "success",
+          published: true,
+          costUsd: 0,
+          numTurns: 1,
+          durationMs: 1,
+          sessionId: "session-review-details-append-recheck",
+          executorPhaseTimings: [
+            { name: "executor handoff", status: "completed", durationMs: 50 },
+            { name: "remote runtime", status: "completed", durationMs: 500 },
+          ],
+        }),
+      } as never,
+      telemetryStore: noopTelemetryStore,
+      reviewWorkCoordinator: {
+        claim: (claim: Record<string, unknown>) => ({
+          attemptId: "attempt-review-details-append-recheck-1",
+          familyKey: claim.familyKey as string,
+          source: claim.source as "automatic-review",
+          lane: claim.lane as "review",
+          deliveryId: claim.deliveryId as string,
+          phase: claim.phase as "claimed",
+          claimedAtMs: 100,
+          lastProgressAtMs: 100,
+        }),
+        canPublish: () => allowPublish,
+        setPhase: () => null,
+        getSnapshot: () => null,
+        release: () => undefined,
+        complete: (attemptId: string) => {
+          completedAttemptIds.push(attemptId);
+        },
+      } as never,
+      logger: logger as never,
+    });
+
+    const handler = handlers.get("pull_request.review_requested");
+    expect(handler).toBeDefined();
+
+    await handler!(
+      buildReviewRequestedEvent({
+        requested_reviewer: { login: "kodiai[bot]" },
+      }),
+    );
+
+    expect(issueCommentListCalls).toBe(2);
+    expect(updatedSummaryBody).toBeUndefined();
+    expect(createCommentCalls).toBe(0);
+    expect(completedAttemptIds).toEqual(["attempt-review-details-append-recheck-1"]);
+    expect(
+      entries.some((entry) => entry.message === "Skipping deterministic Review Details append because publish rights were superseded"),
+    ).toBeTrue();
+
+    await workspaceFixture.cleanup();
+  });
+
+  test("rechecks standalone Review Details publish rights after comment lookup", async () => {
+    const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
+    const workspaceFixture = await createWorkspaceFixture();
+    const { logger, entries } = createCaptureLogger();
+
+    let createCommentCalls = 0;
+    let updateCommentCalls = 0;
+    let listCommentsCalls = 0;
+    let allowPublish = true;
+    const completedAttemptIds: string[] = [];
+
+    const eventRouter: EventRouter = {
+      register: (eventKey, handler) => {
+        handlers.set(eventKey, handler);
+      },
+      dispatch: async () => undefined,
+    };
+
+    const jobQueue: JobQueue = {
+      enqueue: async <T>(
+        _installationId: number,
+        fn: (metadata: JobQueueRunMetadata) => Promise<T>,
+      ) => fn(createQueueRunMetadata()),
+      getQueueSize: () => 0,
+      getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
+    };
+
+    const workspaceManager: WorkspaceManager = {
+      create: async () => ({
+        dir: workspaceFixture.dir,
+        cleanup: async () => undefined,
+      }),
+      cleanupStale: async () => 0,
+    };
+
+    const octokit = {
+      rest: {
+        pulls: {
+          listReviewComments: async () => ({ data: [] }),
+          listReviews: async () => ({ data: [] }),
+          listCommits: async () => ({ data: [] }),
+        },
+        issues: {
+          listComments: async () => {
+            listCommentsCalls += 1;
+            allowPublish = false;
+            return { data: [] };
+          },
+          createComment: async () => {
+            createCommentCalls += 1;
+            return { data: { id: 188 } };
+          },
+          updateComment: async () => {
+            updateCommentCalls += 1;
+            return { data: {} };
+          },
+        },
+        reactions: {
+          createForIssue: async () => ({ data: {} }),
+        },
+        search: {
+          issuesAndPullRequests: async () => ({ data: { total_count: 4 } }),
+        },
+      },
+    };
+
+    createReviewHandler({
+      eventRouter,
+      jobQueue,
+      workspaceManager,
+      githubApp: {
+        getAppSlug: () => "kodiai",
+        getInstallationOctokit: async () => octokit as never,
+      } as unknown as GitHubApp,
+      executor: {
+        execute: async () => ({
+          conclusion: "success",
+          published: false,
+          costUsd: 0,
+          numTurns: 1,
+          durationMs: 1,
+          sessionId: "session-review-details-standalone-recheck",
+          executorPhaseTimings: [
+            { name: "executor handoff", status: "completed", durationMs: 50 },
+            { name: "remote runtime", status: "completed", durationMs: 500 },
+          ],
+        }),
+      } as never,
+      telemetryStore: noopTelemetryStore,
+      reviewWorkCoordinator: {
+        claim: (claim: Record<string, unknown>) => ({
+          attemptId: "attempt-review-details-standalone-recheck-1",
+          familyKey: claim.familyKey as string,
+          source: claim.source as "automatic-review",
+          lane: claim.lane as "review",
+          deliveryId: claim.deliveryId as string,
+          phase: claim.phase as "claimed",
+          claimedAtMs: 100,
+          lastProgressAtMs: 100,
+        }),
+        canPublish: () => allowPublish,
+        setPhase: () => null,
+        getSnapshot: () => null,
+        release: () => undefined,
+        complete: (attemptId: string) => {
+          completedAttemptIds.push(attemptId);
+        },
+      } as never,
+      logger: logger as never,
+    });
+
+    const handler = handlers.get("pull_request.review_requested");
+    expect(handler).toBeDefined();
+
+    await handler!(
+      buildReviewRequestedEvent({
+        requested_reviewer: { login: "kodiai[bot]" },
+      }),
+    );
+
+    expect(listCommentsCalls).toBe(1);
+    expect(createCommentCalls).toBe(0);
+    expect(updateCommentCalls).toBe(0);
+    expect(completedAttemptIds).toEqual(["attempt-review-details-standalone-recheck-1"]);
+    expect(
+      entries.some((entry) => entry.message === "Skipping deterministic Review Details standalone comment because publish rights were superseded"),
+    ).toBeTrue();
+
+    await workspaceFixture.cleanup();
+  });
 });
 
 describe("createReviewHandler global knowledge sharing", () => {
@@ -4054,9 +5675,10 @@ describe("createReviewHandler global knowledge sharing", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -4197,9 +5819,10 @@ describe("createReviewHandler global knowledge sharing", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -4334,9 +5957,10 @@ describe("createReviewHandler enforcement integration", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -4475,9 +6099,10 @@ describe("createReviewHandler enforcement integration", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -4618,9 +6243,10 @@ describe("createReviewHandler enforcement integration", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -4754,9 +6380,10 @@ describe("createReviewHandler enforcement integration", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -4837,9 +6464,10 @@ describe("createReviewHandler enforcement integration", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -5059,9 +6687,10 @@ describe("createReviewHandler multi-query retrieval orchestration (RET-07)", () 
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -5213,9 +6842,10 @@ describe("createReviewHandler multi-query retrieval orchestration (RET-07)", () 
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -5303,9 +6933,10 @@ describe("createReviewHandler multi-query retrieval orchestration (RET-07)", () 
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -5499,9 +7130,10 @@ describe("createReviewHandler feedback-driven suppression", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -5652,9 +7284,10 @@ describe("createReviewHandler feedback-driven suppression", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -5821,9 +7454,10 @@ describe("createReviewHandler feedback-driven suppression", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -5992,9 +7626,10 @@ describe("createReviewHandler feedback-driven suppression", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -6167,9 +7802,10 @@ describe("createReviewHandler feedback-driven suppression", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -6419,9 +8055,10 @@ describe("createReviewHandler finding prioritization", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -6678,9 +8315,10 @@ describe("createReviewHandler usageLimit and token wiring", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -6802,9 +8440,10 @@ describe("createReviewHandler dep bump analysis wiring (Phase 57)", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -6945,13 +8584,69 @@ describe("createReviewHandler dep bump analysis wiring (Phase 57)", () => {
   });
 });
 
+describe("createReviewHandler enqueue routing", () => {
+  test("automatic review requests enqueue onto the review lane with a stable PR key", async () => {
+    const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
+    const enqueuedContexts: Array<{ lane?: string; key?: string }> = [];
+
+    createReviewHandler({
+      eventRouter: {
+        register: (eventKey, handler) => {
+          handlers.set(eventKey, handler);
+        },
+        dispatch: async () => undefined,
+      },
+      jobQueue: {
+        enqueue: async <T>(
+          _installationId: number,
+          _fn: (metadata: JobQueueRunMetadata) => Promise<T>,
+          context?: JobQueueContext,
+        ) => {
+          enqueuedContexts.push({ lane: context?.lane, key: context?.key });
+          return undefined as T;
+        },
+        getQueueSize: () => 0,
+        getPendingCount: () => 0,
+        getActiveJobs: getEmptyActiveJobs,
+      },
+      workspaceManager: {} as WorkspaceManager,
+      githubApp: {
+        getAppSlug: () => "kodiai",
+        getInstallationOctokit: async () => {
+          throw new Error("not used");
+        },
+      } as unknown as GitHubApp,
+      executor: {
+        execute: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      telemetryStore: noopTelemetryStore,
+      logger: createNoopLogger() as never,
+    });
+
+    const handler = handlers.get("pull_request.review_requested");
+    expect(handler).toBeDefined();
+
+    await handler!(
+      buildReviewRequestedEvent({
+        requested_reviewer: { login: "kodiai[bot]" },
+      }),
+    );
+
+    expect(enqueuedContexts).toEqual([
+      { lane: "review", key: "acme/repo#101" },
+    ]);
+  });
+});
+
 describe("createReviewHandler timeout resilience", () => {
   test("full timeout with no output posts partial timeout comment and enqueues a reduced-scope retry", async () => {
     const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
     const workspaceFixture = await createWorkspaceFixture();
 
     const createdCommentBodies: string[] = [];
-    const enqueuedContexts: Array<{ action?: string; jobType?: string }> = [];
+    const enqueuedContexts: Array<{ action?: string; jobType?: string; lane?: string; key?: string }> = [];
 
     const eventRouter: EventRouter = {
       register: (eventKey, handler) => {
@@ -6963,24 +8658,38 @@ describe("createReviewHandler timeout resilience", () => {
     const jobQueue: JobQueue = {
       enqueue: async <T>(
         _installationId: number,
-        fn: () => Promise<T>,
+        fn: (metadata: JobQueueRunMetadata) => Promise<T>,
         context?: {
           deliveryId?: string;
           eventName?: string;
           action?: string;
           jobType?: string;
           prNumber?: number;
+          lane?: string;
+          key?: string;
         },
       ) => {
-        enqueuedContexts.push({ action: context?.action, jobType: context?.jobType });
+        enqueuedContexts.push({
+          action: context?.action,
+          jobType: context?.jobType,
+          lane: context?.lane,
+          key: context?.key,
+        });
         if (context?.action === "review-retry") {
           // Do not execute the retry job in this unit test.
           return undefined as T;
         }
-        return fn();
+        return fn(
+          createQueueRunMetadata({
+            queuedAtMs: 1_000,
+            startedAtMs: 900,
+            waitMs: -100,
+          }),
+        );
       },
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -7096,18 +8805,25 @@ describe("createReviewHandler timeout resilience", () => {
     expect(reviewDetails!).toContain("remote runtime: unavailable");
     expect(reviewDetails!).toContain("publication:");
 
-    expect(enqueuedContexts.some((c) => c.action === "review-retry")).toBe(true);
+    const retryContext = enqueuedContexts.find((context) => context.action === "review-retry");
+    expect(retryContext).toEqual({
+      action: "review-retry",
+      jobType: "pull-request-review-retry",
+      lane: "review",
+      key: "acme/repo#101",
+    });
 
     await workspaceFixture.cleanup();
   });
 
-  test("transient agent exit 143 retries once before posting an error", async () => {
+  test("suppresses timeout Review Details publication when publish rights are lost after partial review", async () => {
     const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
-    const workspaceFixture = await createWorkspaceFixture({ autoApprove: true });
+    const workspaceFixture = await createWorkspaceFixture();
+    const { logger, entries } = createCaptureLogger();
 
     const createdCommentBodies: string[] = [];
-    let executeCount = 0;
-    let approveCount = 0;
+    const completedAttemptIds: string[] = [];
+    const canPublishResults = [true, false];
 
     const eventRouter: EventRouter = {
       register: (eventKey, handler) => {
@@ -7117,9 +8833,27 @@ describe("createReviewHandler timeout resilience", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(
+        _installationId: number,
+        fn: (metadata: JobQueueRunMetadata) => Promise<T>,
+        context?: {
+          action?: string;
+        },
+      ) => {
+        if (context?.action === "review-retry") {
+          return undefined as T;
+        }
+        return fn(
+          createQueueRunMetadata({
+            queuedAtMs: 1_000,
+            startedAtMs: 900,
+            waitMs: -100,
+          }),
+        );
+      },
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -7130,22 +8864,19 @@ describe("createReviewHandler timeout resilience", () => {
       cleanupStale: async () => 0,
     };
 
+    let nextCommentId = 200;
     const octokit = {
       rest: {
         pulls: {
           listReviewComments: async () => ({ data: [] }),
           listReviews: async () => ({ data: [] }),
           listCommits: async () => ({ data: [] }),
-          createReview: async () => {
-            approveCount++;
-            return { data: {} };
-          },
         },
         issues: {
           listComments: async () => ({ data: [] }),
           createComment: async (params: { body: string }) => {
             createdCommentBodies.push(params.body);
-            return { data: { id: 100 } };
+            return { data: { id: nextCommentId++ } };
           },
           updateComment: async () => ({ data: {} }),
         },
@@ -7164,62 +8895,571 @@ describe("createReviewHandler timeout resilience", () => {
         getInstallationOctokit: async () => octokit as never,
       } as unknown as GitHubApp,
       executor: {
-        execute: async () => {
-          executeCount++;
-          if (executeCount === 1) {
+        execute: async () => ({
+          conclusion: "error",
+          isTimeout: true,
+          published: false,
+          errorMessage: "timeout",
+          costUsd: 0,
+          numTurns: 1,
+          durationMs: 1,
+          sessionId: "session-timeout-review-details-superseded",
+          model: "test-model",
+          inputTokens: 0,
+          outputTokens: 0,
+          cacheReadTokens: 0,
+          cacheCreationTokens: 0,
+          stopReason: "timeout",
+        }),
+      } as never,
+      telemetryStore: noopTelemetryStore,
+      knowledgeStore: createKnowledgeStoreStub({
+        getCheckpoint: () => null,
+        updateCheckpointCommentId: () => undefined,
+        deleteCheckpoint: () => undefined,
+      }) as never,
+      reviewWorkCoordinator: {
+        claim: (claim: Record<string, unknown>) => ({
+          attemptId: "attempt-timeout-details-1",
+          familyKey: claim.familyKey as string,
+          source: claim.source as "automatic-review",
+          lane: claim.lane as "review",
+          deliveryId: claim.deliveryId as string,
+          phase: claim.phase as "claimed",
+          claimedAtMs: 100,
+          lastProgressAtMs: 100,
+        }),
+        canPublish: () => canPublishResults.shift() ?? false,
+        setPhase: () => null,
+        getSnapshot: () => null,
+        release: () => undefined,
+        complete: (attemptId: string) => {
+          completedAttemptIds.push(attemptId);
+        },
+      } as never,
+      logger: logger as never,
+    });
+
+    const handler = handlers.get("pull_request.review_requested");
+    expect(handler).toBeDefined();
+
+    await handler!(
+      buildReviewRequestedEvent({
+        requested_reviewer: { login: "kodiai[bot]" },
+        pull_request: {
+          number: 101,
+          draft: false,
+          title: "Timeout review details suppression",
+          body: "",
+          commits: 0,
+          additions: 1,
+          deletions: 0,
+          user: { login: "octocat" },
+          base: { ref: "main", sha: "mainsha" },
+          head: {
+            sha: "abcdef1234567890",
+            ref: "feature",
+            repo: {
+              full_name: "acme/repo",
+              name: "repo",
+              owner: { login: "acme" },
+            },
+          },
+          labels: [],
+        },
+      }),
+    );
+
+    const partial = createdCommentBodies.find((body) => body.includes("**Partial review**"));
+    const reviewDetails = createdCommentBodies.find((body) => body.includes("<summary>Review Details</summary>"));
+
+    expect(partial).toBeDefined();
+    expect(reviewDetails).toBeUndefined();
+    expect(completedAttemptIds).toEqual(["attempt-timeout-details-1"]);
+    expect(
+      entries.some((entry) => entry.message === "Skipping timeout Review Details comment because publish rights were superseded"),
+    ).toBeTrue();
+
+    await workspaceFixture.cleanup();
+  });
+
+  test("queued retry keeps publish rights after the parent attempt unwinds", async () => {
+    const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
+    const workspaceFixture = await createWorkspaceFixture();
+    const { logger } = createCaptureLogger();
+
+    const createdCommentBodies: string[] = [];
+    const completedAttemptIds: string[] = [];
+    const checkpointState = new Map<string, {
+      partialCommentId?: number;
+      findingCount?: number;
+      filesReviewed?: string[];
+      summaryDraft?: string;
+    }>();
+
+    const reviewOutputKey = buildReviewOutputKey({
+      installationId: 42,
+      owner: "acme",
+      repo: "repo",
+      prNumber: 101,
+      action: "review_requested",
+      deliveryId: "delivery-123",
+      headSha: "abcdef1234567890",
+    });
+    const retryReviewOutputKey = `${reviewOutputKey}-retry-1`;
+    checkpointState.set(retryReviewOutputKey, {
+      findingCount: 1,
+      filesReviewed: ["README.md"],
+      summaryDraft: "Retry found one issue.",
+    });
+
+    let updatedCommentBody: string | undefined;
+    let queuedRetryJob: ((metadata: JobQueueRunMetadata) => Promise<unknown>) | undefined;
+    let nextCommentId = 300;
+    let executeCount = 0;
+
+    const eventRouter: EventRouter = {
+      register: (eventKey, handler) => {
+        handlers.set(eventKey, handler);
+      },
+      dispatch: async () => undefined,
+    };
+
+    const queueMetadata = createQueueRunMetadata();
+
+    const jobQueue: JobQueue = {
+      enqueue: async <T>(
+        _installationId: number,
+        fn: (metadata: JobQueueRunMetadata) => Promise<T>,
+        context?: {
+          action?: string;
+        },
+      ) => {
+        if (context?.action === "review-retry") {
+          queuedRetryJob = fn as (metadata: JobQueueRunMetadata) => Promise<unknown>;
+          return undefined as T;
+        }
+        return fn(queueMetadata);
+      },
+      getQueueSize: () => 0,
+      getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
+    };
+
+    const workspaceManager: WorkspaceManager = {
+      create: async () => ({
+        dir: workspaceFixture.dir,
+        cleanup: async () => undefined,
+      }),
+      cleanupStale: async () => 0,
+    };
+
+    const coordinator = createReviewWorkCoordinator({
+      nowFn: (() => {
+        let nowMs = 10_000;
+        return () => ++nowMs;
+      })(),
+    });
+    const reviewWorkCoordinator = {
+      claim: (claim: Parameters<typeof coordinator.claim>[0]) => coordinator.claim(claim),
+      canPublish: (attemptId: string) => coordinator.canPublish(attemptId),
+      setPhase: (
+        attemptId: string,
+        phase: Parameters<NonNullable<typeof coordinator.setPhase>>[1],
+      ) => coordinator.setPhase(attemptId, phase),
+      getSnapshot: (familyKey: string) => coordinator.getSnapshot(familyKey),
+      release: (attemptId: string) => coordinator.release(attemptId),
+      complete: (attemptId: string) => {
+        completedAttemptIds.push(attemptId);
+        coordinator.complete(attemptId);
+      },
+    };
+
+    const octokit = {
+      rest: {
+        pulls: {
+          listReviewComments: async () => ({ data: [] }),
+          listReviews: async () => ({ data: [] }),
+          listCommits: async () => ({ data: [] }),
+        },
+        issues: {
+          listComments: async () => ({ data: [] }),
+          createComment: async (params: { body: string }) => {
+            createdCommentBodies.push(params.body);
+            return { data: { id: nextCommentId++ } };
+          },
+          updateComment: async (params: { body: string }) => {
+            updatedCommentBody = params.body;
+            return { data: {} };
+          },
+        },
+        reactions: {
+          createForIssue: async () => ({ data: {} }),
+        },
+      },
+    };
+
+    createReviewHandler({
+      eventRouter,
+      jobQueue,
+      workspaceManager,
+      githubApp: {
+        getAppSlug: () => "kodiai",
+        getInstallationOctokit: async () => octokit as never,
+      } as unknown as GitHubApp,
+      executor: {
+        execute: async (context: { eventType: string }) => {
+          executeCount += 1;
+          if (context.eventType === "pull_request.review-retry") {
             return {
-              conclusion: "error",
+              conclusion: "success",
               published: false,
-              errorMessage: "Failed with exit code 143",
               costUsd: 0,
               numTurns: 1,
               durationMs: 1,
-              sessionId: "session-exit-143-first",
+              sessionId: "session-timeout-retry-followup",
               model: "test-model",
               inputTokens: 0,
               outputTokens: 0,
               cacheReadTokens: 0,
               cacheCreationTokens: 0,
-              stopReason: undefined,
+              stopReason: "end_turn",
             };
           }
-
           return {
-            conclusion: "success",
+            conclusion: "error",
+            isTimeout: true,
             published: false,
+            errorMessage: "timeout",
             costUsd: 0,
             numTurns: 1,
             durationMs: 1,
-            sessionId: "session-exit-143-retry",
+            sessionId: "session-timeout-retry-root",
             model: "test-model",
             inputTokens: 0,
             outputTokens: 0,
             cacheReadTokens: 0,
             cacheCreationTokens: 0,
-            stopReason: "end_turn",
+            stopReason: "timeout",
           };
         },
       } as never,
       telemetryStore: noopTelemetryStore,
-      logger: createNoopLogger(),
+      knowledgeStore: createKnowledgeStoreStub({
+        saveCheckpoint: async (checkpoint: {
+          reviewOutputKey: string;
+          partialCommentId?: number;
+          findingCount?: number;
+          filesReviewed?: string[];
+          summaryDraft?: string;
+        }) => {
+          checkpointState.set(checkpoint.reviewOutputKey, {
+            partialCommentId: checkpoint.partialCommentId,
+            findingCount: checkpoint.findingCount,
+            filesReviewed: checkpoint.filesReviewed,
+            summaryDraft: checkpoint.summaryDraft,
+          });
+        },
+        getCheckpoint: async (key: string) => checkpointState.get(key) ?? null,
+        updateCheckpointCommentId: (key: string, partialCommentId: number) => {
+          const current = checkpointState.get(key) ?? {};
+          checkpointState.set(key, { ...current, partialCommentId });
+        },
+        deleteCheckpoint: (key: string) => {
+          checkpointState.delete(key);
+        },
+      }) as never,
+      reviewWorkCoordinator: reviewWorkCoordinator as never,
+      logger: logger as never,
     });
 
-    const handler = handlers.get("pull_request.opened");
+    const handler = handlers.get("pull_request.review_requested");
     expect(handler).toBeDefined();
 
-    await handler!({
-      ...buildReviewRequestedEvent({ action: "opened" }),
-      name: "pull_request",
-      payload: {
-        ...buildReviewRequestedEvent({}).payload,
-        action: "opened",
-      },
-    });
+    await handler!(
+      buildReviewRequestedEvent({
+        requested_reviewer: { login: "kodiai[bot]" },
+        pull_request: {
+          number: 101,
+          draft: false,
+          title: "Timeout retry merge success",
+          body: "",
+          commits: 0,
+          additions: 1,
+          deletions: 0,
+          user: { login: "octocat" },
+          base: { ref: "main", sha: "mainsha" },
+          head: {
+            sha: "abcdef1234567890",
+            ref: "feature",
+            repo: {
+              full_name: "acme/repo",
+              name: "repo",
+              owner: { login: "acme" },
+            },
+          },
+          labels: [],
+        },
+      }),
+    );
+
+    expect(queuedRetryJob).toBeDefined();
+    expect(completedAttemptIds).toEqual(["review-work-1"]);
+
+    await queuedRetryJob!(queueMetadata);
 
     expect(executeCount).toBe(2);
-    expect(createdCommentBodies.some((body) => body.includes("Failed with exit code 143"))).toBe(false);
-    expect(createdCommentBodies.some((body) => body.includes("Kodiai encountered an error"))).toBe(false);
-    expect(approveCount).toBe(1);
+    expect(createdCommentBodies.some((body) => body.includes("**Partial review**"))).toBeTrue();
+    expect(updatedCommentBody).toBeDefined();
+    expect(updatedCommentBody).toContain("Retry found one issue.");
+    expect(updatedCommentBody).toContain("in retry");
+    expect(completedAttemptIds).toEqual(["review-work-1", "review-work-2"]);
+
+    await workspaceFixture.cleanup();
+  });
+
+  test("suppresses retry partial review merge when newer review work supersedes the queued retry", async () => {
+    const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
+    const workspaceFixture = await createWorkspaceFixture();
+    const { logger, entries } = createCaptureLogger();
+
+    const createdCommentBodies: string[] = [];
+    const completedAttemptIds: string[] = [];
+    const checkpointState = new Map<string, {
+      partialCommentId?: number;
+      findingCount?: number;
+      filesReviewed?: string[];
+      summaryDraft?: string;
+    }>();
+
+    const reviewOutputKey = buildReviewOutputKey({
+      installationId: 42,
+      owner: "acme",
+      repo: "repo",
+      prNumber: 101,
+      action: "review_requested",
+      deliveryId: "delivery-123",
+      headSha: "abcdef1234567890",
+    });
+    const retryReviewOutputKey = `${reviewOutputKey}-retry-1`;
+    checkpointState.set(retryReviewOutputKey, {
+      findingCount: 1,
+      filesReviewed: ["README.md"],
+      summaryDraft: "Retry found one issue.",
+    });
+
+    let updatedCommentBody: string | undefined;
+    let queuedRetryJob: ((metadata: JobQueueRunMetadata) => Promise<unknown>) | undefined;
+    let nextCommentId = 350;
+    let executeCount = 0;
+
+    const eventRouter: EventRouter = {
+      register: (eventKey, handler) => {
+        handlers.set(eventKey, handler);
+      },
+      dispatch: async () => undefined,
+    };
+
+    const queueMetadata = createQueueRunMetadata();
+
+    const jobQueue: JobQueue = {
+      enqueue: async <T>(
+        _installationId: number,
+        fn: (metadata: JobQueueRunMetadata) => Promise<T>,
+        context?: {
+          action?: string;
+        },
+      ) => {
+        if (context?.action === "review-retry") {
+          queuedRetryJob = fn as (metadata: JobQueueRunMetadata) => Promise<unknown>;
+          return undefined as T;
+        }
+        return fn(queueMetadata);
+      },
+      getQueueSize: () => 0,
+      getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
+    };
+
+    const workspaceManager: WorkspaceManager = {
+      create: async () => ({
+        dir: workspaceFixture.dir,
+        cleanup: async () => undefined,
+      }),
+      cleanupStale: async () => 0,
+    };
+
+    const coordinator = createReviewWorkCoordinator({
+      nowFn: (() => {
+        let nowMs = 12_000;
+        return () => ++nowMs;
+      })(),
+    });
+    const reviewWorkCoordinator = {
+      claim: (claim: Parameters<typeof coordinator.claim>[0]) => coordinator.claim(claim),
+      canPublish: (attemptId: string) => coordinator.canPublish(attemptId),
+      setPhase: (
+        attemptId: string,
+        phase: Parameters<NonNullable<typeof coordinator.setPhase>>[1],
+      ) => coordinator.setPhase(attemptId, phase),
+      getSnapshot: (familyKey: string) => coordinator.getSnapshot(familyKey),
+      release: (attemptId: string) => coordinator.release(attemptId),
+      complete: (attemptId: string) => {
+        completedAttemptIds.push(attemptId);
+        coordinator.complete(attemptId);
+      },
+    };
+
+    const octokit = {
+      rest: {
+        pulls: {
+          listReviewComments: async () => ({ data: [] }),
+          listReviews: async () => ({ data: [] }),
+          listCommits: async () => ({ data: [] }),
+        },
+        issues: {
+          listComments: async () => ({ data: [] }),
+          createComment: async (params: { body: string }) => {
+            createdCommentBodies.push(params.body);
+            return { data: { id: nextCommentId++ } };
+          },
+          updateComment: async (params: { body: string }) => {
+            updatedCommentBody = params.body;
+            return { data: {} };
+          },
+        },
+        reactions: {
+          createForIssue: async () => ({ data: {} }),
+        },
+      },
+    };
+
+    createReviewHandler({
+      eventRouter,
+      jobQueue,
+      workspaceManager,
+      githubApp: {
+        getAppSlug: () => "kodiai",
+        getInstallationOctokit: async () => octokit as never,
+      } as unknown as GitHubApp,
+      executor: {
+        execute: async (context: { eventType: string }) => {
+          executeCount += 1;
+          if (context.eventType === "pull_request.review-retry") {
+            return {
+              conclusion: "success",
+              published: false,
+              costUsd: 0,
+              numTurns: 1,
+              durationMs: 1,
+              sessionId: "session-timeout-retry-followup-superseded",
+              model: "test-model",
+              inputTokens: 0,
+              outputTokens: 0,
+              cacheReadTokens: 0,
+              cacheCreationTokens: 0,
+              stopReason: "end_turn",
+            };
+          }
+          return {
+            conclusion: "error",
+            isTimeout: true,
+            published: false,
+            errorMessage: "timeout",
+            costUsd: 0,
+            numTurns: 1,
+            durationMs: 1,
+            sessionId: "session-timeout-retry-root-superseded",
+            model: "test-model",
+            inputTokens: 0,
+            outputTokens: 0,
+            cacheReadTokens: 0,
+            cacheCreationTokens: 0,
+            stopReason: "timeout",
+          };
+        },
+      } as never,
+      telemetryStore: noopTelemetryStore,
+      knowledgeStore: createKnowledgeStoreStub({
+        saveCheckpoint: async (checkpoint: {
+          reviewOutputKey: string;
+          partialCommentId?: number;
+          findingCount?: number;
+          filesReviewed?: string[];
+          summaryDraft?: string;
+        }) => {
+          checkpointState.set(checkpoint.reviewOutputKey, {
+            partialCommentId: checkpoint.partialCommentId,
+            findingCount: checkpoint.findingCount,
+            filesReviewed: checkpoint.filesReviewed,
+            summaryDraft: checkpoint.summaryDraft,
+          });
+        },
+        getCheckpoint: async (key: string) => checkpointState.get(key) ?? null,
+        updateCheckpointCommentId: (key: string, partialCommentId: number) => {
+          const current = checkpointState.get(key) ?? {};
+          checkpointState.set(key, { ...current, partialCommentId });
+        },
+        deleteCheckpoint: (key: string) => {
+          checkpointState.delete(key);
+        },
+      }) as never,
+      reviewWorkCoordinator: reviewWorkCoordinator as never,
+      logger: logger as never,
+    });
+
+    const handler = handlers.get("pull_request.review_requested");
+    expect(handler).toBeDefined();
+
+    await handler!(
+      buildReviewRequestedEvent({
+        requested_reviewer: { login: "kodiai[bot]" },
+        pull_request: {
+          number: 101,
+          draft: false,
+          title: "Timeout retry merge suppression",
+          body: "",
+          commits: 0,
+          additions: 1,
+          deletions: 0,
+          user: { login: "octocat" },
+          base: { ref: "main", sha: "mainsha" },
+          head: {
+            sha: "abcdef1234567890",
+            ref: "feature",
+            repo: {
+              full_name: "acme/repo",
+              name: "repo",
+              owner: { login: "acme" },
+            },
+          },
+          labels: [],
+        },
+      }),
+    );
+
+    expect(queuedRetryJob).toBeDefined();
+    expect(completedAttemptIds).toEqual(["review-work-1"]);
+
+    const supersedingExplicitAttempt = reviewWorkCoordinator.claim({
+      familyKey: buildReviewFamilyKey("acme", "repo", 101),
+      source: "explicit-review",
+      lane: "interactive-review",
+      deliveryId: "delivery-explicit-456",
+      phase: "claimed",
+    });
+    reviewWorkCoordinator.setPhase(supersedingExplicitAttempt.attemptId, "executor-dispatch");
+    reviewWorkCoordinator.complete(supersedingExplicitAttempt.attemptId);
+
+    await queuedRetryJob!(queueMetadata);
+
+    expect(executeCount).toBe(2);
+    expect(createdCommentBodies.some((body) => body.includes("**Partial review**"))).toBeTrue();
+    expect(updatedCommentBody).toBeUndefined();
+    expect(completedAttemptIds).toEqual(["review-work-1", "review-work-3", "review-work-2"]);
+    expect(
+      entries.some((entry) => entry.message === "Skipping retry partial review merge because publish rights were superseded"),
+    ).toBeTrue();
 
     await workspaceFixture.cleanup();
   });
@@ -7253,9 +9493,10 @@ describe("createReviewHandler author-tier search cache integration", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -7423,9 +9664,10 @@ describe("createReviewHandler author-tier search cache integration", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -7612,9 +9854,10 @@ describe("createReviewHandler author-tier search cache integration", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -8338,9 +10581,10 @@ describe("createReviewHandler synchronize gating", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -8543,9 +10787,10 @@ describe("createReviewHandler draft PR behavior", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -8668,9 +10913,153 @@ describe("createReviewHandler draft PR behavior", () => {
   });
 });
 
+describe("createReviewHandler coordinator phase checkpoints", () => {
+  test("advances through pre-executor checkpoint phases before dispatching the executor", async () => {
+    const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
+    const workspaceFixture = await createWorkspaceFixture();
+
+    const phaseTransitions: string[] = [];
+    let phasesSeenAtExecutor: string[] = [];
+    const coordinator = createReviewWorkCoordinator({
+      nowFn: (() => {
+        let nowMs = 12_000;
+        return () => ++nowMs;
+      })(),
+    });
+    const reviewWorkCoordinator = {
+      claim: (claim: Parameters<typeof coordinator.claim>[0]) => coordinator.claim(claim),
+      canPublish: (attemptId: Parameters<typeof coordinator.canPublish>[0]) => coordinator.canPublish(attemptId),
+      setPhase: (
+        attemptId: Parameters<typeof coordinator.setPhase>[0],
+        phase: Parameters<NonNullable<typeof coordinator.setPhase>>[1],
+      ) => {
+        phaseTransitions.push(phase);
+        return coordinator.setPhase(attemptId, phase);
+      },
+      getSnapshot: (familyKey: Parameters<typeof coordinator.getSnapshot>[0]) => coordinator.getSnapshot(familyKey),
+      release: (attemptId: Parameters<typeof coordinator.release>[0]) => coordinator.release(attemptId),
+      complete: (attemptId: Parameters<typeof coordinator.complete>[0]) => coordinator.complete(attemptId),
+    };
+
+    const eventRouter: EventRouter = {
+      register: (eventKey, handler) => {
+        handlers.set(eventKey, handler);
+      },
+      dispatch: async () => undefined,
+    };
+
+    const jobQueue: JobQueue = {
+      enqueue: async <T>(
+        _installationId: number,
+        fn: (metadata: JobQueueRunMetadata) => Promise<T>,
+      ) => fn(createQueueRunMetadata()),
+      getQueueSize: () => 0,
+      getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
+    };
+
+    const workspaceManager: WorkspaceManager = {
+      create: async () => ({
+        dir: workspaceFixture.dir,
+        cleanup: async () => undefined,
+      }),
+      cleanupStale: async () => 0,
+    };
+
+    const octokit = {
+      rest: {
+        pulls: {
+          listReviewComments: async () => ({ data: [] }),
+          listReviews: async () => ({ data: [] }),
+          listCommits: async () => ({ data: [] }),
+        },
+        issues: {
+          listComments: async () => ({ data: [] }),
+          createComment: async () => ({ data: { id: 1 } }),
+          updateComment: async () => ({ data: {} }),
+        },
+        reactions: {
+          createForIssue: async () => ({ data: {} }),
+        },
+        search: {
+          issuesAndPullRequests: async () => ({ data: { total_count: 4 } }),
+        },
+      },
+    };
+
+    createReviewHandler({
+      eventRouter,
+      jobQueue,
+      workspaceManager,
+      githubApp: {
+        getAppSlug: () => "kodiai",
+        getInstallationOctokit: async () => octokit as never,
+      } as unknown as GitHubApp,
+      executor: {
+        execute: async () => {
+          phasesSeenAtExecutor = [...phaseTransitions];
+          return {
+            conclusion: "success",
+            published: false,
+            costUsd: 0,
+            numTurns: 1,
+            durationMs: 1,
+            sessionId: "session-phase-checkpoints",
+          };
+        },
+      } as never,
+      telemetryStore: noopTelemetryStore,
+      reviewWorkCoordinator,
+      logger: createNoopLogger(),
+    });
+
+    const handler = handlers.get("pull_request.review_requested");
+    expect(handler).toBeDefined();
+
+    await handler!(
+      buildReviewRequestedEvent({
+        requested_reviewer: { login: "kodiai[bot]" },
+        pull_request: {
+          number: 101,
+          draft: false,
+          title: "Coordinator phase checkpoints",
+          body: "",
+          commits: 0,
+          additions: 40,
+          deletions: 10,
+          user: { login: "octocat" },
+          author_association: "CONTRIBUTOR",
+          base: { ref: "main", sha: "mainsha" },
+          head: {
+            sha: "abcdef1234567890",
+            ref: "feature/phase-checkpoints",
+            repo: {
+              full_name: "acme/repo",
+              name: "repo",
+              owner: { login: "acme" },
+            },
+          },
+          labels: [],
+        },
+      }),
+    );
+
+    await workspaceFixture.cleanup();
+
+    expect(phasesSeenAtExecutor).toEqual([
+      "load-config",
+      "workspace-create",
+      "incremental-diff",
+      "prompt-build",
+      "executor-dispatch",
+    ]);
+    expect(phaseTransitions).toContain("publish");
+  });
+});
+
 describe("createReviewHandler phase timing logging", () => {
   async function runPhaseTimingScenario(options: {
-    queueMetadata?: { queuedAtMs: number; startedAtMs: number; waitMs: number };
+    queueMetadata?: JobQueueRunMetadata;
   }) {
     const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
     const workspaceFixture = await createWorkspaceFixture();
@@ -8684,10 +11073,13 @@ describe("createReviewHandler phase timing logging", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: (metadata?: { queuedAtMs: number; startedAtMs: number; waitMs: number }) => Promise<T>) =>
-        fn(options.queueMetadata),
+      enqueue: async <T>(
+        _installationId: number,
+        fn: (metadata: JobQueueRunMetadata) => Promise<T>,
+      ) => fn(options.queueMetadata ?? createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -8783,11 +11175,7 @@ describe("createReviewHandler phase timing logging", () => {
 
   test("emits one correlated review phase timing payload with the required six phases", async () => {
     const { entries, workspaceDir } = await runPhaseTimingScenario({
-      queueMetadata: {
-        queuedAtMs: 1_000,
-        startedAtMs: 1_250,
-        waitMs: 250,
-      },
+      queueMetadata: createQueueRunMetadata(),
     });
 
     const matchingEntries = entries.filter((entry) => entry.message === "Review phase timing summary");
@@ -8836,11 +11224,11 @@ describe("createReviewHandler phase timing logging", () => {
 
   test("marks queue wait unavailable instead of coercing invalid wait metadata to zero", async () => {
     const { entries } = await runPhaseTimingScenario({
-      queueMetadata: {
+      queueMetadata: createQueueRunMetadata({
         queuedAtMs: 1_000,
         startedAtMs: 900,
         waitMs: -100,
-      },
+      }),
     });
 
     const summary = entries.find((entry) => entry.message === "Review phase timing summary")?.data as {
@@ -8895,10 +11283,13 @@ describe("createReviewHandler Review Details phase timing publication", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: (metadata?: { queuedAtMs: number; startedAtMs: number; waitMs: number }) => Promise<T>) =>
-        fn({ queuedAtMs: 1_000, startedAtMs: 1_250, waitMs: 250 }),
+      enqueue: async <T>(
+        _installationId: number,
+        fn: (metadata: JobQueueRunMetadata) => Promise<T>,
+      ) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -9009,10 +11400,13 @@ describe("createReviewHandler Review Details phase timing publication", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: (metadata?: { queuedAtMs: number; startedAtMs: number; waitMs: number }) => Promise<T>) =>
-        fn({ queuedAtMs: 1_000, startedAtMs: 1_250, waitMs: 250 }),
+      enqueue: async <T>(
+        _installationId: number,
+        fn: (metadata: JobQueueRunMetadata) => Promise<T>,
+      ) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {
@@ -9152,9 +11546,10 @@ describe("createReviewHandler bounded review disclosure", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {

--- a/src/handlers/review.test.ts
+++ b/src/handlers/review.test.ts
@@ -4339,9 +4339,10 @@ describe("createReviewHandler diff collection resilience", () => {
     };
 
     const jobQueue: JobQueue = {
-      enqueue: async <T>(_installationId: number, fn: () => Promise<T>) => fn(),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
     };
 
     const workspaceManager: WorkspaceManager = {

--- a/src/handlers/review.test.ts
+++ b/src/handlers/review.test.ts
@@ -11047,13 +11047,167 @@ describe("createReviewHandler coordinator phase checkpoints", () => {
     await workspaceFixture.cleanup();
 
     expect(phasesSeenAtExecutor).toEqual([
-      "load-config",
       "workspace-create",
+      "load-config",
       "incremental-diff",
       "prompt-build",
       "executor-dispatch",
     ]);
     expect(phaseTransitions).toContain("publish");
+  });
+
+  test("exposes truthful workspace-create and load-config phases at async boundaries", async () => {
+    const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
+    const workspaceFixture = await createWorkspaceFixture();
+    const reviewFamilyKey = buildReviewFamilyKey("acme", "repo", 102);
+    await Bun.write(
+      join(workspaceFixture.dir, ".kodiai.yml"),
+      [
+        "review:",
+        "  enabled: true",
+        "  autoApprove: false",
+        "  onSynchronize: true",
+        "  requestUiRereviewTeamOnOpen: false",
+        "  triggers:",
+        "    onOpened: true",
+        "    onReadyForReview: true",
+        "    onReviewRequested: true",
+        "  skipAuthors: []",
+        "  skipPaths: []",
+        "",
+      ].join("\n"),
+    );
+
+    let phaseAtWorkspaceCreate: string | undefined;
+    let phaseAtConfigWarning: string | undefined;
+    const coordinator = createReviewWorkCoordinator({
+      nowFn: (() => {
+        let nowMs = 13_000;
+        return () => ++nowMs;
+      })(),
+    });
+
+    const logger = {
+      info: () => undefined,
+      warn: (_data: Record<string, unknown>, message: string) => {
+        if (message === "Config warning detected") {
+          phaseAtConfigWarning = coordinator.getSnapshot(reviewFamilyKey)?.attempts[0]?.phase;
+        }
+      },
+      error: () => undefined,
+      debug: () => undefined,
+      trace: () => undefined,
+      fatal: () => undefined,
+      child: () => logger,
+    } as unknown as Logger;
+
+    const eventRouter: EventRouter = {
+      register: (eventKey, handler) => {
+        handlers.set(eventKey, handler);
+      },
+      dispatch: async () => undefined,
+    };
+
+    const jobQueue: JobQueue = {
+      enqueue: async <T>(
+        _installationId: number,
+        fn: (metadata: JobQueueRunMetadata) => Promise<T>,
+      ) => fn(createQueueRunMetadata()),
+      getQueueSize: () => 0,
+      getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
+    };
+
+    const workspaceManager: WorkspaceManager = {
+      create: async () => {
+        phaseAtWorkspaceCreate = coordinator.getSnapshot(reviewFamilyKey)?.attempts[0]?.phase;
+        return {
+          dir: workspaceFixture.dir,
+          cleanup: async () => undefined,
+        };
+      },
+      cleanupStale: async () => 0,
+    };
+
+    const octokit = {
+      rest: {
+        pulls: {
+          listReviewComments: async () => ({ data: [] }),
+          listReviews: async () => ({ data: [] }),
+          listCommits: async () => ({ data: [] }),
+        },
+        issues: {
+          listComments: async () => ({ data: [] }),
+          createComment: async () => ({ data: { id: 1 } }),
+          updateComment: async () => ({ data: {} }),
+        },
+        reactions: {
+          createForIssue: async () => ({ data: {} }),
+        },
+        search: {
+          issuesAndPullRequests: async () => ({ data: { total_count: 4 } }),
+        },
+      },
+    };
+
+    createReviewHandler({
+      eventRouter,
+      jobQueue,
+      workspaceManager,
+      githubApp: {
+        getAppSlug: () => "kodiai",
+        getInstallationOctokit: async () => octokit as never,
+      } as unknown as GitHubApp,
+      executor: {
+        execute: async () => ({
+          conclusion: "success",
+          published: false,
+          costUsd: 0,
+          numTurns: 1,
+          durationMs: 1,
+          sessionId: "session-phase-boundaries",
+        }),
+      } as never,
+      telemetryStore: noopTelemetryStore,
+      reviewWorkCoordinator: coordinator,
+      logger,
+    });
+
+    const handler = handlers.get("pull_request.review_requested");
+    expect(handler).toBeDefined();
+
+    await handler!(
+      buildReviewRequestedEvent({
+        requested_reviewer: { login: "kodiai[bot]" },
+        pull_request: {
+          number: 102,
+          draft: false,
+          title: "Coordinator phase boundary checkpoints",
+          body: "",
+          commits: 0,
+          additions: 20,
+          deletions: 5,
+          user: { login: "octocat" },
+          author_association: "CONTRIBUTOR",
+          base: { ref: "main", sha: "mainsha" },
+          head: {
+            sha: "bcdef1234567890a",
+            ref: "feature/phase-boundaries",
+            repo: {
+              full_name: "acme/repo",
+              name: "repo",
+              owner: { login: "acme" },
+            },
+          },
+          labels: [],
+        },
+      }),
+    );
+
+    await workspaceFixture.cleanup();
+
+    expect(phaseAtWorkspaceCreate).toBe("workspace-create");
+    expect(phaseAtConfigWarning).toBe("load-config");
   });
 });
 

--- a/src/handlers/review.ts
+++ b/src/handlers/review.ts
@@ -1747,7 +1747,6 @@ export function createReviewHandler(deps: {
 
       let workspace: Workspace | undefined;
       try {
-        setReviewWorkPhase("load-config");
         setReviewWorkPhase("workspace-create");
         workspacePhaseStartedAt = Date.now();
         // Create workspace with depth 50 for diff context
@@ -1773,6 +1772,7 @@ export function createReviewHandler(deps: {
         const fetchRemoteReview = await buildAuthFetchUrl(workspace.dir, workspace.token);
         await $`git -C ${workspace.dir} fetch ${fetchRemoteReview} ${pr.base.ref}:refs/remotes/origin/${pr.base.ref} --depth=1`.quiet();
 
+        setReviewWorkPhase("load-config");
         // Load repo config (.kodiai.yml) with defaults
         const { config, warnings } = await loadRepoConfig(workspace.dir);
         for (const w of warnings) {

--- a/src/handlers/review.ts
+++ b/src/handlers/review.ts
@@ -7,6 +7,7 @@ import type {
 import type { Logger } from "pino";
 import type { EventRouter, WebhookEvent } from "../webhook/types.ts";
 import type { JobQueue, WorkspaceManager, Workspace, JobQueueWaitMetadata } from "../jobs/types.ts";
+import type { ReviewWorkCoordinator } from "../jobs/review-work-coordinator.ts";
 import type {
   ExecutorPhaseTiming,
   ReviewPhaseName,
@@ -14,7 +15,6 @@ import type {
 } from "../execution/types.ts";
 import type { GitHubApp } from "../auth/github-app.ts";
 import type { createExecutor } from "../execution/executor.ts";
-import type { ExecutionResult } from "../execution/types.ts";
 import type { TelemetryStore } from "../telemetry/types.ts";
 import type { KnowledgeStore, PriorFinding } from "../knowledge/types.ts";
 import type { LearningMemoryStore, EmbeddingProvider, LearningMemoryRecord } from "../knowledge/types.ts";
@@ -89,6 +89,8 @@ import {
   ensureSearchRateLimitDisclosureInSummary,
   extractSearchErrorStatus,
   extractSearchErrorText,
+  isSearchRateLimitError,
+  resolveRateLimitBackoffMs,
   toConfidenceBand,
   fingerprintFindingTitle,
   buildReviewDetailsMarker,
@@ -116,6 +118,11 @@ import {
 import type { CodeSnippetStore } from "../knowledge/code-snippet-types.ts";
 import { $ } from "bun";
 import { fetchAndCheckoutPullRequestHeadRef, buildAuthFetchUrl } from "../jobs/workspace.ts";
+import {
+  buildReviewFamilyKey,
+  createReviewWorkCoordinator,
+  type ReviewWorkPhase,
+} from "../jobs/review-work-coordinator.ts";
 import { classifyAuthor, type AuthorTier } from "../lib/author-classifier.ts";
 import type { ContributorProfileStore, ContributorExpertise } from "../contributor/types.ts";
 import {
@@ -129,6 +136,7 @@ import {
   type ReviewAuthorClassification,
 } from "../contributor/review-author-resolution.ts";
 import { updateExpertiseIncremental } from "../contributor/expertise-scorer.ts";
+import type { AuthorCacheEntry, AuthorCacheTier } from "../knowledge/types.ts";
 import { suggestIdentityLink } from "./identity-suggest.ts";
 import { sanitizeOutgoingMentions } from "../lib/sanitizer.ts";
 import {
@@ -324,7 +332,7 @@ function buildReviewDetailsPhaseTimingSummary(params: {
 
 export function resolveAuthorTierFromSources(params: {
   contributorTier?: AuthorTier | null;
-  cachedTier?: AuthorTier | null;
+  cachedTier?: AuthorCacheTier | null;
   fallbackTier: AuthorTier;
 }): { tier: AuthorTier; source: "contributor-profile" | "author-cache" | "fallback" } {
   const { contributorTier, cachedTier, fallbackTier } = params;
@@ -340,12 +348,98 @@ export function resolveAuthorTierFromSources(params: {
   return { tier: fallbackTier, source: "fallback" };
 }
 
-function shouldRetryTransientAgentExit(result: Pick<ExecutionResult, "conclusion" | "errorMessage" | "isTimeout" | "published">): boolean {
-  if (result.conclusion !== "error") return false;
-  if (result.isTimeout) return false;
-  if (result.published) return false;
+function normalizeAuthorCacheTier(value: string | null | undefined): AuthorCacheTier | null {
+  if (value === "first-time" || value === "regular" || value === "core") {
+    return value;
+  }
+  return null;
+}
 
-  return /Failed with exit code 143\b/i.test(result.errorMessage ?? "");
+function normalizeAuthorCacheEntry(entry: AuthorCacheEntry | null | undefined): AuthorCacheEntry | null {
+  if (!entry) {
+    return null;
+  }
+
+  const normalizedTier = normalizeAuthorCacheTier(entry.tier);
+  if (!normalizedTier) {
+    return null;
+  }
+
+  return {
+    ...entry,
+    tier: normalizedTier,
+  };
+}
+
+function normalizeContributorProfileTier(value: string | null | undefined): AuthorTier | null {
+  if (value === "newcomer" || value === "developing" || value === "established" || value === "senior") {
+    return value;
+  }
+  return null;
+}
+
+function hasAssociationFallbackSignal(authorAssociation: string): boolean {
+  return [
+    "MEMBER",
+    "OWNER",
+    "FIRST_TIMER",
+    "FIRST_TIME_CONTRIBUTOR",
+    "COLLABORATOR",
+    "CONTRIBUTOR",
+  ].includes(authorAssociation);
+}
+
+async function executeSearchWithRateLimitRetry(params: {
+  operation: () => Promise<number>;
+  logger: Logger;
+  authorLogin: string;
+}): Promise<{ value: number | null; retryAttempts: number; degraded: boolean }> {
+  const { operation, logger, authorLogin } = params;
+
+  try {
+    return {
+      value: await operation(),
+      retryAttempts: 0,
+      degraded: false,
+    };
+  } catch (err) {
+    if (!isSearchRateLimitError(err)) {
+      throw err;
+    }
+
+    const backoffMs = resolveRateLimitBackoffMs(err);
+    logger.warn(
+      { err, authorLogin, backoffMs, retryAttempts: 1 },
+      "Search API rate limit detected; retrying author-tier enrichment once",
+    );
+
+    if (backoffMs > 0) {
+      await Bun.sleep(backoffMs);
+    }
+
+    try {
+      return {
+        value: await operation(),
+        retryAttempts: 1,
+        degraded: false,
+      };
+    } catch (retryErr) {
+      if (!isSearchRateLimitError(retryErr)) {
+        throw retryErr;
+      }
+
+      logger.warn(
+        { err: retryErr, authorLogin, retryAttempts: 1 },
+        "Search API remained rate-limited after one retry; degrading enrichment",
+      );
+
+      return {
+        value: null,
+        retryAttempts: 1,
+        degraded: true,
+      };
+    }
+  }
 }
 
 async function fetchCommitMessages(
@@ -383,6 +477,7 @@ async function upsertReviewDetailsComment(params: {
   reviewOutputKey: string;
   body: string;
   botHandles: string[];
+  recheckCanPublish?: () => boolean;
 }): Promise<void> {
   const { octokit, owner, repo, prNumber, reviewOutputKey, body, botHandles } = params;
   const marker = buildReviewDetailsMarker(reviewOutputKey);
@@ -400,6 +495,10 @@ async function upsertReviewDetailsComment(params: {
   const existingComment = commentsResponse.data.find((comment) =>
     typeof comment.body === "string" && comment.body.includes(marker)
   );
+
+  if (params.recheckCanPublish && !params.recheckCanPublish()) {
+    return;
+  }
 
   if (existingComment) {
     await octokit.rest.issues.updateComment({
@@ -429,6 +528,7 @@ async function appendReviewDetailsToSummary(params: {
   botHandles: string[];
   requireDegradationDisclosure: boolean;
   reviewBoundedness?: ReviewBoundednessContract | null;
+  recheckCanPublish?: () => boolean;
 }): Promise<void> {
   const { octokit, owner, repo, prNumber, reviewOutputKey, botHandles } = params;
   let updatedReviewDetails = params.reviewDetailsBlock;
@@ -492,6 +592,10 @@ async function appendReviewDetailsToSummary(params: {
     const before = summaryBody.slice(0, lastCloseIdx);
     const after = summaryBody.slice(lastCloseIdx);
     updatedBody = `${before}\n\n${updatedReviewDetails}\n${after}`;
+  }
+
+  if (params.recheckCanPublish && !params.recheckCanPublish()) {
+    return;
   }
 
   await octokit.rest.issues.updateComment({
@@ -1221,6 +1325,8 @@ export function createReviewHandler(deps: {
   }) => Promise<ReviewGraphBlastRadiusResult>;
   /** Optional SQL client for guardrail audit logging (GUARD-06). */
   sql?: import("../db/client.ts").Sql;
+  /** Optional in-memory coordinator for same-PR review-family publish rights. */
+  reviewWorkCoordinator?: ReviewWorkCoordinator;
   /** Optional cluster model store for thematic finding scoring (M037/S02). */
   clusterModelStore?: SuggestionClusterStore;
   /** Optional diff context collector for deterministic tests and bounded fallback behavior. */
@@ -1249,6 +1355,7 @@ export function createReviewHandler(deps: {
     issueStore,
     reviewGraphQuery,
     sql,
+    reviewWorkCoordinator: injectedReviewWorkCoordinator,
     clusterModelStore,
     diffContextCollector = collectDiffContext,
     logger,
@@ -1256,6 +1363,18 @@ export function createReviewHandler(deps: {
 
   const guardrailAuditStore = sql ? createGuardrailAuditStore(sql) : undefined;
   const structuralImpactCache = createStructuralImpactCache();
+  const reviewWorkCoordinator = injectedReviewWorkCoordinator ?? createReviewWorkCoordinator();
+  if (!injectedReviewWorkCoordinator) {
+    logger.warn(
+      {
+        gate: "review-family-coordinator",
+        gateResult: "private-fallback",
+        coordinationScope: "handler-local",
+        handler: "review",
+      },
+      "Review work coordinator not injected; using a private handler-local fallback (cross-handler coordination disabled)",
+    );
+  }
 
   let authorPrCountSearchCache: SearchCache<number> | undefined;
   if (injectedSearchCache) {
@@ -1491,7 +1610,33 @@ export function createReviewHandler(deps: {
       "Review enqueue started",
     );
 
-    await jobQueue.enqueue(event.installationId, async (queueMetadata) => {
+    const reviewFamilyKey = buildReviewFamilyKey(apiOwner, apiRepo, pr.number);
+    const reviewWorkAttempt = reviewWorkCoordinator.claim({
+      familyKey: reviewFamilyKey,
+      source: "automatic-review",
+      lane: "review",
+      deliveryId: event.id,
+      phase: "claimed",
+    });
+    let reviewWorkAttemptCommitted = false;
+    let reviewWorkAttemptFinalized = false;
+
+    function finalizeReviewWorkAttempt(): void {
+      if (reviewWorkAttemptFinalized) {
+        return;
+      }
+
+      reviewWorkAttemptFinalized = true;
+      if (reviewWorkAttemptCommitted) {
+        reviewWorkCoordinator.complete(reviewWorkAttempt.attemptId);
+        return;
+      }
+
+      reviewWorkCoordinator.release(reviewWorkAttempt.attemptId);
+    }
+
+    try {
+      await jobQueue.enqueue(event.installationId, async (queueMetadata) => {
       const reviewPhaseTimings = new Map<ReviewPhaseName, ReviewPhaseTiming>();
       reviewPhaseTimings.set("queue wait", buildQueueWaitPhase(queueMetadata));
       const reviewStartedAt = Date.now();
@@ -1505,6 +1650,52 @@ export function createReviewHandler(deps: {
         "executor phase timings unavailable",
       );
       let executorResult: Awaited<ReturnType<typeof executor.execute>> | undefined;
+
+      function setReviewWorkPhaseForAttempt(
+        attemptId: string,
+        phase: ReviewWorkPhase,
+      ): void {
+        if (attemptId === reviewWorkAttempt.attemptId) {
+          reviewWorkAttemptCommitted = true;
+        }
+        reviewWorkCoordinator.setPhase(attemptId, phase);
+      }
+
+      function setReviewWorkPhase(phase: ReviewWorkPhase): void {
+        setReviewWorkPhaseForAttempt(reviewWorkAttempt.attemptId, phase);
+      }
+
+      function canPublishReviewWorkOutput(
+        attemptId: string,
+        outputLabel: string,
+        deliveryId: string,
+      ): boolean {
+        if (reviewWorkCoordinator.canPublish(attemptId)) {
+          return true;
+        }
+
+        const currentAttempt = reviewWorkCoordinator
+          .getSnapshot(reviewFamilyKey)
+          ?.attempts.find((attempt) => attempt.attemptId === attemptId);
+        logger.info(
+          {
+            ...baseLog,
+            deliveryId,
+            gate: "review-family-coordinator",
+            gateResult: "skipped",
+            skipReason: "publish-rights-lost",
+            reviewFamilyKey,
+            reviewWorkAttemptId: attemptId,
+            supersededByAttemptId: currentAttempt?.supersededByAttemptId ?? null,
+          },
+          `Skipping ${outputLabel} because publish rights were superseded`,
+        );
+        return false;
+      }
+
+      function canPublishVisibleOutput(outputLabel: string): boolean {
+        return canPublishReviewWorkOutput(reviewWorkAttempt.attemptId, outputLabel, event.id);
+      }
 
       // Durable run state idempotency check (REL-01)
       // Check before expensive workspace creation. Uses SHA pair as identity key.
@@ -1556,6 +1747,8 @@ export function createReviewHandler(deps: {
 
       let workspace: Workspace | undefined;
       try {
+        setReviewWorkPhase("load-config");
+        setReviewWorkPhase("workspace-create");
         workspacePhaseStartedAt = Date.now();
         // Create workspace with depth 50 for diff context
         workspace = await workspaceManager.create(event.installationId, {
@@ -1866,6 +2059,7 @@ export function createReviewHandler(deps: {
           }
         }
 
+        setReviewWorkPhase("incremental-diff");
         // Incremental diff computation (REV-01)
         // Determine if this is an incremental re-review based on prior completed reviews.
         // Works for both synchronize and review_requested events (state-driven, not event-driven).
@@ -2122,16 +2316,32 @@ export function createReviewHandler(deps: {
             const commentBody = buildDependsReviewComment(reviewData);
             const inlineComments = buildDependsInlineComments(reviewData, prFilesForDepends);
 
+            // The [depends] fast path can publish before the standard review executor runs.
+            // Promote this review-family attempt before the first publish gate so an
+            // uncontested dependency review can still emit its summary/inline output.
+            setReviewWorkPhase("publish");
+
+            let publishedDependsSummary = false;
+            let publishedDependsInlineComments = false;
+
             // Post top-level summary comment
-            await idempotencyOctokit.rest.issues.createComment({
-              owner: apiOwner,
-              repo: apiRepo,
-              issue_number: pr.number,
-              body: commentBody,
-            });
+            if (canPublishVisibleOutput("[depends] deep review summary comment")) {
+              setReviewWorkPhase("publish");
+              await idempotencyOctokit.rest.issues.createComment({
+                owner: apiOwner,
+                repo: apiRepo,
+                issue_number: pr.number,
+                body: commentBody,
+              });
+              publishedDependsSummary = true;
+            }
 
             // Post inline review comments (if any)
-            if (inlineComments.length > 0) {
+            if (
+              inlineComments.length > 0
+              && canPublishVisibleOutput("[depends] deep review inline comments")
+            ) {
+              setReviewWorkPhase("publish");
               await idempotencyOctokit.rest.pulls.createReview({
                 owner: apiOwner,
                 repo: apiRepo,
@@ -2143,16 +2353,19 @@ export function createReviewHandler(deps: {
                   body: c.body,
                 })),
               });
+              publishedDependsInlineComments = true;
             }
 
-            logger.info({
-              ...baseLog,
-              gate: "depends-review-complete",
-              verdict: verdict.level,
-              packagesCount: dependsBumpInfo.packages.length,
-              inlineCommentCount: inlineComments.length,
-              hasRetrievalContext: !!dependsRetrievalContext,
-            }, "[depends] deep review posted");
+            if (publishedDependsSummary || publishedDependsInlineComments) {
+              logger.info({
+                ...baseLog,
+                gate: "depends-review-complete",
+                verdict: verdict.level,
+                packagesCount: dependsBumpInfo.packages.length,
+                inlineCommentCount: inlineComments.length,
+                hasRetrievalContext: !!dependsRetrievalContext,
+              }, "[depends] deep review posted");
+            }
 
             // 9. Determine if standard Claude review should also run
             const buildConfigPaths = ["tools/depends/", "cmake/modules/", "project/BuildDependencies/", "project/cmake/"];
@@ -2913,6 +3126,7 @@ export function createReviewHandler(deps: {
           }
         }
 
+        setReviewWorkPhase("prompt-build");
         // Build review prompt
         const reviewPrompt = buildReviewPrompt({
           owner: apiOwner,
@@ -3011,7 +3225,9 @@ export function createReviewHandler(deps: {
           }),
         );
 
-        const executionInput = {
+        // Execute review via Claude
+        setReviewWorkPhase("executor-dispatch");
+        const result = await executor.execute({
           workspace,
           installationId: event.installationId,
           owner: apiOwner,
@@ -3020,7 +3236,7 @@ export function createReviewHandler(deps: {
           commentId: undefined,
           botHandles: [githubApp.getAppSlug(), "claude"],
           eventType: `pull_request.${payload.action}`,
-          taskType: "review.full" as const,
+          taskType: "review.full",
           triggerBody: reviewPrompt,
           prompt: reviewPrompt,
           reviewOutputKey,
@@ -3032,26 +3248,15 @@ export function createReviewHandler(deps: {
           dynamicTimeoutSeconds: config.timeout.dynamicScaling !== false
             ? timeoutEstimate.dynamicTimeoutSeconds
             : undefined,
-        };
-
-        let result = await executor.execute(executionInput);
-
-        if (shouldRetryTransientAgentExit(result)) {
-          logger.warn(
-            {
-              ...baseLog,
-              gate: "transient-agent-exit",
-              gateResult: "retrying",
-              errorMessage: result.errorMessage,
-            },
-            "Transient agent exit detected, retrying review once",
-          );
-
-          result = await executor.execute({
-            ...executionInput,
-            deliveryId: `${event.id}-transient-retry-1`,
-          });
+        });
+        executorResult = result;
+        executorPhaseTimings = result.executorPhaseTimings ?? buildExecutorUnavailablePhases(
+          "executor phase timings unavailable",
+        );
+        for (const phase of executorPhaseTimings) {
+          reviewPhaseTimings.set(phase.name, phase);
         }
+        publicationPhaseStartedAt = Date.now();
 
         executorResult = result;
         executorPhaseTimings = result.executorPhaseTimings ?? buildExecutorUnavailablePhases(
@@ -3650,24 +3855,49 @@ export function createReviewHandler(deps: {
 
             if (result.published) {
               // Summary comment was posted -- append Review Details to it
-              try {
-                await appendReviewDetailsToSummary({
-                  octokit: extractionOctokit,
-                  owner: apiOwner,
-                  repo: apiRepo,
-                  prNumber: pr.number,
-                  reviewOutputKey,
-                  reviewDetailsBlock: fullDetailsBody,
-                  botHandles: [githubApp.getAppSlug(), "claude"],
-                  requireDegradationDisclosure: authorClassification.searchEnrichment.degraded,
-                  reviewBoundedness,
-                });
-              } catch (appendErr) {
-                // Fallback: post standalone if append fails (e.g., summary comment not found yet)
-                logger.warn(
-                  { ...baseLog, gate: "review-details-output", gateResult: "append-fallback", err: appendErr },
-                  "Failed to append Review Details to summary comment; posting standalone",
-                );
+              if (canPublishVisibleOutput("deterministic Review Details append")) {
+                try {
+                  setReviewWorkPhase("publish");
+                  await appendReviewDetailsToSummary({
+                    octokit: extractionOctokit,
+                    owner: apiOwner,
+                    repo: apiRepo,
+                    prNumber: pr.number,
+                    reviewOutputKey,
+                    reviewDetailsBlock: fullDetailsBody,
+                    botHandles: [githubApp.getAppSlug(), "claude"],
+                    requireDegradationDisclosure: authorClassification.searchEnrichment.degraded,
+                    reviewBoundedness,
+                    recheckCanPublish: () =>
+                      canPublishVisibleOutput("deterministic Review Details append"),
+                  });
+                } catch (appendErr) {
+                  // Fallback: post standalone if append fails (e.g., summary comment not found yet)
+                  logger.warn(
+                    { ...baseLog, gate: "review-details-output", gateResult: "append-fallback", err: appendErr },
+                    "Failed to append Review Details to summary comment; posting standalone",
+                  );
+                  if (canPublishVisibleOutput("deterministic Review Details standalone comment")) {
+                    setReviewWorkPhase("publish");
+                    await upsertReviewDetailsComment({
+                      octokit: extractionOctokit,
+                      owner: apiOwner,
+                      repo: apiRepo,
+                      prNumber: pr.number,
+                      reviewOutputKey,
+                      body: fullDetailsBody,
+                      botHandles: [githubApp.getAppSlug(), "claude"],
+                      recheckCanPublish: () =>
+                        canPublishVisibleOutput("deterministic Review Details standalone comment"),
+                    });
+                  }
+                }
+              }
+            } else {
+              // No summary comment (clean review) -- post standalone Review Details
+              // FORMAT-11 exemption: no summary exists to embed into; standalone preserves metrics visibility
+              if (canPublishVisibleOutput("deterministic Review Details standalone comment")) {
+                setReviewWorkPhase("publish");
                 await upsertReviewDetailsComment({
                   octokit: extractionOctokit,
                   owner: apiOwner,
@@ -3676,20 +3906,10 @@ export function createReviewHandler(deps: {
                   reviewOutputKey,
                   body: fullDetailsBody,
                   botHandles: [githubApp.getAppSlug(), "claude"],
+                  recheckCanPublish: () =>
+                    canPublishVisibleOutput("deterministic Review Details standalone comment"),
                 });
               }
-            } else {
-              // No summary comment (clean review) -- post standalone Review Details
-              // FORMAT-11 exemption: no summary exists to embed into; standalone preserves metrics visibility
-              await upsertReviewDetailsComment({
-                octokit: extractionOctokit,
-                owner: apiOwner,
-                repo: apiRepo,
-                prNumber: pr.number,
-                reviewOutputKey,
-                body: fullDetailsBody,
-                botHandles: [githubApp.getAppSlug(), "claude"],
-              });
             }
           } catch (err) {
             logger.warn(
@@ -3751,13 +3971,16 @@ export function createReviewHandler(deps: {
               "Execution cost exceeded warning threshold",
             );
             try {
-              const warnOctokit = await githubApp.getInstallationOctokit(event.installationId);
-              await warnOctokit.rest.issues.createComment({
-                owner: apiOwner,
-                repo: apiRepo,
-                issue_number: pr.number,
-                body: sanitizeOutgoingMentions(`> **Kodiai cost warning:** This execution cost \$${result.costUsd.toFixed(4)} USD, exceeding the configured threshold of \$${config.telemetry.costWarningUsd.toFixed(2)} USD.\n>\n> Configure in \`.kodiai.yml\`:\n> \`\`\`yml\n> telemetry:\n>   costWarningUsd: 5.0  # or 0 to disable\n> \`\`\``, [githubApp.getAppSlug(), "claude"]),
-              });
+              if (canPublishVisibleOutput("cost warning comment")) {
+                setReviewWorkPhase("publish");
+                const warnOctokit = await githubApp.getInstallationOctokit(event.installationId);
+                await warnOctokit.rest.issues.createComment({
+                  owner: apiOwner,
+                  repo: apiRepo,
+                  issue_number: pr.number,
+                  body: sanitizeOutgoingMentions(`> **Kodiai cost warning:** This execution cost \$${result.costUsd.toFixed(4)} USD, exceeding the configured threshold of \$${config.telemetry.costWarningUsd.toFixed(2)} USD.\n>\n> Configure in \`.kodiai.yml\`:\n> \`\`\`yml\n> telemetry:\n>   costWarningUsd: 5.0  # or 0 to disable\n> \`\`\``, [githubApp.getAppSlug(), "claude"]),
+                });
+              }
             } catch (err) {
               logger.warn({ err }, "Failed to post cost warning comment (non-blocking)");
             }
@@ -4047,6 +4270,7 @@ export function createReviewHandler(deps: {
           const complexityInfo = timeoutEstimate?.reasoning ?? "unknown";
 
           let publishedPartialReview = false;
+          let partialCommentId: number | undefined;
 
           if (result.isTimeout) {
             // Step 1: Read checkpoint data
@@ -4088,94 +4312,99 @@ export function createReviewHandler(deps: {
             });
 
             const octokit = await githubApp.getInstallationOctokit(event.installationId);
-            const partialComment = await octokit.rest.issues.createComment({
-              owner: apiOwner,
-              repo: apiRepo,
-              issue_number: pr.number,
-              body: sanitizeOutgoingMentions(partialBody, [githubApp.getAppSlug(), "claude"]),
-            });
-            const partialCommentId = partialComment.data.id;
-
-            // Store partial comment ID in checkpoint for retry to find (best-effort).
-            // Use saveCheckpoint() to ensure a record exists even when the run
-            // timed out before the checkpoint tool was ever called.
-            if (knowledgeStore?.saveCheckpoint) {
-              await knowledgeStore.saveCheckpoint({
-                reviewOutputKey,
-                repo: `${apiOwner}/${apiRepo}`,
-                prNumber: pr.number,
-                filesReviewed: checkpoint?.filesReviewed ?? [],
-                findingCount: checkpoint?.findingCount ?? 0,
-                summaryDraft,
-                totalFiles: changedFiles.length,
-                partialCommentId,
-              });
-            } else {
-              knowledgeStore?.updateCheckpointCommentId?.(reviewOutputKey, partialCommentId);
-            }
-
-            publishedPartialReview = true;
-
-            logger.info(
-              {
-                deliveryId: event.id,
-                prNumber: pr.number,
-                partialCommentId,
-                filesReviewed: checkpoint?.filesReviewed?.length ?? 0,
-                findingCount: checkpoint?.findingCount ?? 0,
-                hasPartialResults,
-                isChronicTimeout,
-                recentTimeouts,
-              },
-              "Published partial review on timeout",
-            );
-
-            try {
-              await upsertReviewDetailsComment({
-                octokit,
+            if (canPublishVisibleOutput("timeout partial review")) {
+              setReviewWorkPhase("publish");
+              const partialComment = await octokit.rest.issues.createComment({
                 owner: apiOwner,
                 repo: apiRepo,
-                prNumber: pr.number,
-                reviewOutputKey,
-                body: buildReviewDetailsBody(),
-                botHandles: [githubApp.getAppSlug(), "claude"],
+                issue_number: pr.number,
+                body: sanitizeOutgoingMentions(partialBody, [githubApp.getAppSlug(), "claude"]),
               });
-            } catch (reviewDetailsErr) {
-              logger.warn(
-                {
-                  ...baseLog,
-                  gate: "review-details-output",
-                  gateResult: "timeout-failed",
-                  reviewOutputKey,
-                  err: reviewDetailsErr,
-                },
-                "Failed to publish Review Details for timeout partial output",
-              );
-            }
+              partialCommentId = partialComment.data.id;
 
-            // Structured resilience telemetry (best-effort)
-            if (config.telemetry.enabled) {
-              try {
-                await telemetryStore.recordResilienceEvent?.({
-                  deliveryId: event.id,
+              // Store partial comment ID in checkpoint for retry to find (best-effort).
+              // Use saveCheckpoint() to ensure a record exists even when the run
+              // timed out before the checkpoint tool was ever called.
+              if (knowledgeStore?.saveCheckpoint) {
+                await knowledgeStore.saveCheckpoint({
+                  reviewOutputKey,
                   repo: `${apiOwner}/${apiRepo}`,
                   prNumber: pr.number,
-                  prAuthor: pr.user.login,
-                  eventType: `pull_request.${payload.action}`,
-                  kind: "timeout",
-                  reviewOutputKey,
-                  executionConclusion,
-                  hadInlineOutput: hasPublishedInlines,
-                  checkpointFilesReviewed: checkpoint?.filesReviewed?.length ?? 0,
-                  checkpointFindingCount: checkpoint?.findingCount ?? 0,
-                  checkpointTotalFiles: changedFiles.length,
+                  filesReviewed: checkpoint?.filesReviewed ?? [],
+                  findingCount: checkpoint?.findingCount ?? 0,
+                  summaryDraft,
+                  totalFiles: changedFiles.length,
                   partialCommentId,
-                  recentTimeouts,
-                  chronicTimeout: isChronicTimeout,
-                  retryEnqueued: false,
                 });
-              } catch (err) {
-                logger.warn({ err }, "Resilience telemetry write failed (non-blocking)");
+              } else {
+                knowledgeStore?.updateCheckpointCommentId?.(reviewOutputKey, partialCommentId);
+              }
+
+              publishedPartialReview = true;
+
+              logger.info(
+                {
+                  deliveryId: event.id,
+                  prNumber: pr.number,
+                  partialCommentId,
+                  filesReviewed: checkpoint?.filesReviewed?.length ?? 0,
+                  findingCount: checkpoint?.findingCount ?? 0,
+                  hasPartialResults,
+                  isChronicTimeout,
+                  recentTimeouts,
+                },
+                "Published partial review on timeout",
+              );
+
+              try {
+                if (canPublishVisibleOutput("timeout Review Details comment")) {
+                  await upsertReviewDetailsComment({
+                    octokit,
+                    owner: apiOwner,
+                    repo: apiRepo,
+                    prNumber: pr.number,
+                    reviewOutputKey,
+                    body: buildReviewDetailsBody(),
+                    botHandles: [githubApp.getAppSlug(), "claude"],
+                  });
+                }
+              } catch (reviewDetailsErr) {
+                logger.warn(
+                  {
+                    ...baseLog,
+                    gate: "review-details-output",
+                    gateResult: "timeout-failed",
+                    reviewOutputKey,
+                    err: reviewDetailsErr,
+                  },
+                  "Failed to publish Review Details for timeout partial output",
+                );
+              }
+
+              // Structured resilience telemetry (best-effort)
+              if (config.telemetry.enabled) {
+                try {
+                  await telemetryStore.recordResilienceEvent?.({
+                    deliveryId: event.id,
+                    repo: `${apiOwner}/${apiRepo}`,
+                    prNumber: pr.number,
+                    prAuthor: pr.user.login,
+                    eventType: `pull_request.${payload.action}`,
+                    kind: "timeout",
+                    reviewOutputKey,
+                    executionConclusion,
+                    hadInlineOutput: hasPublishedInlines,
+                    checkpointFilesReviewed: checkpoint?.filesReviewed?.length ?? 0,
+                    checkpointFindingCount: checkpoint?.findingCount ?? 0,
+                    checkpointTotalFiles: changedFiles.length,
+                    partialCommentId,
+                    recentTimeouts,
+                    chronicTimeout: isChronicTimeout,
+                    retryEnqueued: false,
+                  });
+                } catch (err) {
+                  logger.warn({ err }, "Resilience telemetry write failed (non-blocking)");
+                }
               }
             }
 
@@ -4255,10 +4484,23 @@ export function createReviewHandler(deps: {
                   "Enqueueing retry with reduced scope",
                 );
 
-                // Fire-and-forget enqueue -- do not await the retry result
+                const retryDeliveryId = `${event.id}-retry-1`;
+                const retryReviewWorkAttempt = reviewWorkCoordinator.claim({
+                  familyKey: reviewFamilyKey,
+                  source: "automatic-review",
+                  lane: "review",
+                  deliveryId: retryDeliveryId,
+                  phase: "claimed",
+                });
+
+                // Fire-and-forget enqueue -- do not await the retry result.
+                // Claim before queueing so the retry is visible in family diagnostics
+                // and retains its request ordering, but publish rights only become
+                // authoritative when the queued retry actually starts executing.
                 void jobQueue.enqueue(event.installationId, async () => {
                   let retryWorkspace: Workspace | undefined;
                   try {
+                    setReviewWorkPhaseForAttempt(retryReviewWorkAttempt.attemptId, "workspace-create");
                     retryWorkspace = await workspaceManager.create(event.installationId, {
                       owner: cloneOwner,
                       repo: cloneRepo,
@@ -4293,6 +4535,7 @@ export function createReviewHandler(deps: {
                         ? `${config.review.prompt.trim()}\n\n${retryInstruction}`
                         : retryInstruction;
 
+                    setReviewWorkPhaseForAttempt(retryReviewWorkAttempt.attemptId, "prompt-build");
                     const retryPrompt = buildReviewPrompt({
                       owner: apiOwner,
                       repo: apiRepo,
@@ -4365,6 +4608,7 @@ export function createReviewHandler(deps: {
                       structuralImpact: structuralImpactForReview,
                     });
 
+                    setReviewWorkPhaseForAttempt(retryReviewWorkAttempt.attemptId, "executor-dispatch");
                     const retryResult = await executor.execute({
                       workspace: retryWorkspace,
                       installationId: event.installationId,
@@ -4378,7 +4622,7 @@ export function createReviewHandler(deps: {
                       triggerBody: "",
                       prompt: retryPrompt,
                       reviewOutputKey: retryReviewOutputKey,
-                      deliveryId: `${event.id}-retry-1`,
+                      deliveryId: retryDeliveryId,
                       dynamicTimeoutSeconds: retryTimeout,
                       knowledgeStore,
                       totalFiles: changedFiles.length,
@@ -4394,7 +4638,7 @@ export function createReviewHandler(deps: {
                       if (config.telemetry.enabled) {
                         try {
                           await telemetryStore.recordResilienceEvent?.({
-                            deliveryId: `${event.id}-retry-1`,
+                            deliveryId: retryDeliveryId,
                             parentDeliveryId: event.id,
                             repo: `${apiOwner}/${apiRepo}`,
                             prNumber: pr.number,
@@ -4447,36 +4691,44 @@ export function createReviewHandler(deps: {
 
                       if (!commentIdToUpdate) {
                         logger.warn(
-                          { deliveryId: `${event.id}-retry-1`, prNumber: pr.number },
+                          { deliveryId: retryDeliveryId, prNumber: pr.number },
                           "No partial comment ID available for retry update",
                         );
                         return;
                       }
-                      await retryOctokit.rest.issues.updateComment({
-                        owner: apiOwner,
-                        repo: apiRepo,
-                        comment_id: commentIdToUpdate,
-                        body: sanitizeOutgoingMentions(mergedBody, [githubApp.getAppSlug(), "claude"]),
-                      });
 
-                      logger.info(
-                        {
-                          deliveryId: `${event.id}-retry-1`,
-                          prNumber: pr.number,
-                          retryConclusion: retryResult.conclusion,
-                          retryFilesReviewed,
-                          partialCommentId,
-                        },
-                        "Retry complete -- updated partial review comment with merged results",
-                      );
+                      if (canPublishReviewWorkOutput(
+                        retryReviewWorkAttempt.attemptId,
+                        "retry partial review merge",
+                        retryDeliveryId,
+                      )) {
+                        setReviewWorkPhaseForAttempt(retryReviewWorkAttempt.attemptId, "publish");
+                        await retryOctokit.rest.issues.updateComment({
+                          owner: apiOwner,
+                          repo: apiRepo,
+                          comment_id: commentIdToUpdate,
+                          body: sanitizeOutgoingMentions(mergedBody, [githubApp.getAppSlug(), "claude"]),
+                        });
 
-                      // Cleanup checkpoint data after successful merge
-                      knowledgeStore?.deleteCheckpoint?.(reviewOutputKey);
-                      knowledgeStore?.deleteCheckpoint?.(retryReviewOutputKey);
+                        logger.info(
+                          {
+                            deliveryId: retryDeliveryId,
+                            prNumber: pr.number,
+                            retryConclusion: retryResult.conclusion,
+                            retryFilesReviewed,
+                            partialCommentId,
+                          },
+                          "Retry complete -- updated partial review comment with merged results",
+                        );
+
+                        // Cleanup checkpoint data after successful merge
+                        knowledgeStore?.deleteCheckpoint?.(reviewOutputKey);
+                        knowledgeStore?.deleteCheckpoint?.(retryReviewOutputKey);
+                      }
                     } else {
                       logger.info(
                         {
-                          deliveryId: `${event.id}-retry-1`,
+                          deliveryId: retryDeliveryId,
                           prNumber: pr.number,
                           retryConclusion: retryResult.conclusion,
                         },
@@ -4487,7 +4739,7 @@ export function createReviewHandler(deps: {
                     if (config.telemetry.enabled) {
                       try {
                         await telemetryStore.record({
-                          deliveryId: `${event.id}-retry-1`,
+                          deliveryId: retryDeliveryId,
                           repo: `${apiOwner}/${apiRepo}`,
                           prNumber: pr.number,
                           prAuthor: pr.user.login,
@@ -4516,7 +4768,7 @@ export function createReviewHandler(deps: {
                     logger.error(
                       {
                         err: retryErr,
-                        deliveryId: `${event.id}-retry-1`,
+                        deliveryId: retryDeliveryId,
                         prNumber: pr.number,
                       },
                       "Retry failed with error",
@@ -4526,19 +4778,26 @@ export function createReviewHandler(deps: {
                       await retryWorkspace.cleanup();
                     }
 
-                    // Best-effort checkpoint cleanup even on retry failure.
-                    // Retry attempts are capped at 1, so leaving checkpoint rows
-                    // behind provides little value and can accumulate stale state.
-                    knowledgeStore?.deleteCheckpoint?.(retryReviewOutputKey);
-                    knowledgeStore?.deleteCheckpoint?.(reviewOutputKey);
+                    try {
+                      reviewWorkCoordinator.complete(retryReviewWorkAttempt.attemptId);
+                    } finally {
+                      // Best-effort checkpoint cleanup even on retry failure.
+                      // Retry attempts are capped at 1, so leaving checkpoint rows
+                      // behind provides little value and can accumulate stale state.
+                      knowledgeStore?.deleteCheckpoint?.(retryReviewOutputKey);
+                      knowledgeStore?.deleteCheckpoint?.(reviewOutputKey);
+                    }
                   }
                 }, {
-                  deliveryId: `${event.id}-retry-1`,
+                  deliveryId: retryDeliveryId,
                   eventName: event.name,
                   action: `review-retry`,
+                  lane: "review",
+                  key: reviewFamilyKey,
                   jobType: "pull-request-review-retry",
                   prNumber: pr.number,
                 }).catch((err) => {
+                  reviewWorkCoordinator.release(retryReviewWorkAttempt.attemptId);
                   logger.error(
                     { err, deliveryId: event.id, prNumber: pr.number },
                     "Failed to enqueue retry job",
@@ -4572,11 +4831,14 @@ export function createReviewHandler(deps: {
             }
 
             const octokit = await githubApp.getInstallationOctokit(event.installationId);
-            await postOrUpdateErrorComment(octokit, {
-              owner: apiOwner,
-              repo: apiRepo,
-              issueNumber: pr.number,
-            }, sanitizeOutgoingMentions(errorBody, [githubApp.getAppSlug(), "claude"]), logger);
+            if (canPublishVisibleOutput("error comment")) {
+              setReviewWorkPhase("publish");
+              await postOrUpdateErrorComment(octokit, {
+                owner: apiOwner,
+                repo: apiRepo,
+                issueNumber: pr.number,
+              }, sanitizeOutgoingMentions(errorBody, [githubApp.getAppSlug(), "claude"]), logger);
+            }
           }
         }
 
@@ -4627,6 +4889,11 @@ export function createReviewHandler(deps: {
             }
 
             {
+              if (!canPublishVisibleOutput("auto-approval")) {
+                return;
+              }
+
+              setReviewWorkPhase("publish");
               const approvalEvidence = [
                 `Review prompt covered ${promptFiles.length} changed file${promptFiles.length === 1 ? "" : "s"}.`,
               ];
@@ -4715,20 +4982,33 @@ export function createReviewHandler(deps: {
         const errorBody = formatErrorComment(category, detail);
         try {
           const errOctokit = await githubApp.getInstallationOctokit(event.installationId);
-          await postOrUpdateErrorComment(errOctokit, {
-            owner: apiOwner,
-            repo: apiRepo,
-            issueNumber: pr.number,
-          }, sanitizeOutgoingMentions(errorBody, [githubApp.getAppSlug(), "claude"]), logger);
-          reviewPhaseTimings.set(
-            "publication",
-            createReviewPhaseTiming({
-              name: "publication",
-              status: "degraded",
-              durationMs: Math.max(0, Date.now() - publicationPhaseStartedAt),
-              detail: "posted error comment after handler failure",
-            }),
-          );
+          if (canPublishVisibleOutput("handler failure error comment")) {
+            setReviewWorkPhase("publish");
+            await postOrUpdateErrorComment(errOctokit, {
+              owner: apiOwner,
+              repo: apiRepo,
+              issueNumber: pr.number,
+            }, sanitizeOutgoingMentions(errorBody, [githubApp.getAppSlug(), "claude"]), logger);
+            reviewPhaseTimings.set(
+              "publication",
+              createReviewPhaseTiming({
+                name: "publication",
+                status: "degraded",
+                durationMs: Math.max(0, Date.now() - publicationPhaseStartedAt),
+                detail: "posted error comment after handler failure",
+              }),
+            );
+          } else {
+            reviewPhaseTimings.set(
+              "publication",
+              createReviewPhaseTiming({
+                name: "publication",
+                status: "degraded",
+                durationMs: Math.max(0, Date.now() - publicationPhaseStartedAt),
+                detail: "suppressed error comment after handler failure because publish rights were lost",
+              }),
+            );
+          }
         } catch (commentErr) {
           logger.error({ err: commentErr }, "Failed to post error comment to PR");
           reviewPhaseTimings.set(
@@ -4801,9 +5081,14 @@ export function createReviewHandler(deps: {
       deliveryId: event.id,
       eventName: event.name,
       action,
+      lane: "review",
+      key: reviewFamilyKey,
       jobType: "pull-request-review",
       prNumber: pr.number,
     });
+    } finally {
+      finalizeReviewWorkAttempt();
+    }
 
     logger.info(
       { ...baseLog, gate: "enqueue", gateResult: "completed" },

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { createWebhookRoutes } from "./routes/webhooks.ts";
 import { createSlackEventRoutes } from "./routes/slack-events.ts";
 import { createHealthRoutes } from "./routes/health.ts";
 import { createJobQueue } from "./jobs/queue.ts";
+import { createReviewWorkCoordinator } from "./jobs/review-work-coordinator.ts";
 import { createWorkspaceManager, shouldUseGist } from "./jobs/workspace.ts";
 import { createBotUserClient } from "./auth/bot-user.ts";
 import { createForkManager } from "./jobs/fork-manager.ts";
@@ -73,6 +74,7 @@ const gistPublisher = createGistPublisher(botUserClient, logger);
 
 // Job infrastructure
 const jobQueue = createJobQueue(logger);
+const reviewWorkCoordinator = createReviewWorkCoordinator();
 const workspaceManager = createWorkspaceManager(githubApp, logger);
 
 // Defense-in-depth: clean up any stale workspaces from previous runs
@@ -365,6 +367,7 @@ createReviewHandler({
   },
   issueStore,
   sql,
+  reviewWorkCoordinator,
   logger,
 });
 createMentionHandler({
@@ -379,6 +382,7 @@ createMentionHandler({
   forkManager,
   gistPublisher,
   sql,
+  reviewWorkCoordinator,
   logger,
 });
 createFeedbackSyncHandler({

--- a/src/jobs/queue.test-helpers.ts
+++ b/src/jobs/queue.test-helpers.ts
@@ -1,0 +1,19 @@
+import type { JobQueue, JobQueueRunMetadata } from "./types.ts";
+
+/** Test-only helpers for stubbing JobQueue in unit tests. */
+export function createQueueRunMetadata(
+  overrides: Partial<JobQueueRunMetadata> = {},
+): JobQueueRunMetadata {
+  return {
+    queuedAtMs: 1_000,
+    startedAtMs: 1_250,
+    waitMs: 250,
+    jobId: "job-1",
+    lane: "review",
+    key: "test-job",
+    setPhase: () => undefined,
+    ...overrides,
+  };
+}
+
+export const getEmptyActiveJobs: JobQueue["getActiveJobs"] = () => [];

--- a/src/jobs/queue.test.ts
+++ b/src/jobs/queue.test.ts
@@ -1,6 +1,13 @@
 import { expect, test } from "bun:test";
 import type { Logger } from "pino";
 import { createJobQueue } from "./queue.ts";
+import type { JobQueue, JobQueueRunMetadata } from "./types.ts";
+
+const _enqueueCallbackRequiresMetadata: Parameters<JobQueue["enqueue"]>[1] = async (
+  metadata: JobQueueRunMetadata,
+) => metadata.waitMs;
+
+void _enqueueCallbackRequiresMetadata;
 
 function createNoopLogger(): Logger {
   const noop = () => undefined;
@@ -15,13 +22,11 @@ function createNoopLogger(): Logger {
   } as unknown as Logger;
 }
 
-test("createJobQueue passes structured wait metadata to queued review callbacks", async () => {
+test("createJobQueue passes structured run metadata to queued review callbacks", async () => {
   const queue = createJobQueue(createNoopLogger());
   const firstStarted = Promise.withResolvers<void>();
   const releaseFirst = Promise.withResolvers<void>();
-  let secondJobMetadata:
-    | { queuedAtMs: number; startedAtMs: number; waitMs: number }
-    | undefined;
+  let secondJobMetadata: JobQueueRunMetadata | undefined;
 
   const firstJob = queue.enqueue(42, async () => {
     firstStarted.resolve();
@@ -31,10 +36,14 @@ test("createJobQueue passes structured wait metadata to queued review callbacks"
 
   await firstStarted.promise;
 
-  const secondJob = queue.enqueue(42, async (metadata) => {
-    secondJobMetadata = metadata;
-    return "second";
-  });
+  const secondJob = queue.enqueue(
+    42,
+    async (metadata) => {
+      secondJobMetadata = metadata;
+      return "second";
+    },
+    { lane: "review", key: "pr-42" },
+  );
 
   await Bun.sleep(20);
   releaseFirst.resolve();
@@ -46,4 +55,80 @@ test("createJobQueue passes structured wait metadata to queued review callbacks"
   expect(metadata.waitMs).toBeGreaterThanOrEqual(15);
   expect(metadata.startedAtMs).toBeGreaterThanOrEqual(metadata.queuedAtMs);
   expect(metadata.startedAtMs - metadata.queuedAtMs).toBe(metadata.waitMs);
+  expect(metadata.jobId).toBeString();
+  expect(metadata.lane).toBe("review");
+  expect(metadata.key).toBe("pr-42");
+  expect(metadata.setPhase).toBeFunction();
+});
+
+test("createJobQueue lets interactive-review start while a review lane job is stuck on the same PR key", async () => {
+  const queue = createJobQueue(createNoopLogger());
+  const reviewStarted = Promise.withResolvers<void>();
+  const releaseReview = Promise.withResolvers<void>();
+  let interactiveStartedBeforeReviewRelease = false;
+
+  const reviewJob = queue.enqueue(
+    42,
+    async () => {
+      reviewStarted.resolve();
+      await releaseReview.promise;
+      return "review";
+    },
+    { lane: "review", key: "acme/repo#42" },
+  );
+
+  await reviewStarted.promise;
+
+  const interactiveJob = queue.enqueue(
+    42,
+    async () => {
+      interactiveStartedBeforeReviewRelease = true;
+      return "interactive-review";
+    },
+    { lane: "interactive-review", key: "acme/repo#42" },
+  );
+
+  await Bun.sleep(20);
+  const interactiveStartedWhileReviewWasRunning =
+    interactiveStartedBeforeReviewRelease;
+  releaseReview.resolve();
+
+  await Promise.all([reviewJob, interactiveJob]);
+
+  expect(interactiveStartedWhileReviewWasRunning).toBeTrue();
+});
+
+test("createJobQueue updates active job snapshots when setPhase is called", async () => {
+  const queue = createJobQueue(createNoopLogger());
+  const jobStarted = Promise.withResolvers<void>();
+  const releaseJob = Promise.withResolvers<void>();
+  let runMetadata: JobQueueRunMetadata | undefined;
+
+  const job = queue.enqueue(
+    42,
+    async (metadata) => {
+      runMetadata = metadata;
+      jobStarted.resolve();
+      await releaseJob.promise;
+      return "done";
+    },
+    { lane: "review", key: "pr-42" },
+  );
+
+  await jobStarted.promise;
+
+  runMetadata!.setPhase("publishing");
+
+  const [activeJob] = queue.getActiveJobs(42);
+  expect(activeJob).toBeDefined();
+  const snapshot = activeJob!;
+  expect(snapshot.phase).toBe("publishing");
+  expect(snapshot.lane).toBe("review");
+  expect(snapshot.key).toBe("pr-42");
+  expect(snapshot.lastProgressAtMs).toBeGreaterThanOrEqual(snapshot.startedAtMs ?? 0);
+
+  releaseJob.resolve();
+  await job;
+
+  expect(queue.getActiveJobs(42)).toHaveLength(0);
 });

--- a/src/jobs/queue.ts
+++ b/src/jobs/queue.ts
@@ -1,80 +1,226 @@
 import PQueue from "p-queue";
 import type { Logger } from "pino";
-import type { JobQueue, JobQueueWaitMetadata } from "./types.ts";
+import type {
+  JobLane,
+  JobQueue,
+  JobQueueContext,
+  JobQueueRunMetadata,
+  JobSnapshot,
+} from "./types.ts";
+
+const DEFAULT_JOB_LANE: JobLane = "review";
+const QUEUED_PHASE = "queued";
+const RUNNING_PHASE = "running";
+
+type InstallationLaneQueues = Map<JobLane, PQueue>;
+type InstallationActiveJobs = Map<string, JobSnapshot>;
 
 /**
  * Create a job queue with per-installation concurrency control.
  *
- * Each installation gets its own PQueue(concurrency: 1), ensuring
- * only one job runs per installation at a time. Queues for different
- * installations run in parallel. Idle queues are pruned to prevent
- * the map from growing unbounded.
+ * Each installation gets independent per-lane PQueue(concurrency: 1)
+ * instances. Jobs in different lanes can run in parallel, while jobs in the
+ * same lane remain serialized. Active job snapshots are tracked from enqueue
+ * through completion so callers can inspect machine-readable queue state.
  */
 export function createJobQueue(logger: Logger): JobQueue {
-  const queues = new Map<number, PQueue>();
+  const laneQueues = new Map<number, InstallationLaneQueues>();
+  const activeJobs = new Map<number, InstallationActiveJobs>();
   let nextJobId = 1;
 
-  function getOrCreateQueue(installationId: number): PQueue {
-    let queue = queues.get(installationId);
+  function getOrCreateInstallationQueues(installationId: number): InstallationLaneQueues {
+    let queues = laneQueues.get(installationId);
+    if (!queues) {
+      queues = new Map<JobLane, PQueue>();
+      laneQueues.set(installationId, queues);
+    }
+    return queues;
+  }
+
+  function getOrCreateQueue(installationId: number, lane: JobLane): PQueue {
+    const queues = getOrCreateInstallationQueues(installationId);
+    let queue = queues.get(lane);
     if (!queue) {
       queue = new PQueue({ concurrency: 1 });
-      queues.set(installationId, queue);
-      logger.debug({ installationId }, "Created new job queue for installation");
+      queues.set(lane, queue);
+      logger.debug(
+        { installationId, lane },
+        "Created new job queue lane for installation",
+      );
     }
     return queue;
+  }
+
+  function getOrCreateActiveJobs(installationId: number): InstallationActiveJobs {
+    let jobs = activeJobs.get(installationId);
+    if (!jobs) {
+      jobs = new Map<string, JobSnapshot>();
+      activeJobs.set(installationId, jobs);
+    }
+    return jobs;
+  }
+
+  function sumQueueMetric(
+    installationId: number,
+    selector: (queue: PQueue) => number,
+  ): number {
+    const queues = laneQueues.get(installationId);
+    if (!queues) {
+      return 0;
+    }
+
+    let total = 0;
+    for (const queue of queues.values()) {
+      total += selector(queue);
+    }
+    return total;
+  }
+
+  function pruneLaneQueue(installationId: number, lane: JobLane): void {
+    const queues = laneQueues.get(installationId);
+    const queue = queues?.get(lane);
+    if (!queues || !queue) {
+      return;
+    }
+
+    if (queue.size === 0 && queue.pending === 0) {
+      queues.delete(lane);
+      logger.debug(
+        { installationId, lane },
+        "Pruned idle job queue lane for installation",
+      );
+    }
+
+    if (queues.size === 0) {
+      laneQueues.delete(installationId);
+    }
+  }
+
+  function deleteActiveJob(installationId: number, jobId: string): void {
+    const jobs = activeJobs.get(installationId);
+    if (!jobs) {
+      return;
+    }
+
+    jobs.delete(jobId);
+    if (jobs.size === 0) {
+      activeJobs.delete(installationId);
+    }
+  }
+
+  function createSnapshot(
+    installationId: number,
+    jobId: string,
+    lane: JobLane,
+    key: string,
+    queuedAtMs: number,
+    context?: JobQueueContext,
+  ): JobSnapshot {
+    return {
+      jobId,
+      installationId,
+      lane,
+      key,
+      jobType: context?.jobType,
+      deliveryId: context?.deliveryId,
+      prNumber: context?.prNumber,
+      phase: QUEUED_PHASE,
+      queuedAtMs,
+      lastProgressAtMs: queuedAtMs,
+    };
   }
 
   return {
     async enqueue<T>(
       installationId: number,
-      fn: (metadata?: JobQueueWaitMetadata) => Promise<T>,
-      context?: {
-        deliveryId?: string;
-        eventName?: string;
-        action?: string;
-        jobType?: string;
-        prNumber?: number;
-      },
+      fn: (metadata: JobQueueRunMetadata) => Promise<T>,
+      context?: JobQueueContext,
     ): Promise<T> {
-      const queue = getOrCreateQueue(installationId);
+      const lane = context?.lane ?? DEFAULT_JOB_LANE;
+      const queue = getOrCreateQueue(installationId, lane);
       const jobId = `${installationId}-${nextJobId++}`;
-      const queuedAt = Date.now();
+      const key = context?.key ?? jobId;
+      const queuedAtMs = Date.now();
+      const snapshot = createSnapshot(
+        installationId,
+        jobId,
+        lane,
+        key,
+        queuedAtMs,
+        context,
+      );
+      getOrCreateActiveJobs(installationId).set(jobId, snapshot);
 
       logger.info(
         {
           jobId,
           installationId,
+          lane,
+          key,
           deliveryId: context?.deliveryId,
           eventName: context?.eventName,
           action: context?.action,
           jobType: context?.jobType,
           prNumber: context?.prNumber,
-          queueSize: queue.size,
-          pendingCount: queue.pending,
+          phase: snapshot.phase,
+          queueSize: sumQueueMetric(installationId, (candidateQueue) => candidateQueue.size),
+          pendingCount: sumQueueMetric(installationId, (candidateQueue) => candidateQueue.pending),
+          laneQueueSize: queue.size,
+          lanePendingCount: queue.pending,
+          activeJobCount: activeJobs.get(installationId)?.size ?? 0,
         },
         "Enqueuing job for installation",
       );
 
       try {
-        const result = await (queue.add(async () => {
-          const startedAt = Date.now();
-          const waitMetadata: JobQueueWaitMetadata = {
-            queuedAtMs: queuedAt,
-            startedAtMs: startedAt,
-            waitMs: startedAt - queuedAt,
+        return await queue.add(async (): Promise<T> => {
+          const startedAtMs = Date.now();
+          snapshot.startedAtMs = startedAtMs;
+          snapshot.phase = RUNNING_PHASE;
+          snapshot.lastProgressAtMs = startedAtMs;
+
+          const waitMetadata: JobQueueRunMetadata = {
+            queuedAtMs,
+            startedAtMs,
+            waitMs: startedAtMs - queuedAtMs,
+            jobId,
+            lane,
+            key,
+            setPhase(phase: string): void {
+              const progressAtMs = Date.now();
+              snapshot.phase = phase;
+              snapshot.lastProgressAtMs = progressAtMs;
+              logger.debug(
+                {
+                  jobId,
+                  installationId,
+                  lane,
+                  key,
+                  phase,
+                  lastProgressAtMs: progressAtMs,
+                },
+                "Job phase updated",
+              );
+            },
           };
+
           logger.info(
             {
               jobId,
               installationId,
+              lane,
+              key,
               deliveryId: context?.deliveryId,
               eventName: context?.eventName,
               action: context?.action,
               jobType: context?.jobType,
               prNumber: context?.prNumber,
+              phase: snapshot.phase,
               waitMs: waitMetadata.waitMs,
-              queueSize: queue.size,
-              pendingCount: queue.pending,
+              queueSize: sumQueueMetric(installationId, (candidateQueue) => candidateQueue.size),
+              pendingCount: sumQueueMetric(installationId, (candidateQueue) => candidateQueue.pending),
+              laneQueueSize: queue.size,
+              lanePendingCount: queue.pending,
             },
             "Job execution started",
           );
@@ -85,12 +231,15 @@ export function createJobQueue(logger: Logger): JobQueue {
               {
                 jobId,
                 installationId,
+                lane,
+                key,
                 deliveryId: context?.deliveryId,
                 eventName: context?.eventName,
                 action: context?.action,
                 jobType: context?.jobType,
                 prNumber: context?.prNumber,
-                durationMs: Date.now() - startedAt,
+                phase: snapshot.phase,
+                durationMs: Date.now() - startedAtMs,
               },
               "Job execution completed",
             );
@@ -101,37 +250,39 @@ export function createJobQueue(logger: Logger): JobQueue {
                 err,
                 jobId,
                 installationId,
+                lane,
+                key,
                 deliveryId: context?.deliveryId,
                 eventName: context?.eventName,
                 action: context?.action,
                 jobType: context?.jobType,
                 prNumber: context?.prNumber,
-                durationMs: Date.now() - startedAt,
+                phase: snapshot.phase,
+                durationMs: Date.now() - startedAtMs,
               },
               "Job execution failed",
             );
             throw err;
           }
-        }) as Promise<T>);
-        return result;
+        });
       } finally {
-        // Prune idle queue after job completes
-        if (queue.size === 0 && queue.pending === 0) {
-          queues.delete(installationId);
-          logger.debug(
-            { installationId, jobId },
-            "Pruned idle job queue for installation",
-          );
-        }
+        deleteActiveJob(installationId, jobId);
+        pruneLaneQueue(installationId, lane);
       }
     },
 
     getQueueSize(installationId: number): number {
-      return queues.get(installationId)?.size ?? 0;
+      return sumQueueMetric(installationId, (queue) => queue.size);
     },
 
     getPendingCount(installationId: number): number {
-      return queues.get(installationId)?.pending ?? 0;
+      return sumQueueMetric(installationId, (queue) => queue.pending);
+    },
+
+    getActiveJobs(installationId: number): JobSnapshot[] {
+      return Array.from(activeJobs.get(installationId)?.values() ?? [])
+        .sort((left, right) => left.queuedAtMs - right.queuedAtMs)
+        .map((snapshot) => ({ ...snapshot }));
     },
   };
 }

--- a/src/jobs/review-work-coordinator.test.ts
+++ b/src/jobs/review-work-coordinator.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildReviewFamilyKey,
+  createReviewWorkCoordinator,
+} from "./review-work-coordinator.ts";
+
+const ACTIVE_PHASE = "executor-dispatch" as const;
+
+describe("createReviewWorkCoordinator", () => {
+  test("newer pending explicit claim does not suppress an older active automatic review", () => {
+    let nowMs = 1_000;
+    const coordinator = createReviewWorkCoordinator({
+      nowFn: () => nowMs++,
+    });
+    const familyKey = buildReviewFamilyKey("Acme", "Repo", 42);
+
+    const automaticAttempt = coordinator.claim({
+      familyKey,
+      source: "automatic-review",
+      lane: "review",
+      deliveryId: "delivery-auto-1",
+      phase: "claimed",
+    });
+    coordinator.setPhase(automaticAttempt.attemptId, ACTIVE_PHASE);
+
+    const explicitAttempt = coordinator.claim({
+      familyKey,
+      source: "explicit-review",
+      lane: "interactive-review",
+      deliveryId: "delivery-explicit-2",
+      phase: "claimed",
+    });
+
+    expect(coordinator.canPublish(automaticAttempt.attemptId)).toBeTrue();
+    expect(coordinator.canPublish(explicitAttempt.attemptId)).toBeFalse();
+
+    const snapshot = coordinator.getSnapshot(familyKey);
+    expect(snapshot).not.toBeNull();
+    expect(snapshot?.familyKey).toBe(familyKey);
+    expect(snapshot?.attempts).toHaveLength(2);
+
+    const storedAutomaticAttempt = snapshot?.attempts.find((attempt) => attempt.attemptId === automaticAttempt.attemptId);
+    const storedExplicitAttempt = snapshot?.attempts.find((attempt) => attempt.attemptId === explicitAttempt.attemptId);
+
+    expect(storedAutomaticAttempt).toMatchObject({
+      familyKey,
+      source: "automatic-review",
+      lane: "review",
+      deliveryId: "delivery-auto-1",
+      phase: ACTIVE_PHASE,
+    });
+    expect(storedAutomaticAttempt?.supersededByAttemptId).toBeUndefined();
+    expect(storedExplicitAttempt).toMatchObject({
+      familyKey,
+      source: "explicit-review",
+      lane: "interactive-review",
+      deliveryId: "delivery-explicit-2",
+      phase: "claimed",
+    });
+    expect(storedExplicitAttempt?.supersededByAttemptId).toBeUndefined();
+  });
+
+  test("newer explicit review stays authoritative after it starts and completes before the older automatic review", () => {
+    let nowMs = 4_000;
+    const coordinator = createReviewWorkCoordinator({
+      nowFn: () => ++nowMs,
+    });
+    const familyKey = buildReviewFamilyKey("acme", "repo", 6);
+
+    const automaticAttempt = coordinator.claim({
+      familyKey,
+      source: "automatic-review",
+      lane: "review",
+      deliveryId: "delivery-auto-1",
+      phase: "claimed",
+    });
+    const explicitAttempt = coordinator.claim({
+      familyKey,
+      source: "explicit-review",
+      lane: "interactive-review",
+      deliveryId: "delivery-explicit-2",
+      phase: "claimed",
+    });
+
+    coordinator.setPhase(explicitAttempt.attemptId, ACTIVE_PHASE);
+    coordinator.complete(explicitAttempt.attemptId);
+    coordinator.setPhase(automaticAttempt.attemptId, ACTIVE_PHASE);
+
+    expect(coordinator.canPublish(automaticAttempt.attemptId)).toBeFalse();
+    expect(coordinator.canPublish(explicitAttempt.attemptId)).toBeFalse();
+
+    expect(coordinator.getSnapshot(familyKey)?.attempts).toEqual([
+      expect.objectContaining({
+        attemptId: automaticAttempt.attemptId,
+        familyKey,
+        source: "automatic-review",
+        phase: ACTIVE_PHASE,
+        supersededByAttemptId: explicitAttempt.attemptId,
+      }),
+    ]);
+  });
+
+  test("getSnapshot returns a stale copy while setPhase updates live attempt progress", () => {
+    let nowMs = 5_000;
+    const coordinator = createReviewWorkCoordinator({
+      nowFn: () => ++nowMs,
+    });
+    const familyKey = buildReviewFamilyKey("acme", "repo", 7);
+
+    const attempt = coordinator.claim({
+      familyKey,
+      source: "automatic-review",
+      lane: "review",
+      deliveryId: "delivery-1",
+      phase: "claimed",
+    });
+
+    const staleSnapshot = coordinator.getSnapshot(familyKey);
+    expect(staleSnapshot).not.toBeNull();
+    const staleAttempt = staleSnapshot?.attempts[0];
+    expect(staleAttempt?.phase).toBe("claimed");
+
+    coordinator.setPhase(attempt.attemptId, ACTIVE_PHASE);
+
+    const freshSnapshot = coordinator.getSnapshot(familyKey);
+    const freshAttempt = freshSnapshot?.attempts[0];
+
+    expect(staleAttempt?.phase).toBe("claimed");
+    expect(freshAttempt?.phase).toBe(ACTIVE_PHASE);
+    expect(freshAttempt?.lastProgressAtMs).toBeGreaterThan(staleAttempt?.lastProgressAtMs ?? 0);
+  });
+
+  test("releasing an abandoned middle claim keeps a later retry pending until the retry actually starts", () => {
+    let nowMs = 6_500;
+    const coordinator = createReviewWorkCoordinator({
+      nowFn: () => ++nowMs,
+    });
+    const familyKey = buildReviewFamilyKey("acme", "repo", 8);
+
+    const automaticAttempt = coordinator.claim({
+      familyKey,
+      source: "automatic-review",
+      lane: "review",
+      deliveryId: "delivery-auto-1",
+      phase: "claimed",
+    });
+    coordinator.setPhase(automaticAttempt.attemptId, ACTIVE_PHASE);
+
+    const abandonedExplicitAttempt = coordinator.claim({
+      familyKey,
+      source: "explicit-review",
+      lane: "interactive-review",
+      deliveryId: "delivery-explicit-2",
+      phase: "claimed",
+    });
+    const retryAttempt = coordinator.claim({
+      familyKey,
+      source: "automatic-review",
+      lane: "review",
+      deliveryId: "delivery-auto-1-retry-1",
+      phase: "claimed",
+    });
+
+    coordinator.release(abandonedExplicitAttempt.attemptId);
+
+    expect(coordinator.canPublish(automaticAttempt.attemptId)).toBeTrue();
+    expect(coordinator.canPublish(retryAttempt.attemptId)).toBeFalse();
+    const storedAutomaticAttemptBeforeRetry = coordinator
+      .getSnapshot(familyKey)
+      ?.attempts.find((attempt) => attempt.attemptId === automaticAttempt.attemptId);
+    expect(storedAutomaticAttemptBeforeRetry?.supersededByAttemptId).toBeUndefined();
+
+    coordinator.setPhase(retryAttempt.attemptId, ACTIVE_PHASE);
+
+    expect(coordinator.canPublish(automaticAttempt.attemptId)).toBeFalse();
+    expect(coordinator.canPublish(retryAttempt.attemptId)).toBeTrue();
+    const storedAutomaticAttempt = coordinator
+      .getSnapshot(familyKey)
+      ?.attempts.find((attempt) => attempt.attemptId === automaticAttempt.attemptId);
+    expect(storedAutomaticAttempt?.supersededByAttemptId).toBe(retryAttempt.attemptId);
+  });
+
+  test("a queued retry only becomes publishable after it actually starts running", () => {
+    let nowMs = 7_500;
+    const coordinator = createReviewWorkCoordinator({
+      nowFn: () => ++nowMs,
+    });
+    const familyKey = buildReviewFamilyKey("acme", "repo", 88);
+
+    const automaticAttempt = coordinator.claim({
+      familyKey,
+      source: "automatic-review",
+      lane: "review",
+      deliveryId: "delivery-auto-1",
+      phase: "claimed",
+    });
+    coordinator.setPhase(automaticAttempt.attemptId, ACTIVE_PHASE);
+
+    const retryAttempt = coordinator.claim({
+      familyKey,
+      source: "automatic-review",
+      lane: "review",
+      deliveryId: "delivery-auto-1-retry-1",
+      phase: "claimed",
+    });
+
+    coordinator.complete(automaticAttempt.attemptId);
+
+    expect(coordinator.canPublish(automaticAttempt.attemptId)).toBeFalse();
+    expect(coordinator.canPublish(retryAttempt.attemptId)).toBeFalse();
+    expect(coordinator.getSnapshot(familyKey)?.attempts).toEqual([
+      expect.objectContaining({
+        attemptId: retryAttempt.attemptId,
+        phase: "claimed",
+      }),
+    ]);
+
+    coordinator.setPhase(retryAttempt.attemptId, ACTIVE_PHASE);
+
+    expect(coordinator.canPublish(retryAttempt.attemptId)).toBeTrue();
+  });
+
+  test("completing the latest attempt clears the family snapshot", () => {
+    let nowMs = 8_500;
+    const coordinator = createReviewWorkCoordinator({
+      nowFn: () => ++nowMs,
+    });
+    const familyKey = buildReviewFamilyKey("acme", "repo", 89);
+
+    const attempt = coordinator.claim({
+      familyKey,
+      source: "automatic-review",
+      lane: "review",
+      deliveryId: "delivery-auto-2",
+      phase: "claimed",
+    });
+    coordinator.setPhase(attempt.attemptId, ACTIVE_PHASE);
+
+    coordinator.complete(attempt.attemptId);
+
+    expect(coordinator.canPublish(attempt.attemptId)).toBeFalse();
+    expect(coordinator.getSnapshot(familyKey)).toBeNull();
+  });
+});

--- a/src/jobs/review-work-coordinator.ts
+++ b/src/jobs/review-work-coordinator.ts
@@ -1,0 +1,250 @@
+export type ReviewWorkSource = "automatic-review" | "explicit-review";
+export type ReviewWorkLane = "review" | "interactive-review";
+export type ReviewWorkPhase =
+  | "claimed"
+  | "workspace-create"
+  | "load-config"
+  | "incremental-diff"
+  | "prompt-build"
+  | "executor-dispatch"
+  | "publish";
+
+export type ReviewWorkAttempt = {
+  attemptId: string;
+  familyKey: string;
+  source: ReviewWorkSource;
+  lane: ReviewWorkLane;
+  deliveryId: string;
+  phase: ReviewWorkPhase;
+  claimedAtMs: number;
+  lastProgressAtMs: number;
+  supersededByAttemptId?: string;
+};
+
+export type ReviewWorkClaim = {
+  familyKey: string;
+  source: ReviewWorkSource;
+  lane: ReviewWorkLane;
+  deliveryId: string;
+  phase: ReviewWorkPhase;
+};
+
+export type ReviewWorkSnapshot = {
+  familyKey: string;
+  attempts: ReviewWorkAttempt[];
+};
+
+type InternalReviewWorkAttempt = ReviewWorkAttempt & {
+  lifecycle: "pending" | "active";
+  claimOrdinal: number;
+};
+
+type ReviewWorkFamilyState = {
+  attemptIds: string[];
+  nextClaimOrdinal: number;
+  latestAuthoritativeClaimOrdinal: number;
+  latestAuthoritativeAttemptId?: string;
+};
+
+export type ReviewWorkCoordinator = {
+  claim(claim: ReviewWorkClaim): ReviewWorkAttempt;
+  canPublish(attemptId: string): boolean;
+  setPhase(attemptId: string, phase: ReviewWorkPhase): ReviewWorkAttempt | null;
+  getSnapshot(familyKey: string): ReviewWorkSnapshot | null;
+  release(attemptId: string): void;
+  complete(attemptId: string): void;
+};
+
+function cloneAttempt(attempt: InternalReviewWorkAttempt, supersededByAttemptId?: string): ReviewWorkAttempt {
+  return {
+    attemptId: attempt.attemptId,
+    familyKey: attempt.familyKey,
+    source: attempt.source,
+    lane: attempt.lane,
+    deliveryId: attempt.deliveryId,
+    phase: attempt.phase,
+    claimedAtMs: attempt.claimedAtMs,
+    lastProgressAtMs: attempt.lastProgressAtMs,
+    ...(supersededByAttemptId ? { supersededByAttemptId } : {}),
+  };
+}
+
+export function buildReviewFamilyKey(owner: string, repo: string, prNumber: number): string {
+  return `${owner.trim().toLowerCase()}/${repo.trim().toLowerCase()}#${prNumber}`;
+}
+
+export function createReviewWorkCoordinator(options?: {
+  nowFn?: () => number;
+}): ReviewWorkCoordinator {
+  const nowFn = options?.nowFn ?? (() => Date.now());
+  const attemptsById = new Map<string, InternalReviewWorkAttempt>();
+  const familyStatesByKey = new Map<string, ReviewWorkFamilyState>();
+  let nextAttemptId = 1;
+
+  function getOrCreateFamilyState(familyKey: string): ReviewWorkFamilyState {
+    const existingFamilyState = familyStatesByKey.get(familyKey);
+    if (existingFamilyState) {
+      return existingFamilyState;
+    }
+
+    const nextFamilyState: ReviewWorkFamilyState = {
+      attemptIds: [],
+      nextClaimOrdinal: 1,
+      latestAuthoritativeClaimOrdinal: 0,
+    };
+    familyStatesByKey.set(familyKey, nextFamilyState);
+    return nextFamilyState;
+  }
+
+  function getFamilyAttempts(familyKey: string): InternalReviewWorkAttempt[] {
+    const familyState = familyStatesByKey.get(familyKey);
+    if (!familyState) {
+      return [];
+    }
+
+    return familyState.attemptIds
+      .map((attemptId) => attemptsById.get(attemptId))
+      .filter((attempt): attempt is InternalReviewWorkAttempt => attempt !== undefined);
+  }
+
+  function getSupersedingAttemptId(attempt: InternalReviewWorkAttempt): string | undefined {
+    const familyState = familyStatesByKey.get(attempt.familyKey);
+    if (!familyState) {
+      return undefined;
+    }
+
+    if (familyState.latestAuthoritativeClaimOrdinal <= attempt.claimOrdinal) {
+      return undefined;
+    }
+
+    return familyState.latestAuthoritativeAttemptId;
+  }
+
+  function clearFamily(familyKey: string): void {
+    const familyState = familyStatesByKey.get(familyKey);
+    if (!familyState) {
+      return;
+    }
+
+    for (const attemptId of familyState.attemptIds) {
+      attemptsById.delete(attemptId);
+    }
+    familyStatesByKey.delete(familyKey);
+  }
+
+  function removeAttemptFromFamily(attempt: InternalReviewWorkAttempt): void {
+    attemptsById.delete(attempt.attemptId);
+    const familyState = familyStatesByKey.get(attempt.familyKey);
+    if (!familyState) {
+      return;
+    }
+
+    familyState.attemptIds = familyState.attemptIds.filter(
+      (existingAttemptId) => existingAttemptId !== attempt.attemptId,
+    );
+
+    if (familyState.attemptIds.length === 0) {
+      clearFamily(attempt.familyKey);
+    }
+  }
+
+  function promoteAttemptToAuthoritative(attempt: InternalReviewWorkAttempt): void {
+    const familyState = familyStatesByKey.get(attempt.familyKey);
+    if (!familyState || attempt.lifecycle === "active") {
+      return;
+    }
+
+    attempt.lifecycle = "active";
+    if (attempt.claimOrdinal > familyState.latestAuthoritativeClaimOrdinal) {
+      familyState.latestAuthoritativeClaimOrdinal = attempt.claimOrdinal;
+      familyState.latestAuthoritativeAttemptId = attempt.attemptId;
+    }
+  }
+
+  return {
+    claim(claim) {
+      const claimedAtMs = nowFn();
+      const attemptId = `review-work-${nextAttemptId++}`;
+      const familyState = getOrCreateFamilyState(claim.familyKey);
+      const claimOrdinal = familyState.nextClaimOrdinal++;
+      const attempt: InternalReviewWorkAttempt = {
+        attemptId,
+        familyKey: claim.familyKey,
+        source: claim.source,
+        lane: claim.lane,
+        deliveryId: claim.deliveryId,
+        phase: claim.phase,
+        claimedAtMs,
+        lastProgressAtMs: claimedAtMs,
+        lifecycle: claim.phase === "claimed" ? "pending" : "active",
+        claimOrdinal,
+      };
+
+      attemptsById.set(attemptId, attempt);
+      familyState.attemptIds.push(attemptId);
+      if (attempt.lifecycle === "active" && claimOrdinal > familyState.latestAuthoritativeClaimOrdinal) {
+        familyState.latestAuthoritativeClaimOrdinal = claimOrdinal;
+        familyState.latestAuthoritativeAttemptId = attemptId;
+      }
+
+      return cloneAttempt(attempt, getSupersedingAttemptId(attempt));
+    },
+
+    canPublish(attemptId) {
+      const attempt = attemptsById.get(attemptId);
+      if (!attempt || attempt.lifecycle !== "active") {
+        return false;
+      }
+
+      const familyState = familyStatesByKey.get(attempt.familyKey);
+      return familyState !== undefined && familyState.latestAuthoritativeClaimOrdinal === attempt.claimOrdinal;
+    },
+
+    setPhase(attemptId, phase) {
+      const attempt = attemptsById.get(attemptId);
+      if (!attempt) {
+        return null;
+      }
+
+      attempt.phase = phase;
+      attempt.lastProgressAtMs = nowFn();
+      if (phase !== "claimed") {
+        promoteAttemptToAuthoritative(attempt);
+      }
+
+      return cloneAttempt(attempt, getSupersedingAttemptId(attempt));
+    },
+
+    getSnapshot(familyKey) {
+      const attempts = getFamilyAttempts(familyKey)
+        .map((attempt) => cloneAttempt(attempt, getSupersedingAttemptId(attempt)));
+
+      if (attempts.length === 0) {
+        return null;
+      }
+
+      return {
+        familyKey,
+        attempts,
+      };
+    },
+
+    release(attemptId) {
+      const attempt = attemptsById.get(attemptId);
+      if (!attempt) {
+        return;
+      }
+
+      removeAttemptFromFamily(attempt);
+    },
+
+    complete(attemptId) {
+      const attempt = attemptsById.get(attemptId);
+      if (!attempt || attempt.lifecycle !== "active") {
+        return;
+      }
+
+      removeAttemptFromFamily(attempt);
+    },
+  };
+}

--- a/src/jobs/types.ts
+++ b/src/jobs/types.ts
@@ -33,24 +33,53 @@ export interface JobQueueWaitMetadata {
   waitMs: number;
 }
 
+export type JobLane = "interactive-review" | "review" | "sync";
+
+export interface JobSnapshot {
+  jobId: string;
+  installationId: number;
+  lane: JobLane;
+  key: string;
+  jobType?: string;
+  deliveryId?: string;
+  prNumber?: number;
+  phase: string;
+  queuedAtMs: number;
+  startedAtMs?: number;
+  lastProgressAtMs: number;
+}
+
+export interface JobQueueRunMetadata extends JobQueueWaitMetadata {
+  jobId: string;
+  lane: JobLane;
+  key: string;
+  setPhase(phase: string): void;
+}
+
+export interface JobQueueContext {
+  lane?: JobLane;
+  key?: string;
+  deliveryId?: string;
+  eventName?: string;
+  action?: string;
+  jobType?: string;
+  prNumber?: number;
+}
+
 /** Job queue with per-installation concurrency control */
 export interface JobQueue {
   /** Enqueue a job for an installation. Returns a Promise resolving to the job result. */
   enqueue<T>(
     installationId: number,
-    fn: (metadata?: JobQueueWaitMetadata) => Promise<T>,
-    context?: {
-      deliveryId?: string;
-      eventName?: string;
-      action?: string;
-      jobType?: string;
-      prNumber?: number;
-    },
+    fn: (metadata: JobQueueRunMetadata) => Promise<T>,
+    context?: JobQueueContext,
   ): Promise<T>;
   /** Number of waiting (not yet running) jobs for an installation */
   getQueueSize(installationId: number): number;
   /** Number of currently running jobs for an installation */
   getPendingCount(installationId: number): number;
+  /** Active queued/running jobs for an installation, sorted by queuedAtMs. */
+  getActiveJobs(installationId: number): JobSnapshot[];
 }
 
 /** Workspace manager creates and cleans up ephemeral workspaces */


### PR DESCRIPTION
## Summary
- route queued review and mention work onto explicit lanes so `@kodiai review` can run even when older review work is stuck
- coordinate same-PR automatic and explicit review attempts so only the authoritative attempt can publish visible output
- add stale predecessor and phase-timing diagnostics, plus operator runbook updates for the new signals

## Why
An explicit `@kodiai review` on PR #82 was accepted and enqueued but never started because an older automatic review job was already occupying the per-installation single-worker lane.

## Verification
- `bun test ./src/jobs/queue.test.ts ./src/jobs/review-work-coordinator.test.ts ./src/handlers/review.test.ts ./src/handlers/mention.test.ts`
- `bun test ./src/handlers/feedback-sync.test.ts ./src/handlers/review-comment-sync.test.ts ./src/jobs/aca-launcher.test.ts`
- `bun run tsc --noEmit`

## Notes
- This is the clean `main`-based version of the explicit-review escape-hatch hotfix.
- It includes the supporting review/execution surface needed for the hotfix to apply cleanly on top of `main`.