### PR TITLE
feat: harden small PR timeout proof and truthful partial reviews

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,9 @@ node_modules
 .gitignore
 tmp/
 .planning/
+.worktrees/
+.gsd/
+.bg-shell/
 *.md
 !package.json
 .env

--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,7 @@ GITHUB_PRIVATE_KEY_BASE64=        # (required*) base64 -w0 < private-key.pem —
 GITHUB_WEBHOOK_SECRET=            # (required) Webhook secret configured in the GitHub App
 
 # ── Claude Code ──────────────────────────────────
-CLAUDE_CODE_OAUTH_TOKEN=          # (required) OAuth token for Claude Code CLI
+CLAUDE_CODE_OAUTH_TOKEN=          # (required) OAuth token for Claude Code CLI; deploy.sh auto-refreshes from ~/.claude/.credentials.json when present
 ANTHROPIC_API_KEY=                # (optional) Direct Anthropic API key for LLM provider fallback
 
 # ── Server ───────────────────────────────────────

--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,7 @@ GITHUB_PRIVATE_KEY_BASE64=        # (required*) base64 -w0 < private-key.pem —
 GITHUB_WEBHOOK_SECRET=            # (required) Webhook secret configured in the GitHub App
 
 # ── Claude Code ──────────────────────────────────
-CLAUDE_CODE_OAUTH_TOKEN=          # (required) OAuth token for Claude Code CLI; deploy.sh auto-refreshes from ~/.claude/.credentials.json when present
+CLAUDE_CODE_OAUTH_TOKEN=          # (required) 1-year token from `claude setup-token`; do not use ~/.claude/.credentials.json accessToken here
 ANTHROPIC_API_KEY=                # (optional) Direct Anthropic API key for LLM provider fallback
 
 # ── Server ───────────────────────────────────────

--- a/deploy.sh
+++ b/deploy.sh
@@ -17,6 +17,9 @@ set -euo pipefail
 #                                Generate with: base64 -w0 < private-key.pem
 #   GITHUB_WEBHOOK_SECRET      - Webhook secret configured in the GitHub App
 #   CLAUDE_CODE_OAUTH_TOKEN    - OAuth token from `claude setup-token`
+#                                If ~/.claude/.credentials.json exists,
+#                                deploy.sh auto-refreshes this value from
+#                                claudeAiOauth.accessToken before validation.
 #   VOYAGE_API_KEY             - VoyageAI API key for embeddings
 #   SLACK_BOT_TOKEN            - Slack bot OAuth token
 #   SLACK_SIGNING_SECRET       - Slack app signing secret
@@ -38,6 +41,58 @@ if [[ -f "$ENV_FILE" ]]; then
   source "$ENV_FILE"
   set +a
 fi
+
+sync_claude_oauth_token_from_machine() {
+  CLAUDE_CREDENTIALS_FILE=${CLAUDE_CREDENTIALS_FILE:-$HOME/.claude/.credentials.json}
+
+  if [[ ! -f "$CLAUDE_CREDENTIALS_FILE" ]]; then
+    return 0
+  fi
+
+  local machine_token=""
+  if command -v jq >/dev/null 2>&1; then
+    machine_token=$(jq -r '.claudeAiOauth.accessToken // empty' "$CLAUDE_CREDENTIALS_FILE" 2>/dev/null || true)
+  elif command -v node >/dev/null 2>&1; then
+    machine_token=$(node -e 'const fs = require("node:fs"); try { const raw = JSON.parse(fs.readFileSync(process.argv[1], "utf8")); process.stdout.write(raw?.claudeAiOauth?.accessToken ?? ""); } catch { process.stdout.write(""); }' "$CLAUDE_CREDENTIALS_FILE" 2>/dev/null || true)
+  fi
+
+  if [[ -z "$machine_token" ]]; then
+    echo "==> WARNING: Could not read Claude OAuth access token from $CLAUDE_CREDENTIALS_FILE; using existing CLAUDE_CODE_OAUTH_TOKEN value if set."
+    return 0
+  fi
+
+  if [[ "${CLAUDE_CODE_OAUTH_TOKEN:-}" == "$machine_token" ]]; then
+    return 0
+  fi
+
+  CLAUDE_CODE_OAUTH_TOKEN="$machine_token"
+  export CLAUDE_CODE_OAUTH_TOKEN
+
+  if [[ -f "$ENV_FILE" && -w "$ENV_FILE" ]]; then
+    local tmp_env
+    tmp_env=$(mktemp)
+    awk -v tok="$machine_token" '
+      BEGIN { replaced = 0 }
+      /^CLAUDE_CODE_OAUTH_TOKEN=/ {
+        print "CLAUDE_CODE_OAUTH_TOKEN=" tok;
+        replaced = 1;
+        next;
+      }
+      { print }
+      END {
+        if (!replaced) {
+          print "CLAUDE_CODE_OAUTH_TOKEN=" tok;
+        }
+      }
+    ' "$ENV_FILE" > "$tmp_env"
+    mv "$tmp_env" "$ENV_FILE"
+    echo "==> Synced CLAUDE_CODE_OAUTH_TOKEN from $CLAUDE_CREDENTIALS_FILE into $ENV_FILE"
+  else
+    echo "==> Synced CLAUDE_CODE_OAUTH_TOKEN from $CLAUDE_CREDENTIALS_FILE for this deploy run"
+  fi
+}
+
+sync_claude_oauth_token_from_machine
 
 # -- Configuration (customize as needed) --------------------------------------
 RESOURCE_GROUP="rg-kodiai"

--- a/deploy.sh
+++ b/deploy.sh
@@ -46,6 +46,25 @@ ENVIRONMENT="cae-kodiai"
 APP_NAME="ca-kodiai"
 ACR_NAME="kodiairegistry"          # Must be globally unique, alphanumeric only
 IDENTITY_NAME="id-kodiai"
+BUILD_CONTEXT_DIR=$(mktemp -d)
+
+cleanup_build_context() {
+  rm -rf "$BUILD_CONTEXT_DIR"
+}
+trap cleanup_build_context EXIT
+
+prepare_build_context() {
+  mkdir -p "$BUILD_CONTEXT_DIR"
+  rm -rf "$BUILD_CONTEXT_DIR"/*
+
+  cp package.json bun.lock tsconfig.json Dockerfile Dockerfile.agent "$BUILD_CONTEXT_DIR"/
+  mkdir -p "$BUILD_CONTEXT_DIR/src"
+  cp -R src/. "$BUILD_CONTEXT_DIR/src/"
+
+  echo "==> Prepared minimal build context at $BUILD_CONTEXT_DIR"
+}
+
+prepare_build_context
 
 # -- Validate required environment variables ----------------------------------
 missing=()
@@ -174,7 +193,7 @@ APP_IMAGE_DIGEST=$(az acr build \
   --registry "$ACR_NAME" \
   --image kodiai:latest \
   --no-logs \
-  . \
+  "$BUILD_CONTEXT_DIR" \
   --query 'outputImages[0].digest' \
   --output tsv)
 APP_IMAGE="${ACR_NAME}.azurecr.io/kodiai@${APP_IMAGE_DIGEST}"
@@ -243,7 +262,7 @@ ACA_JOB_IMAGE_DIGEST=$(az acr build \
   --image kodiai-agent:latest \
   --file Dockerfile.agent \
   --no-logs \
-  . \
+  "$BUILD_CONTEXT_DIR" \
   --query 'outputImages[0].digest' \
   --output tsv)
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -16,10 +16,11 @@ set -euo pipefail
 #   GITHUB_PRIVATE_KEY_BASE64  - Base64-encoded PEM private key
 #                                Generate with: base64 -w0 < private-key.pem
 #   GITHUB_WEBHOOK_SECRET      - Webhook secret configured in the GitHub App
-#   CLAUDE_CODE_OAUTH_TOKEN    - OAuth token from `claude setup-token`
-#                                If ~/.claude/.credentials.json exists,
-#                                deploy.sh auto-refreshes this value from
-#                                claudeAiOauth.accessToken before validation.
+#   CLAUDE_CODE_OAUTH_TOKEN    - 1-year OAuth token from `claude setup-token`
+#                                Do not use ~/.claude/.credentials.json
+#                                claudeAiOauth.accessToken here — it is a
+#                                rotating Claude login token, not the deploy
+#                                token this runtime expects.
 #   VOYAGE_API_KEY             - VoyageAI API key for embeddings
 #   SLACK_BOT_TOKEN            - Slack bot OAuth token
 #   SLACK_SIGNING_SECRET       - Slack app signing secret
@@ -42,10 +43,10 @@ if [[ -f "$ENV_FILE" ]]; then
   set +a
 fi
 
-sync_claude_oauth_token_from_machine() {
+validate_claude_oauth_token_source() {
   CLAUDE_CREDENTIALS_FILE=${CLAUDE_CREDENTIALS_FILE:-$HOME/.claude/.credentials.json}
 
-  if [[ ! -f "$CLAUDE_CREDENTIALS_FILE" ]]; then
+  if [[ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" || ! -f "$CLAUDE_CREDENTIALS_FILE" ]]; then
     return 0
   fi
 
@@ -56,43 +57,14 @@ sync_claude_oauth_token_from_machine() {
     machine_token=$(node -e 'const fs = require("node:fs"); try { const raw = JSON.parse(fs.readFileSync(process.argv[1], "utf8")); process.stdout.write(raw?.claudeAiOauth?.accessToken ?? ""); } catch { process.stdout.write(""); }' "$CLAUDE_CREDENTIALS_FILE" 2>/dev/null || true)
   fi
 
-  if [[ -z "$machine_token" ]]; then
-    echo "==> WARNING: Could not read Claude OAuth access token from $CLAUDE_CREDENTIALS_FILE; using existing CLAUDE_CODE_OAUTH_TOKEN value if set."
-    return 0
-  fi
-
-  if [[ "${CLAUDE_CODE_OAUTH_TOKEN:-}" == "$machine_token" ]]; then
-    return 0
-  fi
-
-  CLAUDE_CODE_OAUTH_TOKEN="$machine_token"
-  export CLAUDE_CODE_OAUTH_TOKEN
-
-  if [[ -f "$ENV_FILE" && -w "$ENV_FILE" ]]; then
-    local tmp_env
-    tmp_env=$(mktemp)
-    awk -v tok="$machine_token" '
-      BEGIN { replaced = 0 }
-      /^CLAUDE_CODE_OAUTH_TOKEN=/ {
-        print "CLAUDE_CODE_OAUTH_TOKEN=" tok;
-        replaced = 1;
-        next;
-      }
-      { print }
-      END {
-        if (!replaced) {
-          print "CLAUDE_CODE_OAUTH_TOKEN=" tok;
-        }
-      }
-    ' "$ENV_FILE" > "$tmp_env"
-    mv "$tmp_env" "$ENV_FILE"
-    echo "==> Synced CLAUDE_CODE_OAUTH_TOKEN from $CLAUDE_CREDENTIALS_FILE into $ENV_FILE"
-  else
-    echo "==> Synced CLAUDE_CODE_OAUTH_TOKEN from $CLAUDE_CREDENTIALS_FILE for this deploy run"
+  if [[ -n "$machine_token" && "${CLAUDE_CODE_OAUTH_TOKEN:-}" == "$machine_token" ]]; then
+    echo "ERROR: CLAUDE_CODE_OAUTH_TOKEN matches $CLAUDE_CREDENTIALS_FILE accessToken."
+    echo "Use the 1-year token from `claude setup-token`, not the rotating Claude login access token."
+    exit 1
   fi
 }
 
-sync_claude_oauth_token_from_machine
+validate_claude_oauth_token_source
 
 # -- Configuration (customize as needed) --------------------------------------
 RESOURCE_GROUP="rg-kodiai"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -68,6 +68,7 @@ Optional:
 Notes:
 
 - The app runtime expects `GITHUB_PRIVATE_KEY`; the deploy script stores the base64 PEM in an Azure secret and maps it to `GITHUB_PRIVATE_KEY`.
+- If `~/.claude/.credentials.json` exists on the deploy machine, `deploy.sh` treats `claudeAiOauth.accessToken` as the source of truth for `CLAUDE_CODE_OAUTH_TOKEN`, refreshes the in-memory env before validation, and persists the refreshed value back into `ENV_FILE` when writable.
 - Structural-impact output depends on the review-graph and canonical-code substrates being reachable in the deployed environment.
 
 ### Run

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -68,7 +68,7 @@ Optional:
 Notes:
 
 - The app runtime expects `GITHUB_PRIVATE_KEY`; the deploy script stores the base64 PEM in an Azure secret and maps it to `GITHUB_PRIVATE_KEY`.
-- If `~/.claude/.credentials.json` exists on the deploy machine, `deploy.sh` treats `claudeAiOauth.accessToken` as the source of truth for `CLAUDE_CODE_OAUTH_TOKEN`, refreshes the in-memory env before validation, and persists the refreshed value back into `ENV_FILE` when writable.
+- `CLAUDE_CODE_OAUTH_TOKEN` must be the 1-year token from `claude setup-token`. Do **not** point it at `~/.claude/.credentials.json` `claudeAiOauth.accessToken`; that rotating login token is rejected by the deployed runtime path.
 - Structural-impact output depends on the review-graph and canonical-code substrates being reachable in the deployed environment.
 
 ### Run

--- a/docs/runbooks/review-requested-debug.md
+++ b/docs/runbooks/review-requested-debug.md
@@ -109,6 +109,51 @@ When review output is published or an approval is submitted, the handler emits a
   - `prNumber`
   - `reviewOutputKey`
 
+## M050 Timeout-Truth Verifier Surfaces
+
+Use the M048 verifier family directly when you need a machine-checkable answer for the repaired small-PR timeout class.
+
+### Local deterministic timeout-truth proof
+
+```sh
+bun run verify:m048:s03 -- --json
+```
+
+Interpret these fields:
+- `local.timeoutSurfaces.passed=true` means the timeout partial-review line and timeout `Review Details` block still agree on:
+  - analyzed files vs total changed files
+  - captured finding count
+  - retry state (`scheduled ...` vs `skipped ...`)
+- Fixture names:
+  - `timeout-scheduled-retry` — timeout output stayed truthful when a reduced-scope retry is still eligible
+  - `timeout-retry-skipped` — timeout output stayed truthful when chronic-timeout suppression skips the retry
+
+### Live single-run proof for one review output key
+
+```sh
+bun run verify:m048:s01 -- --review-output-key <review-output-key> --json
+```
+
+Interpret these fields:
+- `outcome.class=success|timeout_partial|timeout|failure|unknown`
+- `outcome.summary` explains whether visible partial output was published
+- `evidence.phases` still shows where latency landed (`executor handoff`, `remote runtime`, `publication`)
+
+### Baseline vs candidate timeout-class compare
+
+```sh
+bun run verify:m048:s02 -- \
+  --baseline-review-output-key <baseline-key> \
+  --candidate-review-output-key <candidate-key> \
+  --json
+```
+
+Interpret these fields:
+- `comparison.timeoutClass.state=retired` is the desired repaired outcome
+- `comparison.timeoutClass.state=persisted` means the candidate still landed in the old timeout class
+- `comparison.timeoutClass.state=introduced` means the candidate regressed into the timeout class
+- `status_code=m048_s02_timeout_class_persisted|m048_s02_timeout_class_regressed` is an operator-visible failure even if targeted latency deltas look better
+
 ## 3) Verify the explicit `@kodiai review` publish bridge
 
 On a PR comment, `@kodiai review` is handled by the mention handler as an explicit review request. The executor still runs on `taskType=review.full`, but the mention handler owns the GitHub approval publish bridge and the publish-resolution logs.

--- a/scripts/deploy.test.ts
+++ b/scripts/deploy.test.ts
@@ -28,24 +28,25 @@ describe("deploy.sh", () => {
     expect(deployScript).toContain('ACTIVE_REVISION=${TRAFFIC_ACTIVE_REVISION:-$NEWEST_ACTIVE_REVISION}');
   });
 
-  test("syncs CLAUDE_CODE_OAUTH_TOKEN from machine Claude credentials when available", () => {
+  test("does not auto-sync CLAUDE_CODE_OAUTH_TOKEN from machine Claude credentials", () => {
+    expect(deployScript).not.toContain('sync_claude_oauth_token_from_machine');
+    expect(deployScript).not.toContain('CLAUDE_CODE_OAUTH_TOKEN="$machine_token"');
+    expect(deployScript).not.toContain('Synced CLAUDE_CODE_OAUTH_TOKEN from $CLAUDE_CREDENTIALS_FILE');
+  });
+
+  test("guards against using the rotating Claude login access token for deploy auth", () => {
     expect(deployScript).toContain('CLAUDE_CREDENTIALS_FILE=${CLAUDE_CREDENTIALS_FILE:-$HOME/.claude/.credentials.json}');
     expect(deployScript).toContain('claudeAiOauth.accessToken');
-    expect(deployScript).toContain('CLAUDE_CODE_OAUTH_TOKEN="$machine_token"');
+    expect(deployScript).toContain('CLAUDE_CODE_OAUTH_TOKEN matches $CLAUDE_CREDENTIALS_FILE accessToken');
+    expect(deployScript).toContain('Use the 1-year token from `claude setup-token`');
   });
 
-  test("persists the refreshed Claude OAuth token back into ENV_FILE", () => {
-    expect(deployScript).toContain('awk -v tok="$machine_token"');
-    expect(deployScript).toContain('print "CLAUDE_CODE_OAUTH_TOKEN=" tok;');
-    expect(deployScript).toContain('Synced CLAUDE_CODE_OAUTH_TOKEN from $CLAUDE_CREDENTIALS_FILE into $ENV_FILE');
-  });
-
-  test("runs Claude OAuth sync before required env validation", () => {
-    const syncIndex = deployScript.indexOf('sync_claude_oauth_token_from_machine');
+  test("runs Claude OAuth source validation before required env validation", () => {
+    const validationIndex = deployScript.indexOf('validate_claude_oauth_token_source');
     const missingIndex = deployScript.indexOf('missing=()');
 
-    expect(syncIndex).toBeGreaterThan(-1);
+    expect(validationIndex).toBeGreaterThan(-1);
     expect(missingIndex).toBeGreaterThan(-1);
-    expect(syncIndex).toBeLessThan(missingIndex);
+    expect(validationIndex).toBeLessThan(missingIndex);
   });
 });

--- a/scripts/deploy.test.ts
+++ b/scripts/deploy.test.ts
@@ -27,4 +27,25 @@ describe("deploy.sh", () => {
     expect(deployScript).toContain('sort_by(@, &properties.createdTime) | [-1].name');
     expect(deployScript).toContain('ACTIVE_REVISION=${TRAFFIC_ACTIVE_REVISION:-$NEWEST_ACTIVE_REVISION}');
   });
+
+  test("syncs CLAUDE_CODE_OAUTH_TOKEN from machine Claude credentials when available", () => {
+    expect(deployScript).toContain('CLAUDE_CREDENTIALS_FILE=${CLAUDE_CREDENTIALS_FILE:-$HOME/.claude/.credentials.json}');
+    expect(deployScript).toContain('claudeAiOauth.accessToken');
+    expect(deployScript).toContain('CLAUDE_CODE_OAUTH_TOKEN="$machine_token"');
+  });
+
+  test("persists the refreshed Claude OAuth token back into ENV_FILE", () => {
+    expect(deployScript).toContain('awk -v tok="$machine_token"');
+    expect(deployScript).toContain('print "CLAUDE_CODE_OAUTH_TOKEN=" tok;');
+    expect(deployScript).toContain('Synced CLAUDE_CODE_OAUTH_TOKEN from $CLAUDE_CREDENTIALS_FILE into $ENV_FILE');
+  });
+
+  test("runs Claude OAuth sync before required env validation", () => {
+    const syncIndex = deployScript.indexOf('sync_claude_oauth_token_from_machine');
+    const missingIndex = deployScript.indexOf('missing=()');
+
+    expect(syncIndex).toBeGreaterThan(-1);
+    expect(missingIndex).toBeGreaterThan(-1);
+    expect(syncIndex).toBeLessThan(missingIndex);
+  });
 });

--- a/scripts/verify-m048-s01.test.ts
+++ b/scripts/verify-m048-s01.test.ts
@@ -102,6 +102,8 @@ describe("verify-m048-s01", () => {
     expect(report.success).toBe(true);
     expect(report.status_code).toBe("m048_s01_ok");
     expect(report.sourceAvailability.azureLogs).toBe("present");
+    expect(report.outcome.class).toBe("success");
+    expect(report.outcome.summary).toContain("published output");
     expect(report.evidence?.totalDurationMs).toBe(4_250);
     expect(report.evidence?.phases.map((phase: ReviewPhaseTiming) => phase.name)).toEqual([...REQUIRED_PHASES]);
   });
@@ -211,13 +213,13 @@ describe("verify-m048-s01", () => {
       queryLogs: async () => ({
         query: "phase query",
         rows: [makeRow({
-          conclusion: "timeout",
-          published: false,
+          conclusion: "timeout_partial",
+          published: true,
           phases: makePhases({
             publication: {
-              status: "unavailable",
-              detail: "review timed out before publication",
-              durationMs: undefined,
+              status: "completed",
+              detail: "partial review output published before timeout",
+              durationMs: 625,
             },
           }),
         })],
@@ -227,8 +229,10 @@ describe("verify-m048-s01", () => {
     const human = renderM048S01Report(report);
 
     expect(human).toContain("Status: m048_s01_ok");
-    expect(human).toContain("Conclusion: timeout");
-    expect(human).toContain("publication: unavailable (review timed out before publication)");
+    expect(human).toContain("Outcome class: timeout_partial");
+    expect(human).toContain("Outcome detail: timeout_partial (visible partial output published)");
+    expect(human).toContain("Conclusion: timeout_partial");
+    expect(human).toContain("publication: 625ms");
   });
 
   test("package.json wires verify:m048:s01 to the verifier script", async () => {

--- a/scripts/verify-m048-s01.ts
+++ b/scripts/verify-m048-s01.ts
@@ -25,6 +25,15 @@ export type M048S01StatusCode =
   | "m048_s01_correlation_mismatch"
   | "m048_s01_invalid_phase_payload";
 
+export type M048S01OutcomeClass = "success" | "timeout" | "timeout_partial" | "failure" | "unknown";
+
+export type M048S01Outcome = {
+  class: M048S01OutcomeClass;
+  conclusion: string | null;
+  published: boolean | null;
+  summary: string;
+};
+
 export type M048S01Report = {
   command: "verify:m048:s01";
   generated_at: string;
@@ -43,6 +52,7 @@ export type M048S01Report = {
     duplicateRowCount: number;
     driftedRowCount: number;
   };
+  outcome: M048S01Outcome;
   evidence: PhaseTimingEvidence | null;
   issues: string[];
 };
@@ -100,6 +110,56 @@ function readOptionValue(args: string[], index: number): { value: string | null;
   return {
     value: candidate,
     consumed: true,
+  };
+}
+
+export function deriveM048S01Outcome(evidence: PhaseTimingEvidence | null | undefined): M048S01Outcome {
+  const conclusion = evidence?.conclusion ?? null;
+  const published = evidence?.published ?? null;
+
+  if (!evidence) {
+    return {
+      class: "unknown",
+      conclusion,
+      published,
+      summary: "no correlated phase evidence available",
+    };
+  }
+
+  if (conclusion === "timeout_partial" || (conclusion === "timeout" && published === true)) {
+    return {
+      class: "timeout_partial",
+      conclusion,
+      published,
+      summary: "timeout_partial (visible partial output published)",
+    };
+  }
+
+  if (conclusion === "timeout") {
+    return {
+      class: "timeout",
+      conclusion,
+      published,
+      summary: "timeout (no visible output published)",
+    };
+  }
+
+  if (conclusion === "success") {
+    return {
+      class: "success",
+      conclusion,
+      published,
+      summary: published === true ? "success (published output)" : "success (no published output)",
+    };
+  }
+
+  return {
+    class: conclusion ? "failure" : "unknown",
+    conclusion,
+    published,
+    summary: conclusion
+      ? `${conclusion} (${published === true ? "published output" : published === false ? "no published output" : "publication unknown"})`
+      : "no correlated phase evidence available",
   };
 }
 
@@ -171,6 +231,8 @@ function createBaseReport(params: {
   evidence?: PhaseTimingEvidence | null;
   issues?: string[];
 }): M048S01Report {
+  const evidence = params.evidence ?? null;
+
   return {
     command: "verify:m048:s01",
     generated_at: params.generatedAt ?? new Date().toISOString(),
@@ -189,7 +251,8 @@ function createBaseReport(params: {
       duplicateRowCount: params.duplicateRowCount ?? 0,
       driftedRowCount: params.driftedRowCount ?? 0,
     },
-    evidence: params.evidence ?? null,
+    outcome: deriveM048S01Outcome(evidence),
+    evidence,
     issues: params.issues ?? [],
   };
 }
@@ -344,6 +407,8 @@ export function renderM048S01Report(report: M048S01Report): string {
     `Delivery id: ${report.delivery_id ?? "unavailable"}`,
     `Azure logs: ${report.sourceAvailability.azureLogs}`,
     `Query: workspaces=${report.query.workspaceCount} matched_rows=${report.query.matchedRowCount} duplicates=${report.query.duplicateRowCount} drift=${report.query.driftedRowCount} timespan=${report.query.timespan}`,
+    `Outcome class: ${report.outcome.class}`,
+    `Outcome detail: ${report.outcome.summary}`,
   ];
 
   if (report.evidence) {

--- a/scripts/verify-m048-s02.test.ts
+++ b/scripts/verify-m048-s02.test.ts
@@ -34,6 +34,16 @@ function makeS01Report(params?: {
   issues?: string[];
 }): M048S01Report {
   const phases = params?.phases === null ? null : (params?.phases ?? makePhases());
+  const conclusion = params?.conclusion ?? "success";
+  const published = params?.published ?? true;
+  const outcomeClass = conclusion === "timeout_partial"
+    ? "timeout_partial"
+    : conclusion === "timeout"
+      ? "timeout"
+      : conclusion === "success"
+        ? "success"
+        : "failure";
+
   return {
     command: "verify:m048:s01",
     generated_at: "2026-04-12T18:00:00.000Z",
@@ -52,12 +62,24 @@ function makeS01Report(params?: {
       duplicateRowCount: 0,
       driftedRowCount: 0,
     },
+    outcome: {
+      class: outcomeClass,
+      conclusion,
+      published,
+      summary: conclusion === "timeout_partial"
+        ? "timeout_partial (visible partial output published)"
+        : conclusion === "timeout"
+          ? "timeout (no visible output published)"
+          : conclusion === "success"
+            ? (published ? "success (published output)" : "success (no published output)")
+            : `${conclusion ?? "unknown"} (${published ? "published output" : "no published output"})`,
+    },
     evidence: phases
       ? {
         reviewOutputKey: params?.reviewOutputKey ?? "rok-default",
         deliveryId: params?.deliveryId ?? "delivery-default",
-        conclusion: params?.conclusion ?? "success",
-        published: params?.published ?? true,
+        conclusion,
+        published,
         totalDurationMs: params?.totalDurationMs ?? 21_000,
         timeGenerated: "2026-04-12T17:59:00.000Z",
         revisionName: "ca-kodiai--0000102",
@@ -74,12 +96,14 @@ async function loadModule() {
 }
 
 describe("verify-m048-s02", () => {
-  test("evaluateM048S02 returns an improved compare report with targeted phase deltas and preserved publication continuity", async () => {
+  test("evaluateM048S02 returns an improved compare report with targeted phase deltas, timeout-class retirement, and preserved publication continuity", async () => {
     const { evaluateM048S02 } = await loadModule();
 
     const baseline = makeS01Report({
       reviewOutputKey: "rok-baseline",
       deliveryId: "delivery-baseline",
+      conclusion: "timeout_partial",
+      published: true,
       totalDurationMs: 28_000,
       phases: makePhases({
         "workspace preparation": { durationMs: 7_000 },
@@ -91,6 +115,8 @@ describe("verify-m048-s02", () => {
     const candidate = makeS01Report({
       reviewOutputKey: "rok-candidate",
       deliveryId: "delivery-candidate",
+      conclusion: "success",
+      published: true,
       totalDurationMs: 18_000,
       phases: makePhases({
         "workspace preparation": { durationMs: 3_000 },
@@ -110,6 +136,11 @@ describe("verify-m048-s02", () => {
     expect(report.status_code).toBe("m048_s02_ok");
     expect(report.comparison.outcome).toBe("latency-improved");
     expect(report.comparison.targetedTotal.deltaMs).toBe(-10_000);
+    expect(report.comparison.timeoutClass).toEqual(expect.objectContaining({
+      state: "retired",
+      baselineClass: "timeout_partial",
+      candidateClass: "success",
+    }));
     expect(report.comparison.targetedPhases).toEqual([
       expect.objectContaining({
         name: "workspace preparation",
@@ -162,12 +193,57 @@ describe("verify-m048-s02", () => {
     expect(report.status_code).toBe("m048_s02_no_improvement");
     expect(report.comparison.outcome).toBe("no-improvement");
     expect(report.comparison.targetedTotal.deltaMs).toBe(1_000);
+    expect(report.comparison.timeoutClass.state).toBe("preserved");
     expect(report.comparison.targetedPhases[0]).toEqual(expect.objectContaining({
       name: "workspace preparation",
       direction: "slower",
       deltaMs: 500,
     }));
     expect(report.comparison.publicationContinuity.state).toBe("preserved");
+  });
+
+  test("evaluateM048S02 returns an explicit timeout-class persisted status when the candidate still times out", async () => {
+    const { evaluateM048S02 } = await loadModule();
+
+    const baseline = makeS01Report({
+      reviewOutputKey: "rok-baseline",
+      deliveryId: "delivery-baseline",
+      conclusion: "timeout_partial",
+      published: true,
+      phases: makePhases({
+        "workspace preparation": { durationMs: 7_000 },
+        "executor handoff": { durationMs: 5_000 },
+        "remote runtime": { durationMs: 9_000 },
+      }),
+    });
+    const candidate = makeS01Report({
+      reviewOutputKey: "rok-candidate",
+      deliveryId: "delivery-candidate",
+      conclusion: "timeout_partial",
+      published: true,
+      phases: makePhases({
+        "workspace preparation": { durationMs: 5_000 },
+        "executor handoff": { durationMs: 3_000 },
+        "remote runtime": { durationMs: 8_000 },
+      }),
+    });
+
+    const report = await evaluateM048S02({
+      baseline: { reviewOutputKey: "rok-baseline", deliveryId: "delivery-baseline" },
+      candidate: { reviewOutputKey: "rok-candidate", deliveryId: "delivery-candidate" },
+      evaluate: async ({ reviewOutputKey }) => reviewOutputKey === "rok-baseline" ? baseline : candidate,
+    });
+
+    expect(report.success).toBe(false);
+    expect(report.status_code).toBe("m048_s02_timeout_class_persisted");
+    expect(report.comparison.timeoutClass).toEqual(expect.objectContaining({
+      state: "persisted",
+      baselineClass: "timeout_partial",
+      candidateClass: "timeout_partial",
+    }));
+    expect(report.issues).toContain(
+      "Candidate remained in the small-PR timeout class (timeout_partial) instead of retiring it.",
+    );
   });
 
   test("evaluateM048S02 preserves unavailable evidence as an inconclusive comparison instead of inventing a result", async () => {
@@ -235,9 +311,14 @@ describe("verify-m048-s02", () => {
     });
 
     expect(report.success).toBe(false);
-    expect(report.status_code).toBe("m048_s02_publication_regressed");
+    expect(report.status_code).toBe("m048_s02_timeout_class_regressed");
     expect(report.comparison.outcome).toBe("latency-improved");
     expect(report.comparison.targetedTotal.deltaMs).toBe(-6_500);
+    expect(report.comparison.timeoutClass).toEqual(expect.objectContaining({
+      state: "introduced",
+      baselineClass: "success",
+      candidateClass: "timeout",
+    }));
     expect(report.comparison.publicationContinuity.state).toBe("regressed");
     expect(report.comparison.publicationContinuity.issue).toContain("Candidate lost publication continuity");
     expect(report.comparison.targetedPhases[2]).toEqual(expect.objectContaining({

--- a/scripts/verify-m048-s02.ts
+++ b/scripts/verify-m048-s02.ts
@@ -4,6 +4,7 @@ import {
   discoverAuditWorkspaceIds,
   evaluateM048S01,
   formatDuration,
+  type M048S01OutcomeClass,
   type M048S01Report,
 } from "./verify-m048-s01.ts";
 
@@ -19,11 +20,14 @@ export type M048S02StatusCode =
   | "m048_s02_invalid_arg"
   | "m048_s02_inconclusive"
   | "m048_s02_no_improvement"
+  | "m048_s02_timeout_class_persisted"
+  | "m048_s02_timeout_class_regressed"
   | "m048_s02_publication_regressed";
 
 export type M048S02ComparisonOutcome = "latency-improved" | "no-improvement" | "inconclusive";
 export type M048S02DeltaDirection = "faster" | "slower" | "unchanged" | "unavailable";
 export type M048S02PublicationContinuityState = "preserved" | "regressed" | "improved" | "unknown";
+export type M048S02TimeoutClassState = "retired" | "persisted" | "introduced" | "preserved" | "unknown";
 
 type CompareTarget = {
   reviewOutputKey: string;
@@ -56,6 +60,13 @@ export type M048S02PublicationContinuity = {
   issue: string | null;
 };
 
+export type M048S02TimeoutClass = {
+  state: M048S02TimeoutClassState;
+  baselineClass: M048S01OutcomeClass;
+  candidateClass: M048S01OutcomeClass;
+  issue: string | null;
+};
+
 export type M048S02Report = {
   command: "verify:m048:s02";
   generated_at: string;
@@ -72,6 +83,7 @@ export type M048S02Report = {
       deltaMs: number | null;
       direction: M048S02DeltaDirection;
     };
+    timeoutClass: M048S02TimeoutClass;
     publicationContinuity: M048S02PublicationContinuity;
   };
   issues: string[];
@@ -271,6 +283,12 @@ function createPlaceholderS01Report(params: {
       duplicateRowCount: 0,
       driftedRowCount: 0,
     },
+    outcome: {
+      class: "unknown",
+      conclusion: null,
+      published: null,
+      summary: "no correlated phase evidence available",
+    },
     evidence: null,
     issues: params.issues ?? [],
   };
@@ -306,6 +324,12 @@ function createBaseReport(params: {
         candidateMs: null,
         deltaMs: null,
         direction: "unavailable",
+      },
+      timeoutClass: {
+        state: "unknown",
+        baselineClass: "unknown",
+        candidateClass: "unknown",
+        issue: null,
       },
       publicationContinuity: {
         state: "unknown",
@@ -376,6 +400,58 @@ function buildTargetedTotal(targetedPhases: M048S02PhaseDelta[]): M048S02Report[
     candidateMs,
     deltaMs,
     direction: toDeltaDirection(deltaMs),
+  };
+}
+
+function isTimeoutClass(outcomeClass: M048S01OutcomeClass): boolean {
+  return outcomeClass === "timeout" || outcomeClass === "timeout_partial";
+}
+
+function buildTimeoutClass(baseline: M048S01Report, candidate: M048S01Report): M048S02TimeoutClass {
+  const baselineClass = baseline.outcome.class;
+  const candidateClass = candidate.outcome.class;
+
+  if (baselineClass === "unknown" || candidateClass === "unknown") {
+    return {
+      state: "unknown",
+      baselineClass,
+      candidateClass,
+      issue: "Timeout-class comparison is unavailable because one side lacks correlated phase evidence.",
+    };
+  }
+
+  if (isTimeoutClass(baselineClass) && !isTimeoutClass(candidateClass)) {
+    return {
+      state: "retired",
+      baselineClass,
+      candidateClass,
+      issue: null,
+    };
+  }
+
+  if (isTimeoutClass(baselineClass) && isTimeoutClass(candidateClass)) {
+    return {
+      state: "persisted",
+      baselineClass,
+      candidateClass,
+      issue: `Candidate remained in the small-PR timeout class (${candidateClass}) instead of retiring it.`,
+    };
+  }
+
+  if (!isTimeoutClass(baselineClass) && isTimeoutClass(candidateClass)) {
+    return {
+      state: "introduced",
+      baselineClass,
+      candidateClass,
+      issue: `Candidate regressed into the small-PR timeout class (${candidateClass}) even though baseline was ${baselineClass}.`,
+    };
+  }
+
+  return {
+    state: "preserved",
+    baselineClass,
+    candidateClass,
+    issue: null,
   };
 }
 
@@ -469,11 +545,13 @@ function buildComparison(baseline: M048S01Report, candidate: M048S01Report): {
 
   const targetedPhases = buildTargetedPhaseDeltas(baseline, candidate);
   const targetedTotal = buildTargetedTotal(targetedPhases);
+  const timeoutClass = buildTimeoutClass(baseline, candidate);
   const publicationContinuity = buildPublicationContinuity(baseline, candidate);
   const comparison: M048S02Report["comparison"] = {
     outcome: "inconclusive",
     targetedPhases,
     targetedTotal,
+    timeoutClass,
     publicationContinuity,
   };
 
@@ -495,6 +573,10 @@ function buildComparison(baseline: M048S01Report, candidate: M048S01Report): {
     };
   }
 
+  if (timeoutClass.issue) {
+    issues.push(timeoutClass.issue);
+  }
+
   if (targetedTotal.deltaMs === null) {
     issues.push("Targeted latency delta is unavailable because one or more targeted phases lack numeric durations.");
     return {
@@ -506,6 +588,30 @@ function buildComparison(baseline: M048S01Report, candidate: M048S01Report): {
   }
 
   comparison.outcome = targetedTotal.deltaMs < 0 ? "latency-improved" : "no-improvement";
+
+  if (timeoutClass.state === "persisted") {
+    if (publicationContinuity.issue) {
+      issues.push(publicationContinuity.issue);
+    }
+    return {
+      success: false,
+      statusCode: "m048_s02_timeout_class_persisted",
+      comparison,
+      issues,
+    };
+  }
+
+  if (timeoutClass.state === "introduced") {
+    if (publicationContinuity.issue) {
+      issues.push(publicationContinuity.issue);
+    }
+    return {
+      success: false,
+      statusCode: "m048_s02_timeout_class_regressed",
+      comparison,
+      issues,
+    };
+  }
 
   if (publicationContinuity.issue) {
     issues.push(publicationContinuity.issue);
@@ -661,6 +767,7 @@ export function renderM048S02Report(report: M048S02Report): string {
     `Baseline: ${report.baseline.review_output_key ?? "unavailable"} (delivery ${report.baseline.delivery_id ?? "unavailable"}) status=${report.baseline.status_code} azure=${report.baseline.sourceAvailability.azureLogs}`,
     `Candidate: ${report.candidate.review_output_key ?? "unavailable"} (delivery ${report.candidate.delivery_id ?? "unavailable"}) status=${report.candidate.status_code} azure=${report.candidate.sourceAvailability.azureLogs}`,
     `Targeted total: baseline=${report.comparison.targetedTotal.baselineMs === null ? "unavailable" : formatDuration(report.comparison.targetedTotal.baselineMs)} candidate=${report.comparison.targetedTotal.candidateMs === null ? "unavailable" : formatDuration(report.comparison.targetedTotal.candidateMs)} ${formatDelta(report.comparison.targetedTotal.deltaMs)} (${report.comparison.targetedTotal.direction})`,
+    `Timeout class: ${report.comparison.timeoutClass.state} (baseline=${report.comparison.timeoutClass.baselineClass}, candidate=${report.comparison.timeoutClass.candidateClass})`,
     `Publication continuity: ${report.comparison.publicationContinuity.state} (baseline published=${report.comparison.publicationContinuity.baselinePublished === null ? "unknown" : String(report.comparison.publicationContinuity.baselinePublished)}, candidate published=${report.comparison.publicationContinuity.candidatePublished === null ? "unknown" : String(report.comparison.publicationContinuity.candidatePublished)})`,
     "",
     "Targeted phase deltas:",

--- a/scripts/verify-m048-s03.test.ts
+++ b/scripts/verify-m048-s03.test.ts
@@ -30,6 +30,12 @@ function makeS01Report(params?: {
       duplicateRowCount: 0,
       driftedRowCount: 0,
     },
+    outcome: {
+      class: "success",
+      conclusion: "success",
+      published: true,
+      summary: "success (published output)",
+    },
     evidence: {
       reviewOutputKey: params?.reviewOutputKey ?? "rok-sync",
       deliveryId: params?.deliveryId ?? "delivery-sync",
@@ -70,7 +76,7 @@ describe("verify-m048-s03", () => {
     expect(result.json).toBe(true);
   });
 
-  test("evaluateM048S03 passes the checked-in synchronize preflight and bounded-disclosure fixtures without live evidence", async () => {
+  test("evaluateM048S03 passes the checked-in synchronize preflight, timeout-surface fixtures, and bounded-disclosure fixtures without live evidence", async () => {
     const { evaluateM048S03 } = await loadModule();
 
     const report = await evaluateM048S03({
@@ -82,6 +88,17 @@ describe("verify-m048-s03", () => {
     expect(report.status_code).toBe("m048_s03_ok");
     expect(report.local.synchronizeConfig.passed).toBe(true);
     expect(report.local.synchronizeConfig.effectiveOnSynchronize).toBe(true);
+    expect(report.local.timeoutSurfaces.passed).toBe(true);
+    expect(report.local.timeoutSurfaces.fixtures).toEqual([
+      expect.objectContaining({
+        name: "timeout-scheduled-retry",
+        passed: true,
+      }),
+      expect.objectContaining({
+        name: "timeout-retry-skipped",
+        passed: true,
+      }),
+    ]);
     expect(report.local.boundedDisclosure.passed).toBe(true);
     expect(report.local.boundedDisclosure.fixtures).toEqual([
       expect.objectContaining({
@@ -125,6 +142,36 @@ describe("verify-m048-s03", () => {
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
+  });
+
+  test("evaluateM048S03 returns a named timeout-surface failure when timeout-proof fixtures drift", async () => {
+    const { evaluateM048S03 } = await loadModule();
+
+    const report = await evaluateM048S03({
+      workspaceDir: process.cwd(),
+      generatedAt: "2026-04-13T05:10:00.000Z",
+      evaluateTimeoutSurfaces: async () => ({
+        passed: false,
+        fixtures: [
+          {
+            name: "timeout-scheduled-retry",
+            passed: false,
+            partialReviewLine: "> **Partial review** -- timed out after analyzing 5 of 5 files (600s).",
+            partialReviewRetryLine: null,
+            reviewDetailsProgressLine: "- Analyzed progress before timeout: 5/5 changed files",
+            reviewDetailsFindingLine: "- Findings captured before timeout: 3 total",
+            reviewDetailsRetryLine: "- Retry state: scheduled reduced-scope retry",
+            issues: ["Timeout progress drifted back to implied full-review counts."],
+          },
+        ],
+        issues: ["Timeout progress drifted back to implied full-review counts."],
+      }),
+    });
+
+    expect(report.success).toBe(false);
+    expect(report.status_code).toBe("m048_s03_timeout_surface_failed");
+    expect(report.local.timeoutSurfaces.passed).toBe(false);
+    expect(report.issues).toContain("Timeout progress drifted back to implied full-review counts.");
   });
 
   test("evaluateM048S03 returns a named bounded-disclosure failure when fixture proof drifts", async () => {
@@ -188,6 +235,9 @@ describe("verify-m048-s03", () => {
       status_code: "m048_s01_ok",
       success: true,
       review_output_key: reviewOutputKey,
+      outcome: expect.objectContaining({
+        class: "success",
+      }),
     }));
   });
 
@@ -212,6 +262,11 @@ describe("verify-m048-s03", () => {
             effectiveOnSynchronize: true,
             warnings: [],
             passed: true,
+            issues: [],
+          },
+          timeoutSurfaces: {
+            passed: true,
+            fixtures: [],
             issues: [],
           },
           boundedDisclosure: {

--- a/scripts/verify-m048-s03.ts
+++ b/scripts/verify-m048-s03.ts
@@ -3,6 +3,9 @@ import {
   ensureReviewBoundednessDisclosureInSummary,
   resolveReviewBoundedness,
 } from "../src/lib/review-boundedness.ts";
+import { formatPartialReviewComment } from "../src/lib/partial-review-formatter.ts";
+import { formatReviewDetailsSummary } from "../src/lib/review-utils.ts";
+import { projectContributorExperienceContract } from "../src/contributor/experience-contract.ts";
 import { parseReviewOutputKey } from "../src/handlers/review-idempotency.ts";
 import {
   evaluateM048S01,
@@ -28,6 +31,7 @@ export type M048S03StatusCode =
   | "m048_s03_ok"
   | "m048_s03_invalid_arg"
   | "m048_s03_sync_config_drift"
+  | "m048_s03_timeout_surface_failed"
   | "m048_s03_bounded_disclosure_failed"
   | "m048_s03_live_key_mismatch"
   | "m048_s03_live_evidence_unavailable";
@@ -38,6 +42,23 @@ export type M048S03SynchronizeConfigReport = {
   effectiveOnSynchronize: boolean;
   warnings: ConfigWarning[];
   passed: boolean;
+  issues: string[];
+};
+
+export type M048S03TimeoutSurfaceFixtureReport = {
+  name: string;
+  passed: boolean;
+  partialReviewLine: string | null;
+  partialReviewRetryLine: string | null;
+  reviewDetailsProgressLine: string | null;
+  reviewDetailsFindingLine: string | null;
+  reviewDetailsRetryLine: string | null;
+  issues: string[];
+};
+
+export type M048S03TimeoutSurfaceReport = {
+  passed: boolean;
+  fixtures: M048S03TimeoutSurfaceFixtureReport[];
   issues: string[];
 };
 
@@ -74,6 +95,7 @@ export type M048S03Report = {
   status_code: M048S03StatusCode;
   local: {
     synchronizeConfig: M048S03SynchronizeConfigReport;
+    timeoutSurfaces: M048S03TimeoutSurfaceReport;
     boundedDisclosure: M048S03BoundedDisclosureReport;
   };
   live: M048S03LiveReport;
@@ -86,12 +108,91 @@ type ParsedArgs = {
   reviewOutputKey: string | null;
 };
 
+type TimeoutSurfaceFixtureDefinition = {
+  name: string;
+  partialReviewParams: Parameters<typeof formatPartialReviewComment>[0];
+  expectedPartialReviewLine: string;
+  expectedPartialReviewRetryLine?: string | null;
+  reviewDetailsParams: Parameters<typeof formatReviewDetailsSummary>[0];
+  expectedReviewDetailsProgressLine: string;
+  expectedReviewDetailsFindingLine: string;
+  expectedReviewDetailsRetryLine: string;
+};
+
 type BoundedFixtureDefinition = {
   name: string;
   expectedDisclosureRequired: boolean;
   expectedSentence: string | null;
   input: Parameters<typeof resolveReviewBoundedness>[0];
 };
+
+const REVIEW_DETAILS_TIMEOUT_BASE = {
+  reviewOutputKey: "timeout-proof-key",
+  filesReviewed: 5,
+  linesAdded: 24,
+  linesRemoved: 8,
+  findingCounts: { critical: 0, major: 1, medium: 2, minor: 0 },
+  profileSelection: {
+    selectedProfile: "strict" as const,
+    source: "auto" as const,
+    linesChanged: 32,
+    autoBand: "small" as const,
+  },
+  contributorExperience: projectContributorExperienceContract({
+    source: "author-cache",
+    tier: "regular",
+  }).reviewDetails,
+};
+
+const DEFAULT_TIMEOUT_SURFACE_FIXTURES: TimeoutSurfaceFixtureDefinition[] = [
+  {
+    name: "timeout-scheduled-retry",
+    partialReviewParams: {
+      summaryDraft: "Review timed out after partial progress was recorded.",
+      filesReviewed: 2,
+      totalFiles: 5,
+      timedOutAfterSeconds: 600,
+    },
+    expectedPartialReviewLine: "> **Partial review** -- timed out after analyzing 2 of 5 files (600s).",
+    reviewDetailsParams: {
+      ...REVIEW_DETAILS_TIMEOUT_BASE,
+      timeoutProgress: {
+        analyzedFiles: 2,
+        totalFiles: 5,
+        findingCount: 3,
+        retryState: "scheduled reduced-scope retry",
+      },
+    },
+    expectedReviewDetailsProgressLine: "- Analyzed progress before timeout: 2/5 changed files",
+    expectedReviewDetailsFindingLine: "- Findings captured before timeout: 3 total",
+    expectedReviewDetailsRetryLine: "- Retry state: scheduled reduced-scope retry",
+  },
+  {
+    name: "timeout-retry-skipped",
+    partialReviewParams: {
+      summaryDraft: "Review timed out after partial progress was recorded.",
+      filesReviewed: 2,
+      totalFiles: 5,
+      timedOutAfterSeconds: 600,
+      isRetrySkipped: true,
+      retrySkipReason: "Retry skipped -- this repo has timed out frequently for this author.",
+    },
+    expectedPartialReviewLine: "> **Partial review** -- timed out after analyzing 2 of 5 files (600s).",
+    expectedPartialReviewRetryLine: "> Retry skipped -- this repo has timed out frequently for this author.",
+    reviewDetailsParams: {
+      ...REVIEW_DETAILS_TIMEOUT_BASE,
+      timeoutProgress: {
+        analyzedFiles: 2,
+        totalFiles: 5,
+        findingCount: 3,
+        retryState: "skipped (frequent timeouts for this repo/author)",
+      },
+    },
+    expectedReviewDetailsProgressLine: "- Analyzed progress before timeout: 2/5 changed files",
+    expectedReviewDetailsFindingLine: "- Findings captured before timeout: 3 total",
+    expectedReviewDetailsRetryLine: "- Retry state: skipped (frequent timeouts for this repo/author)",
+  },
+];
 
 const DEFAULT_BOUNDED_DISCLOSURE_FIXTURES: BoundedFixtureDefinition[] = [
   {
@@ -249,6 +350,7 @@ function createBaseReport(params: {
   success: boolean;
   statusCode: M048S03StatusCode;
   synchronizeConfig: M048S03SynchronizeConfigReport;
+  timeoutSurfaces: M048S03TimeoutSurfaceReport;
   boundedDisclosure: M048S03BoundedDisclosureReport;
   live: M048S03LiveReport;
   issues?: string[];
@@ -261,6 +363,7 @@ function createBaseReport(params: {
     status_code: params.statusCode,
     local: {
       synchronizeConfig: params.synchronizeConfig,
+      timeoutSurfaces: params.timeoutSurfaces,
       boundedDisclosure: params.boundedDisclosure,
     },
     live: params.live,
@@ -275,6 +378,14 @@ function buildDefaultSynchronizeConfigReport(workspaceDir: string): M048S03Synch
     effectiveOnSynchronize: false,
     warnings: [],
     passed: false,
+    issues: [],
+  };
+}
+
+function buildDefaultTimeoutSurfaceReport(): M048S03TimeoutSurfaceReport {
+  return {
+    passed: false,
+    fixtures: [],
     issues: [],
   };
 }
@@ -348,6 +459,67 @@ function countDisclosureOccurrences(body: string, disclosureSentence: string): n
   return (body.match(new RegExp(escapedSentence, "g")) ?? []).length;
 }
 
+function findMatchingLine(body: string, expectedLine: string): string | null {
+  return body.split("\n").find((line) => line.trim() === expectedLine.trim()) ?? null;
+}
+
+export async function evaluateTimeoutSurfaceFixtures(params?: {
+  fixtures?: TimeoutSurfaceFixtureDefinition[];
+}): Promise<M048S03TimeoutSurfaceReport> {
+  const fixtureReports: M048S03TimeoutSurfaceFixtureReport[] = [];
+
+  for (const fixture of params?.fixtures ?? DEFAULT_TIMEOUT_SURFACE_FIXTURES) {
+    const partialReviewBody = formatPartialReviewComment(fixture.partialReviewParams);
+    const reviewDetailsBody = formatReviewDetailsSummary(fixture.reviewDetailsParams);
+    const issues: string[] = [];
+
+    const partialReviewLine = findMatchingLine(partialReviewBody, fixture.expectedPartialReviewLine);
+    const partialReviewRetryLine = fixture.expectedPartialReviewRetryLine
+      ? findMatchingLine(partialReviewBody, fixture.expectedPartialReviewRetryLine)
+      : null;
+    const reviewDetailsProgressLine = findMatchingLine(reviewDetailsBody, fixture.expectedReviewDetailsProgressLine);
+    const reviewDetailsFindingLine = findMatchingLine(reviewDetailsBody, fixture.expectedReviewDetailsFindingLine);
+    const reviewDetailsRetryLine = findMatchingLine(reviewDetailsBody, fixture.expectedReviewDetailsRetryLine);
+
+    if (!partialReviewLine) {
+      issues.push(`Partial review output drifted from expected analyzed-progress line for fixture ${fixture.name}.`);
+    }
+
+    if (fixture.expectedPartialReviewRetryLine && !partialReviewRetryLine) {
+      issues.push(`Partial review output drifted from expected retry line for fixture ${fixture.name}.`);
+    }
+
+    if (!reviewDetailsProgressLine) {
+      issues.push(`Review Details output drifted from expected analyzed-progress line for fixture ${fixture.name}.`);
+    }
+
+    if (!reviewDetailsFindingLine) {
+      issues.push(`Review Details output drifted from expected finding-count line for fixture ${fixture.name}.`);
+    }
+
+    if (!reviewDetailsRetryLine) {
+      issues.push(`Review Details output drifted from expected retry-state line for fixture ${fixture.name}.`);
+    }
+
+    fixtureReports.push({
+      name: fixture.name,
+      passed: issues.length === 0,
+      partialReviewLine,
+      partialReviewRetryLine,
+      reviewDetailsProgressLine,
+      reviewDetailsFindingLine,
+      reviewDetailsRetryLine,
+      issues,
+    });
+  }
+
+  return {
+    passed: fixtureReports.every((fixture) => fixture.passed),
+    fixtures: fixtureReports,
+    issues: fixtureReports.flatMap((fixture) => fixture.issues),
+  };
+}
+
 export async function evaluateBoundedDisclosureFixtures(params?: {
   fixtures?: BoundedFixtureDefinition[];
 }): Promise<M048S03BoundedDisclosureReport> {
@@ -413,6 +585,7 @@ export async function evaluateM048S03(params?: {
   reviewOutputKey?: string | null;
   generatedAt?: string;
   loadConfig?: typeof loadRepoConfig;
+  evaluateTimeoutSurfaces?: () => Promise<M048S03TimeoutSurfaceReport>;
   evaluateBoundedDisclosure?: () => Promise<M048S03BoundedDisclosureReport>;
   evaluateLivePhaseTiming?: (params: {
     reviewOutputKey: string;
@@ -427,6 +600,7 @@ export async function evaluateM048S03(params?: {
     workspaceDir,
     loadConfig: params?.loadConfig,
   });
+  const timeoutSurfaces = await (params?.evaluateTimeoutSurfaces ?? (() => evaluateTimeoutSurfaceFixtures()))();
   const boundedDisclosure = await (params?.evaluateBoundedDisclosure ?? (() => evaluateBoundedDisclosureFixtures()))();
   const baseLive: M048S03LiveReport = {
     requested: reviewOutputKey !== null,
@@ -437,6 +611,7 @@ export async function evaluateM048S03(params?: {
   };
   const baseIssues = [
     ...synchronizeConfig.issues,
+    ...timeoutSurfaces.issues,
     ...boundedDisclosure.issues,
   ];
 
@@ -447,6 +622,21 @@ export async function evaluateM048S03(params?: {
       success: false,
       statusCode: "m048_s03_sync_config_drift",
       synchronizeConfig,
+      timeoutSurfaces,
+      boundedDisclosure,
+      live: baseLive,
+      issues: baseIssues,
+    });
+  }
+
+  if (!timeoutSurfaces.passed) {
+    return createBaseReport({
+      generatedAt,
+      reviewOutputKey,
+      success: false,
+      statusCode: "m048_s03_timeout_surface_failed",
+      synchronizeConfig,
+      timeoutSurfaces,
       boundedDisclosure,
       live: baseLive,
       issues: baseIssues,
@@ -460,6 +650,7 @@ export async function evaluateM048S03(params?: {
       success: false,
       statusCode: "m048_s03_bounded_disclosure_failed",
       synchronizeConfig,
+      timeoutSurfaces,
       boundedDisclosure,
       live: baseLive,
       issues: baseIssues,
@@ -473,6 +664,7 @@ export async function evaluateM048S03(params?: {
       success: true,
       statusCode: "m048_s03_ok",
       synchronizeConfig,
+      timeoutSurfaces,
       boundedDisclosure,
       live: baseLive,
       issues: baseIssues,
@@ -487,6 +679,7 @@ export async function evaluateM048S03(params?: {
       success: false,
       statusCode: "m048_s03_invalid_arg",
       synchronizeConfig,
+      timeoutSurfaces,
       boundedDisclosure,
       live: {
         ...baseLive,
@@ -503,6 +696,7 @@ export async function evaluateM048S03(params?: {
       success: false,
       statusCode: "m048_s03_live_key_mismatch",
       synchronizeConfig,
+      timeoutSurfaces,
       boundedDisclosure,
       live: {
         requested: true,
@@ -532,6 +726,7 @@ export async function evaluateM048S03(params?: {
       success: phaseTiming.success,
       statusCode,
       synchronizeConfig,
+      timeoutSurfaces,
       boundedDisclosure,
       live: {
         requested: true,
@@ -550,6 +745,7 @@ export async function evaluateM048S03(params?: {
       success: false,
       statusCode: "m048_s03_live_evidence_unavailable",
       synchronizeConfig,
+      timeoutSurfaces,
       boundedDisclosure,
       live: {
         requested: true,
@@ -573,8 +769,29 @@ export function renderM048S03Report(report: M048S03Report): string {
     `- Config path: ${report.local.synchronizeConfig.configPath}`,
     `- Config present: ${report.local.synchronizeConfig.configPresent}`,
     `- Effective review.triggers.onSynchronize: ${report.local.synchronizeConfig.effectiveOnSynchronize}`,
-    `Bounded disclosure fixtures: ${report.local.boundedDisclosure.passed ? "pass" : "fail"}`,
+    `Timeout truth fixtures: ${report.local.timeoutSurfaces.passed ? "pass" : "fail"}`,
   ];
+
+  for (const fixture of report.local.timeoutSurfaces.fixtures) {
+    lines.push(`- ${fixture.name}: ${fixture.passed ? "pass" : "fail"}`);
+    if (fixture.partialReviewLine) {
+      lines.push(`  - Partial review: ${fixture.partialReviewLine}`);
+    }
+    if (fixture.partialReviewRetryLine) {
+      lines.push(`  - Partial review retry: ${fixture.partialReviewRetryLine}`);
+    }
+    if (fixture.reviewDetailsProgressLine) {
+      lines.push(`  - Review Details progress: ${fixture.reviewDetailsProgressLine}`);
+    }
+    if (fixture.reviewDetailsFindingLine) {
+      lines.push(`  - Review Details findings: ${fixture.reviewDetailsFindingLine}`);
+    }
+    if (fixture.reviewDetailsRetryLine) {
+      lines.push(`  - Review Details retry: ${fixture.reviewDetailsRetryLine}`);
+    }
+  }
+
+  lines.push(`Bounded disclosure fixtures: ${report.local.boundedDisclosure.passed ? "pass" : "fail"}`);
 
   for (const fixture of report.local.boundedDisclosure.fixtures) {
     lines.push(
@@ -591,6 +808,8 @@ export function renderM048S03Report(report: M048S03Report): string {
     if (report.live.phaseTiming) {
       lines.push(
         `- Reused phase evidence: ${report.live.phaseTiming.status_code} (azure=${report.live.phaseTiming.sourceAvailability.azureLogs})`,
+        `- Outcome class: ${report.live.phaseTiming.outcome.class}`,
+        `- Outcome detail: ${report.live.phaseTiming.outcome.summary}`,
       );
       if (report.live.phaseTiming.evidence?.conclusion) {
         lines.push(`- Conclusion: ${report.live.phaseTiming.evidence.conclusion}`);
@@ -637,9 +856,11 @@ export async function main(
 
   if (reviewOutputKey && (!parsedKey || parsedKey.action !== "synchronize")) {
     const synchronizeConfig = await evaluateSynchronizeConfigPreflight({ workspaceDir });
+    const timeoutSurfaces = await evaluateTimeoutSurfaceFixtures();
     const boundedDisclosure = await evaluateBoundedDisclosureFixtures();
     const issues = [
       ...synchronizeConfig.issues,
+      ...timeoutSurfaces.issues,
       ...boundedDisclosure.issues,
       parsedKey
         ? `Expected a synchronize reviewOutputKey; received action=${parsedKey.action}.`
@@ -650,6 +871,7 @@ export async function main(
       success: false,
       statusCode: parsedKey ? "m048_s03_live_key_mismatch" : "m048_s03_invalid_arg",
       synchronizeConfig,
+      timeoutSurfaces,
       boundedDisclosure,
       live: {
         requested: true,

--- a/src/execution/agent-entrypoint.test.ts
+++ b/src/execution/agent-entrypoint.test.ts
@@ -75,6 +75,47 @@ function makeResultSuccess(): SDKResultMessage {
   };
 }
 
+/** Build a minimal SDK failure result message */
+function makeResultFailure(params?: {
+  subtype?: "error_during_execution" | "error_max_turns" | "error_max_budget_usd" | "error_max_structured_output_retries";
+  stopReason?: string;
+  numTurns?: number;
+}): SDKResultMessage {
+  return {
+    type: "result",
+    subtype: params?.subtype ?? "error_max_turns",
+    session_id: "sess-failure-1",
+    duration_ms: 2200,
+    duration_api_ms: 2100,
+    is_error: true,
+    num_turns: params?.numTurns ?? 26,
+    stop_reason: params?.stopReason ?? "tool_use",
+    total_cost_usd: 0.12,
+    usage: {
+      input_tokens: 120,
+      output_tokens: 60,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+      server_tool_use: null,
+    } as never,
+    modelUsage: {
+      "claude-sonnet-4-5-20250929": {
+        inputTokens: 120,
+        outputTokens: 60,
+        cacheReadInputTokens: 0,
+        cacheCreationInputTokens: 0,
+        webSearchRequests: 0,
+        costUSD: 0.12,
+        contextWindow: 200_000,
+        maxOutputTokens: 8192,
+      },
+    },
+    permission_denials: [],
+    errors: [],
+    uuid: "uuid-failure-1" as never,
+  } as SDKResultMessage;
+}
+
 /** Build a minimal SDK assistant message with content blocks */
 function makeAssistantMessage(content: object[]): object {
   return {
@@ -352,6 +393,27 @@ describe("happy path", () => {
     expect(result.cacheCreationTokens).toBe(5);
     expect(result.resultText).toBe("Looks good!");
     expect(result.stopReason).toBe("end_turn");
+  });
+
+  test("writes failureSubtype for non-success SDK results without rewriting stopReason", async () => {
+    const written: Record<string, string> = {};
+
+    const deps: Partial<EntrypointDeps> = {
+      readFileFn: async () => VALID_AGENT_CONFIG,
+      writeFileFn: async (path, content) => { written[path] = content; },
+      appendFileFn: async () => undefined,
+      queryFn: () => makeAsyncIterable([makeResultFailure()]),
+    };
+
+    await main(deps);
+
+    const resultJson = written["/tmp/ws/result.json"];
+    expect(resultJson).toBeDefined();
+    const result = JSON.parse(resultJson!) as Record<string, unknown>;
+    expect(result.conclusion).toBe("failure");
+    expect(result.failureSubtype).toBe("error_max_turns");
+    expect(result.stopReason).toBe("tool_use");
+    expect(result.resultText).toBeUndefined();
   });
 
   test("writes CLAUDE.md before invoking SDK", async () => {

--- a/src/execution/agent-entrypoint.ts
+++ b/src/execution/agent-entrypoint.ts
@@ -363,6 +363,9 @@ export async function main(deps?: Partial<EntrypointDeps>): Promise<void> {
       cacheReadTokens: totalCacheRead,
       cacheCreationTokens: totalCacheCreation,
       stopReason: resultMessage.stop_reason ?? undefined,
+      ...(resultMessage.subtype !== "success"
+        ? { failureSubtype: resultMessage.subtype }
+        : {}),
       resultText:
         resultMessage.subtype === "success" ? resultMessage.result : undefined,
       ...(toolUseNames.length > 0

--- a/src/execution/review-prompt.test.ts
+++ b/src/execution/review-prompt.test.ts
@@ -1810,6 +1810,19 @@ describe("buildToneGuidelinesSection (rewritten for epistemic discipline)", () =
   });
 });
 
+describe("truthfulness drift guidance in buildReviewPrompt", () => {
+  test("tells reviewers to flag factual drift in changed docs and runbooks", () => {
+    const prompt = buildReviewPrompt(baseContext());
+    expect(prompt).toContain("headers, section labels, commands, verifier names, or config keys contradict each other");
+  });
+
+  test("tells reviewers to flag misleading operator-facing diagnostics as non-blocking by default", () => {
+    const prompt = buildReviewPrompt(baseContext());
+    expect(prompt).toContain("misleading operator-facing or verifier diagnostics");
+    expect(prompt).toContain("Treat these as non-blocking unless the mismatch would cause operators to take the wrong action");
+  });
+});
+
 describe("epistemic section placement in buildReviewPrompt", () => {
   test("epistemic section appears BEFORE conventional commit context", () => {
     const prompt = buildReviewPrompt(baseContext({ conventionalType: { type: "feat", isBreaking: false } }));

--- a/src/execution/review-prompt.ts
+++ b/src/execution/review-prompt.ts
@@ -146,12 +146,23 @@ function buildSeverityClassificationGuidelines(): string {
     "",
     "**MEDIUM:** Edge case handling gaps, missing input validation (non-security), suboptimal error messages, moderate performance issues.",
     "",
-    "**MINOR:** Unused variables/imports (production code only), duplicate code, magic numbers, missing JSDoc.",
+    "**MINOR:** Unused variables/imports (production code only), duplicate code, magic numbers, missing JSDoc, misleading operator diagnostics that do not change runtime behavior.",
     "",
     "**Path context adjustments:**",
     "- Test files: downgrade findings by one severity level (e.g. MAJOR becomes MEDIUM).",
     "- Config files: only report CRITICAL findings.",
-    "- Documentation files: only report factual errors.",
+    "- Documentation files: only report factual errors, including mismatched commands, verifier names, config keys, or contradictory section labels in the changed text.",
+  ].join("\n");
+}
+
+function buildTruthfulnessDriftChecksSection(): string {
+  return [
+    "## Truthfulness Drift Checks",
+    "",
+    "Flag factual drift in changed docs and runbooks when headers, section labels, commands, verifier names, or config keys contradict each other.",
+    "Flag misleading operator-facing or verifier diagnostics when fallback text contradicts known internal state or implies evidence is missing when a field is merely null or degraded.",
+    "Treat these as non-blocking unless the mismatch would cause operators to take the wrong action or trust the wrong state.",
+    "Default classification: MINOR documentation for docs/runbook factual drift, MINOR correctness for misleading diagnostics.",
   ].join("\n");
 }
 
@@ -1959,6 +1970,7 @@ export function buildReviewPrompt(context: {
   // --- Epistemic boundaries (PROMPT-01) ---
   lines.push("", buildEpistemicBoundarySection());
   lines.push("", buildSecurityPolicySection());
+  lines.push("", buildTruthfulnessDriftChecksSection());
 
   if (context.conventionalType) {
     const typeGuidance: Record<string, string> = {

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -111,6 +111,8 @@ export type ExecutionResult = {
   cacheCreationTokens: number | undefined;
   /** SDK stop reason (e.g., "end_turn", "max_tokens") */
   stopReason: string | undefined;
+  /** Non-success SDK result subtype (e.g., "error_max_turns") when present. */
+  failureSubtype?: string;
   /** Final assistant text for successful runs (when provided by SDK). */
   resultText?: string;
   /** Ordered unique tool names observed in assistant tool_use blocks during the run. */

--- a/src/handlers/mention.test.ts
+++ b/src/handlers/mention.test.ts
@@ -6973,6 +6973,117 @@ describe("createMentionHandler review command", () => {
     await workspaceFixture.cleanup();
   });
 
+  test("pr top-level review request posts turn-limit fallback for error_max_turns even when stopReason is tool_use", async () => {
+    const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
+    const workspaceFixture = await createWorkspaceFixture("mention:\n  enabled: true\n");
+
+    const prNumber = 102;
+    const featureSha = (await $`git -C ${workspaceFixture.dir} rev-parse feature`.quiet())
+      .text()
+      .trim();
+    await $`git --git-dir ${workspaceFixture.remoteDir} update-ref refs/pull/${prNumber}/head ${featureSha}`.quiet();
+
+    const issueReplies: string[] = [];
+
+    const eventRouter: EventRouter = {
+      register: (eventKey, handler) => {
+        handlers.set(eventKey, handler);
+      },
+      dispatch: async () => undefined,
+    };
+
+    const jobQueue: JobQueue = {
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
+      getQueueSize: () => 0,
+      getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
+    };
+
+    const workspaceManager: WorkspaceManager = {
+      create: async (_installationId: number, options: CloneOptions) => {
+        await $`git -C ${workspaceFixture.dir} checkout ${options.ref}`.quiet();
+        return { dir: workspaceFixture.dir, cleanup: async () => undefined };
+      },
+      cleanupStale: async () => 0,
+    };
+
+    const octokit = {
+      rest: {
+        reactions: {
+          createForIssueComment: async () => ({ data: {} }),
+          createForPullRequestReviewComment: async () => ({ data: {} }),
+        },
+        pulls: {
+          get: async () => ({
+            data: {
+              title: "Test PR",
+              body: "",
+              user: { login: "octocat" },
+              head: { ref: "feature" },
+              base: { ref: "main" },
+            },
+          }),
+          list: async () => ({ data: [] }),
+          createReplyForReviewComment: async () => ({ data: {} }),
+        },
+        issues: {
+          listComments: async () => ({ data: [] }),
+          createComment: async ({ body }: { body: string }) => {
+            issueReplies.push(body);
+            return { data: {} };
+          },
+        },
+      },
+    };
+
+    createMentionHandler({
+      eventRouter,
+      jobQueue,
+      workspaceManager,
+      githubApp: {
+        getAppSlug: () => "kodiai",
+        getInstallationOctokit: async () => octokit as never,
+      } as unknown as GitHubApp,
+      executor: {
+        execute: async () => ({
+          conclusion: "failure",
+          published: false,
+          failureSubtype: "error_max_turns",
+          stopReason: "tool_use",
+          costUsd: 0,
+          numTurns: 26,
+          durationMs: 1,
+          sessionId: "session-mention-max-turns",
+          model: "claude-sonnet-4-5-20250929",
+          inputTokens: 1,
+          outputTokens: 1,
+          cacheReadTokens: 0,
+          cacheCreationTokens: 0,
+          resultText: undefined,
+          errorMessage: undefined,
+        }),
+      } as never,
+      telemetryStore: noopTelemetryStore,
+      logger: createNoopLogger(),
+    });
+
+    const handler = handlers.get("issue_comment.created");
+    expect(handler).toBeDefined();
+
+    await handler!(
+      buildPrIssueCommentMentionEvent({
+        prNumber,
+        commentBody: "@kodiai review",
+      }),
+    );
+
+    expect(issueReplies).toHaveLength(1);
+    expect(issueReplies[0]).toContain("I ran out of steps analyzing this and wasn't able to post a complete response.");
+    expect(issueReplies[0]).not.toContain("I completed the review run but couldn't publish a GitHub review/comment from it.");
+
+    await workspaceFixture.cleanup();
+  });
+
   test("explicit review mentions advance through truthful pre-executor phases", async () => {
     const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
     const prNumber = 103;

--- a/src/handlers/mention.ts
+++ b/src/handlers/mention.ts
@@ -2623,6 +2623,8 @@ export function createMentionHandler(deps: {
             numTurns: result.numTurns,
             durationMs: result.durationMs,
             sessionId: result.sessionId,
+            stopReason: result.stopReason,
+            failureSubtype: result.failureSubtype,
             usedRepoInspectionTools: result.usedRepoInspectionTools ?? false,
             toolUseNames: result.toolUseNames ?? [],
             ...(explicitReviewRequest ? { explicitReviewRequest: true } : {}),
@@ -3509,7 +3511,10 @@ export function createMentionHandler(deps: {
         // The SDK can return conclusion="failure" with stop reasons other than max_turns,
         // and previously those paths could finish silently.
         if (result.conclusion === "failure" && !mentionOutputPublished && !reviewPublishRightsLost) {
-          if (result.stopReason === "max_turns") {
+          const exhaustedTurnBudget =
+            result.stopReason === "max_turns"
+            || result.failureSubtype === "error_max_turns";
+          if (exhaustedTurnBudget) {
             const turnLimitBody = wrapInDetails(
               [
                 "I ran out of steps analyzing this and wasn't able to post a complete response.",

--- a/src/handlers/review.test.ts
+++ b/src/handlers/review.test.ts
@@ -8817,6 +8817,174 @@ describe("createReviewHandler timeout resilience", () => {
     await workspaceFixture.cleanup();
   });
 
+  test("timeout publication uses checkpoint-backed analyzed progress and retry state", async () => {
+    const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
+    const workspaceFixture = await createWorkspaceFixture();
+
+    const createdCommentBodies: string[] = [];
+    const enqueuedContexts: Array<{ action?: string; jobType?: string }> = [];
+
+    const eventRouter: EventRouter = {
+      register: (eventKey, handler) => {
+        handlers.set(eventKey, handler);
+      },
+      dispatch: async () => undefined,
+    };
+
+    const jobQueue: JobQueue = {
+      enqueue: async <T>(
+        _installationId: number,
+        fn: (metadata: JobQueueRunMetadata) => Promise<T>,
+        context?: {
+          action?: string;
+          jobType?: string;
+        },
+      ) => {
+        enqueuedContexts.push({ action: context?.action, jobType: context?.jobType });
+        if (context?.action === "review-retry") {
+          return undefined as T;
+        }
+        return fn(createQueueRunMetadata());
+      },
+      getQueueSize: () => 0,
+      getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
+    };
+
+    const workspaceManager: WorkspaceManager = {
+      create: async () => ({
+        dir: workspaceFixture.dir,
+        cleanup: async () => undefined,
+      }),
+      cleanupStale: async () => 0,
+    };
+
+    let nextCommentId = 130;
+    const octokit = {
+      rest: {
+        pulls: {
+          listReviewComments: async () => ({ data: [] }),
+          listReviews: async () => ({ data: [] }),
+          listCommits: async () => ({ data: [] }),
+        },
+        issues: {
+          listComments: async () => ({ data: [] }),
+          createComment: async (params: { body: string }) => {
+            createdCommentBodies.push(params.body);
+            return { data: { id: nextCommentId++ } };
+          },
+          updateComment: async () => ({ data: {} }),
+        },
+        reactions: {
+          createForIssue: async () => ({ data: {} }),
+        },
+      },
+    };
+
+    createReviewHandler({
+      eventRouter,
+      jobQueue,
+      workspaceManager,
+      githubApp: {
+        getAppSlug: () => "kodiai",
+        getInstallationOctokit: async () => octokit as never,
+      } as unknown as GitHubApp,
+      executor: {
+        execute: async () => ({
+          conclusion: "error",
+          isTimeout: true,
+          published: false,
+          errorMessage: "timeout",
+          costUsd: 0,
+          numTurns: 1,
+          durationMs: 1,
+          sessionId: "session-timeout-checkpoint-truth",
+          model: "test-model",
+          inputTokens: 0,
+          outputTokens: 0,
+          cacheReadTokens: 0,
+          cacheCreationTokens: 0,
+          stopReason: "timeout",
+        }),
+      } as never,
+      telemetryStore: noopTelemetryStore,
+      knowledgeStore: createKnowledgeStoreStub({
+        getCheckpoint: async () => ({
+          reviewOutputKey: "unused-in-test",
+          repo: "acme/repo",
+          prNumber: 101,
+          filesReviewed: ["README.md"],
+          findingCount: 2,
+          summaryDraft: "Found two issues before timeout.",
+          totalFiles: 3,
+        }),
+        updateCheckpointCommentId: () => undefined,
+        deleteCheckpoint: () => undefined,
+      }) as never,
+      diffContextCollector: async () => ({
+        changedFiles: ["README.md", "src/a.ts", "src/b.ts"],
+        numstatLines: [],
+        diffContent: undefined,
+        strategy: "github-file-list-fallback",
+        mergeBaseRecovered: false,
+        deepenAttempts: 0,
+        unshallowAttempted: false,
+        diffRange: "github-api:file-list",
+      }),
+      logger: createNoopLogger(),
+    });
+
+    const handler = handlers.get("pull_request.review_requested");
+    expect(handler).toBeDefined();
+
+    await handler!(
+      buildReviewRequestedEvent({
+        requested_reviewer: { login: "kodiai[bot]" },
+        pull_request: {
+          number: 101,
+          draft: false,
+          title: "Timeout checkpoint truthfulness",
+          body: "",
+          commits: 0,
+          additions: 3,
+          deletions: 0,
+          user: { login: "octocat" },
+          base: { ref: "main", sha: "mainsha" },
+          head: {
+            sha: "abcdef1234567890",
+            ref: "feature",
+            repo: {
+              full_name: "acme/repo",
+              name: "repo",
+              owner: { login: "acme" },
+            },
+          },
+          labels: [],
+        },
+      }),
+    );
+
+    const partial = createdCommentBodies.find((body) => body.includes("**Partial review**"));
+    expect(partial).toBeDefined();
+    expect(partial!).toContain("timed out after analyzing 1 of 3 files");
+    expect(partial!).toContain("Found two issues before timeout.");
+    expect(partial!).toContain("Scheduling a reduced-scope retry.");
+
+    const reviewDetails = createdCommentBodies.find((body) => body.includes("<summary>Review Details</summary>"));
+    expect(reviewDetails).toBeDefined();
+    expect(reviewDetails!).toContain("- Analyzed progress before timeout: 1/3 changed files");
+    expect(reviewDetails!).toContain("- Findings captured before timeout: 2 total");
+    expect(reviewDetails!).toContain("- Retry state: scheduled reduced-scope retry");
+    expect(reviewDetails!).not.toContain("- Files reviewed: 3");
+
+    expect(enqueuedContexts.find((context) => context.action === "review-retry")).toEqual({
+      action: "review-retry",
+      jobType: "pull-request-review-retry",
+    });
+
+    await workspaceFixture.cleanup();
+  });
+
   test("suppresses timeout Review Details publication when publish rights are lost after partial review", async () => {
     const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
     const workspaceFixture = await createWorkspaceFixture();

--- a/src/handlers/review.ts
+++ b/src/handlers/review.ts
@@ -3800,7 +3800,12 @@ export function createReviewHandler(deps: {
           (diffAnalysis?.metrics.totalLinesAdded ?? 0) +
           (diffAnalysis?.metrics.totalLinesRemoved ?? 0);
 
-        const buildReviewDetailsBody = (): string => {
+        const buildReviewDetailsBody = (timeoutProgress?: {
+          analyzedFiles: number;
+          totalFiles: number;
+          findingCount: number;
+          retryState: string;
+        }): string => {
           const reviewDetailsBody = formatReviewDetailsSummary({
             reviewOutputKey,
             filesReviewed: diffAnalysis?.metrics.totalFiles ?? changedFiles.length,
@@ -3827,6 +3832,7 @@ export function createReviewHandler(deps: {
               publicationPhaseStartedAt,
               totalPhaseStartAt,
             }),
+            timeoutProgress,
           });
 
           const suppressedSection = formatSuppressedFindingsSection(filterResult.filtered);
@@ -4273,12 +4279,30 @@ export function createReviewHandler(deps: {
           let partialCommentId: number | undefined;
 
           if (result.isTimeout) {
-            // Step 1: Read checkpoint data
+            // Step 1: Read checkpoint/progress data
             const checkpoint = (await knowledgeStore?.getCheckpoint?.(reviewOutputKey)) ?? null;
             const hasPublishedInlines = result.published ?? false;
-
-            const hasCheckpointResults = (checkpoint?.findingCount ?? 0) >= 1;
-            const hasPartialResults = hasCheckpointResults || hasPublishedInlines;
+            const timeoutInlineFindings = hasPublishedInlines
+              ? await extractFindingsFromReviewComments({
+                  octokit: extractionOctokit,
+                  owner: apiOwner,
+                  repo: apiRepo,
+                  prNumber: pr.number,
+                  reviewOutputKey,
+                  logger,
+                  baseLog,
+                })
+              : [];
+            const timeoutReviewedFiles = Array.from(new Set([
+              ...(checkpoint?.filesReviewed ?? []),
+              ...timeoutInlineFindings.map((finding) => finding.filePath),
+            ]));
+            const timeoutFindingCount = Math.max(
+              checkpoint?.findingCount ?? 0,
+              timeoutInlineFindings.length,
+            );
+            const timeoutTotalFiles = checkpoint?.totalFiles ?? changedFiles.length;
+            const hasPartialResults = timeoutFindingCount > 0 || timeoutReviewedFiles.length > 0;
 
             // Step 2: Check chronic timeout threshold before publishing
             const recentTimeouts = await telemetryStore.countRecentTimeouts?.(
@@ -4291,27 +4315,95 @@ export function createReviewHandler(deps: {
               ? "timeout_partial"
               : "timeout";
 
+            let retryState = isChronicTimeout
+              ? "skipped (frequent timeouts for this repo/author)"
+              : hasPublishedInlines
+                ? "not scheduled (GitHub-visible findings already posted)"
+                : "not scheduled";
+            let retrySummaryNote: string | undefined;
+            let retryPlan: {
+              reviewOutputKey: string;
+              timeoutSeconds: number;
+              scopeRatio: number;
+              files: string[];
+              timeoutEstimate: ReturnType<typeof estimateTimeoutRisk>;
+              checkpointEnabled: boolean;
+            } | null = null;
+
+            if (!isChronicTimeout && !hasPublishedInlines) {
+              const retryTimeout = Math.max(30, Math.floor(timeoutDuration / 2));
+              const retryScope = computeRetryScope({
+                allFiles: riskScores,
+                filesAlreadyReviewed: timeoutReviewedFiles,
+                totalFiles: timeoutTotalFiles,
+              });
+
+              if (retryScope.filesToReview.length > 0) {
+                const retryFiles = retryScope.filesToReview.map((f) => f.filePath);
+                const retryLinesChanged = retryFiles.reduce((sum, filePath) => {
+                  const stats = perFileStats.get(filePath);
+                  if (!stats) return sum;
+                  return sum + stats.added + stats.removed;
+                }, 0);
+                const retryTimeoutEstimate = estimateTimeoutRisk({
+                  fileCount: retryFiles.length,
+                  linesChanged: retryLinesChanged,
+                  languageComplexity,
+                  isLargePR: false,
+                  baseTimeoutSeconds: retryTimeout,
+                });
+                const retryCheckpointEnabled =
+                  retryTimeoutEstimate.riskLevel === "medium" ||
+                  retryTimeoutEstimate.riskLevel === "high";
+
+                retryPlan = {
+                  reviewOutputKey: `${reviewOutputKey}-retry-1`,
+                  timeoutSeconds: retryTimeout,
+                  scopeRatio: retryScope.scopeRatio,
+                  files: retryFiles,
+                  timeoutEstimate: retryTimeoutEstimate,
+                  checkpointEnabled: retryCheckpointEnabled,
+                };
+                retryState = "scheduled reduced-scope retry";
+                retrySummaryNote = "Scheduling a reduced-scope retry.";
+              } else {
+                retryState = "not scheduled (no remaining files outside analyzed progress)";
+                retrySummaryNote = "Retry not scheduled because no remaining files were outside the analyzed progress.";
+              }
+            } else if (hasPublishedInlines) {
+              retrySummaryNote = "Retry not scheduled because GitHub-visible findings were already posted.";
+            }
+
             // Step 3: Publish partial review with disclaimer.
             // IMPORTANT: also publish a placeholder partial review when we have
             // a full timeout (no checkpoint + no inline output) so we can
             // (a) inform the user and (b) attach a retry result.
-            const summaryDraft = checkpoint?.summaryDraft ?? (hasPartialResults
+            const summaryDraftBase = checkpoint?.summaryDraft ?? (hasPublishedInlines
               ? "Review timed out with findings posted inline above."
-              : (isChronicTimeout
-                ? "Review timed out before producing output. Retry skipped due to frequent timeouts for this repo/author."
-                : "Review timed out before producing output. Scheduling a reduced-scope retry."));
+              : hasPartialResults
+                ? "Review timed out after partial progress was recorded."
+                : "Review timed out before producing output.");
+            const summaryDraft = retrySummaryNote
+              ? `${summaryDraftBase}\n\n${retrySummaryNote}`
+              : summaryDraftBase;
             const partialBody = formatPartialReviewComment({
               summaryDraft,
-              filesReviewed: checkpoint?.filesReviewed?.length ?? 0,
-              totalFiles: changedFiles.length,
+              filesReviewed: timeoutReviewedFiles.length,
+              totalFiles: timeoutTotalFiles,
               timedOutAfterSeconds: timeoutDuration,
               isRetrySkipped: isChronicTimeout,
               retrySkipReason: isChronicTimeout
                 ? "Retry skipped -- this repo has timed out frequently for this author."
                 : undefined,
             });
+            const timeoutReviewDetails = {
+              analyzedFiles: timeoutReviewedFiles.length,
+              totalFiles: timeoutTotalFiles,
+              findingCount: timeoutFindingCount,
+              retryState,
+            };
 
-            const octokit = await githubApp.getInstallationOctokit(event.installationId);
+            const octokit = extractionOctokit;
             if (canPublishVisibleOutput("timeout partial review")) {
               setReviewWorkPhase("publish");
               const partialComment = await octokit.rest.issues.createComment({
@@ -4330,10 +4422,10 @@ export function createReviewHandler(deps: {
                   reviewOutputKey,
                   repo: `${apiOwner}/${apiRepo}`,
                   prNumber: pr.number,
-                  filesReviewed: checkpoint?.filesReviewed ?? [],
-                  findingCount: checkpoint?.findingCount ?? 0,
+                  filesReviewed: timeoutReviewedFiles,
+                  findingCount: timeoutFindingCount,
                   summaryDraft,
-                  totalFiles: changedFiles.length,
+                  totalFiles: timeoutTotalFiles,
                   partialCommentId,
                 });
               } else {
@@ -4347,11 +4439,12 @@ export function createReviewHandler(deps: {
                   deliveryId: event.id,
                   prNumber: pr.number,
                   partialCommentId,
-                  filesReviewed: checkpoint?.filesReviewed?.length ?? 0,
-                  findingCount: checkpoint?.findingCount ?? 0,
+                  filesReviewed: timeoutReviewedFiles.length,
+                  findingCount: timeoutFindingCount,
                   hasPartialResults,
                   isChronicTimeout,
                   recentTimeouts,
+                  retryState,
                 },
                 "Published partial review on timeout",
               );
@@ -4364,7 +4457,7 @@ export function createReviewHandler(deps: {
                     repo: apiRepo,
                     prNumber: pr.number,
                     reviewOutputKey,
-                    body: buildReviewDetailsBody(),
+                    body: buildReviewDetailsBody(timeoutReviewDetails),
                     botHandles: [githubApp.getAppSlug(), "claude"],
                   });
                 }
@@ -4394,9 +4487,9 @@ export function createReviewHandler(deps: {
                     reviewOutputKey,
                     executionConclusion,
                     hadInlineOutput: hasPublishedInlines,
-                    checkpointFilesReviewed: checkpoint?.filesReviewed?.length ?? 0,
-                    checkpointFindingCount: checkpoint?.findingCount ?? 0,
-                    checkpointTotalFiles: changedFiles.length,
+                    checkpointFilesReviewed: timeoutReviewedFiles.length,
+                    checkpointFindingCount: timeoutFindingCount,
+                    checkpointTotalFiles: timeoutTotalFiles,
                     partialCommentId,
                     recentTimeouts,
                     chronicTimeout: isChronicTimeout,
@@ -4412,92 +4505,71 @@ export function createReviewHandler(deps: {
             // Retry is only useful when no GitHub-visible output was published.
             // If inline comments were already posted, avoid a retry that could
             // create additional noise or duplicates.
-            if (!isChronicTimeout && !hasPublishedInlines) {
-              const retryReviewOutputKey = `${reviewOutputKey}-retry-1`;
-              const retryTimeout = Math.max(30, Math.floor(timeoutDuration / 2));
+            if (retryPlan) {
+              const retryReviewOutputKey = retryPlan.reviewOutputKey;
+              const retryTimeout = retryPlan.timeoutSeconds;
+              const retryFiles = retryPlan.files;
+              const retryTimeoutEstimate = retryPlan.timeoutEstimate;
+              const retryCheckpointEnabled = retryPlan.checkpointEnabled;
+              const retryScopeRatio = retryPlan.scopeRatio;
 
-              const filesAlreadyReviewed = checkpoint?.filesReviewed ?? [];
-              const retryScope = computeRetryScope({
-                allFiles: riskScores,
-                filesAlreadyReviewed,
-                totalFiles: changedFiles.length,
+              // Update resilience telemetry with retry plan
+              if (config.telemetry.enabled) {
+                try {
+                  await telemetryStore.recordResilienceEvent?.({
+                    deliveryId: event.id,
+                    repo: `${apiOwner}/${apiRepo}`,
+                    prNumber: pr.number,
+                    prAuthor: pr.user.login,
+                    eventType: `pull_request.${payload.action}`,
+                    kind: "timeout",
+                    reviewOutputKey,
+                    executionConclusion,
+                    hadInlineOutput: hasPublishedInlines,
+                    checkpointFilesReviewed: timeoutReviewedFiles.length,
+                    checkpointFindingCount: timeoutFindingCount,
+                    checkpointTotalFiles: timeoutTotalFiles,
+                    partialCommentId,
+                    recentTimeouts,
+                    chronicTimeout: isChronicTimeout,
+                    retryEnqueued: true,
+                    retryFilesCount: retryFiles.length,
+                    retryScopeRatio,
+                    retryTimeoutSeconds: retryTimeout,
+                    retryRiskLevel: retryTimeoutEstimate.riskLevel,
+                    retryCheckpointEnabled,
+                  });
+                } catch (err) {
+                  logger.warn({ err }, "Resilience telemetry write failed (non-blocking)");
+                }
+              }
+
+              logger.info(
+                {
+                  deliveryId: event.id,
+                  prNumber: pr.number,
+                  retryFiles: retryFiles.length,
+                  scopeRatio: retryScopeRatio,
+                  retryTimeout,
+                  retryRiskLevel: retryTimeoutEstimate.riskLevel,
+                },
+                "Enqueueing retry with reduced scope",
+              );
+
+              const retryDeliveryId = `${event.id}-retry-1`;
+              const retryReviewWorkAttempt = reviewWorkCoordinator.claim({
+                familyKey: reviewFamilyKey,
+                source: "automatic-review",
+                lane: "review",
+                deliveryId: retryDeliveryId,
+                phase: "claimed",
               });
 
-              if (retryScope.filesToReview.length > 0) {
-                const retryFiles = retryScope.filesToReview.map((f) => f.filePath);
-                const retryLinesChanged = retryFiles.reduce((sum, filePath) => {
-                  const stats = perFileStats.get(filePath);
-                  if (!stats) return sum;
-                  return sum + stats.added + stats.removed;
-                }, 0);
-                const retryTimeoutEstimate = estimateTimeoutRisk({
-                  fileCount: retryFiles.length,
-                  linesChanged: retryLinesChanged,
-                  languageComplexity,
-                  isLargePR: false,
-                  baseTimeoutSeconds: retryTimeout,
-                });
-                const retryCheckpointEnabled =
-                  retryTimeoutEstimate.riskLevel === "medium" ||
-                  retryTimeoutEstimate.riskLevel === "high";
-
-                // Update resilience telemetry with retry plan
-                if (config.telemetry.enabled) {
-                  try {
-                    await telemetryStore.recordResilienceEvent?.({
-                      deliveryId: event.id,
-                      repo: `${apiOwner}/${apiRepo}`,
-                      prNumber: pr.number,
-                      prAuthor: pr.user.login,
-                      eventType: `pull_request.${payload.action}`,
-                      kind: "timeout",
-                      reviewOutputKey,
-                      executionConclusion,
-                      hadInlineOutput: hasPublishedInlines,
-                      checkpointFilesReviewed: checkpoint?.filesReviewed?.length ?? 0,
-                      checkpointFindingCount: checkpoint?.findingCount ?? 0,
-                      checkpointTotalFiles: changedFiles.length,
-                      partialCommentId,
-                      recentTimeouts,
-                      chronicTimeout: isChronicTimeout,
-                      retryEnqueued: true,
-                      retryFilesCount: retryFiles.length,
-                      retryScopeRatio: retryScope.scopeRatio,
-                      retryTimeoutSeconds: retryTimeout,
-                      retryRiskLevel: retryTimeoutEstimate.riskLevel,
-                      retryCheckpointEnabled,
-                    });
-                  } catch (err) {
-                    logger.warn({ err }, "Resilience telemetry write failed (non-blocking)");
-                  }
-                }
-
-                logger.info(
-                  {
-                    deliveryId: event.id,
-                    prNumber: pr.number,
-                    retryFiles: retryFiles.length,
-                    scopeRatio: retryScope.scopeRatio,
-                    retryTimeout,
-                    retryRiskLevel: retryTimeoutEstimate.riskLevel,
-                  },
-                  "Enqueueing retry with reduced scope",
-                );
-
-                const retryDeliveryId = `${event.id}-retry-1`;
-                const retryReviewWorkAttempt = reviewWorkCoordinator.claim({
-                  familyKey: reviewFamilyKey,
-                  source: "automatic-review",
-                  lane: "review",
-                  deliveryId: retryDeliveryId,
-                  phase: "claimed",
-                });
-
-                // Fire-and-forget enqueue -- do not await the retry result.
-                // Claim before queueing so the retry is visible in family diagnostics
-                // and retains its request ordering, but publish rights only become
-                // authoritative when the queued retry actually starts executing.
-                void jobQueue.enqueue(event.installationId, async () => {
+              // Fire-and-forget enqueue -- do not await the retry result.
+              // Claim before queueing so the retry is visible in family diagnostics
+              // and retains its request ordering, but publish rights only become
+              // authoritative when the queued retry actually starts executing.
+              void jobQueue.enqueue(event.installationId, async () => {
                   let retryWorkspace: Workspace | undefined;
                   try {
                     setReviewWorkPhaseForAttempt(retryReviewWorkAttempt.attemptId, "workspace-create");
@@ -4625,7 +4697,7 @@ export function createReviewHandler(deps: {
                       deliveryId: retryDeliveryId,
                       dynamicTimeoutSeconds: retryTimeout,
                       knowledgeStore,
-                      totalFiles: changedFiles.length,
+                      totalFiles: timeoutTotalFiles,
                       enableCheckpointTool: retryCheckpointEnabled,
                       enableCommentTools: false,
                     });
@@ -4654,11 +4726,11 @@ export function createReviewHandler(deps: {
                             hadInlineOutput: retryResult.published ?? false,
                             checkpointFilesReviewed: retryCheckpoint?.filesReviewed?.length,
                             checkpointFindingCount: retryCheckpoint?.findingCount,
-                            checkpointTotalFiles: changedFiles.length,
+                            checkpointTotalFiles: timeoutTotalFiles,
                             partialCommentId,
                             retryHasResults,
                             retryFilesCount: retryFiles.length,
-                            retryScopeRatio: retryScope.scopeRatio,
+                            retryScopeRatio,
                             retryTimeoutSeconds: retryTimeout,
                             retryRiskLevel: retryTimeoutEstimate.riskLevel,
                             retryCheckpointEnabled,
@@ -4678,8 +4750,8 @@ export function createReviewHandler(deps: {
                           retryCheckpoint?.summaryDraft ??
                           checkpoint?.summaryDraft ??
                           "Review completed with reduced scope.",
-                        filesReviewed: checkpoint?.filesReviewed?.length ?? 0,
-                        totalFiles: changedFiles.length,
+                        filesReviewed: timeoutReviewedFiles.length,
+                        totalFiles: timeoutTotalFiles,
                         timedOutAfterSeconds: timeoutDuration,
                         isRetryResult: true,
                         retryFilesReviewed,
@@ -4803,7 +4875,6 @@ export function createReviewHandler(deps: {
                     "Failed to enqueue retry job",
                   );
                 });
-              }
             }
           }
 

--- a/src/lib/review-utils.test.ts
+++ b/src/lib/review-utils.test.ts
@@ -121,6 +121,24 @@ describe("formatReviewDetailsSummary", () => {
     expect(result).not.toContain("Tokens:");
   });
 
+  it("renders timeout progress from analyzed evidence instead of generic reviewed totals", () => {
+    const result = formatReviewDetailsSummary({
+      ...BASE_PARAMS,
+      timeoutProgress: {
+        analyzedFiles: 1,
+        totalFiles: 3,
+        findingCount: 2,
+        retryState: "scheduled reduced-scope retry",
+      },
+    });
+
+    expect(result).toContain("- Analyzed progress before timeout: 1/3 changed files");
+    expect(result).toContain("- Findings captured before timeout: 2 total");
+    expect(result).toContain("- Retry state: scheduled reduced-scope retry");
+    expect(result).not.toContain("- Files reviewed: 3");
+    expect(result).not.toContain("- Findings: 0 critical, 1 major, 2 medium, 0 minor");
+  });
+
   it("renders total wall-clock time and the six required phases in stable order", () => {
     const result = formatReviewDetailsSummary({
       ...BASE_PARAMS,

--- a/src/lib/review-utils.ts
+++ b/src/lib/review-utils.ts
@@ -83,6 +83,13 @@ export type ReviewDetailsPhaseTimingSummary = {
   phases?: ReadonlyArray<ReviewPhaseTiming> | null;
 };
 
+export type TimeoutReviewDetailsProgress = {
+  analyzedFiles: number;
+  totalFiles: number;
+  findingCount: number;
+  retryState: string;
+};
+
 // ---------------------------------------------------------------------------
 // Pure helpers
 // ---------------------------------------------------------------------------
@@ -378,6 +385,7 @@ export function formatReviewDetailsSummary(params: {
   };
   structuralImpact?: StructuralImpactPayload | null;
   phaseTimingSummary?: ReviewDetailsPhaseTimingSummary | null;
+  timeoutProgress?: TimeoutReviewDetailsProgress | null;
 }): string {
   const {
     reviewOutputKey,
@@ -396,6 +404,7 @@ export function formatReviewDetailsSummary(params: {
     tokenUsage,
     structuralImpact,
     phaseTimingSummary,
+    timeoutProgress,
   } = params;
 
   const formatProfileLine = (label: string, profile: ResolvedReviewProfile): string => {
@@ -421,7 +430,16 @@ export function formatReviewDetailsSummary(params: {
     "<details>",
     "<summary>Review Details</summary>",
     "",
-    `- Files reviewed: ${filesReviewed}`,
+    ...(timeoutProgress
+      ? [
+          `- Analyzed progress before timeout: ${timeoutProgress.analyzedFiles}/${timeoutProgress.totalFiles} changed files`,
+          `- Findings captured before timeout: ${timeoutProgress.findingCount} total`,
+          `- Retry state: ${timeoutProgress.retryState}`,
+        ]
+      : [
+          `- Files reviewed: ${filesReviewed}`,
+          `- Findings: ${findingCounts.critical} critical, ${findingCounts.major} major, ${findingCounts.medium} medium, ${findingCounts.minor} minor`,
+        ]),
     `- Lines changed: +${linesAdded} -${linesRemoved}`,
     ...(hasBoundedProfileDetails && reviewBoundedness
       ? [
@@ -442,7 +460,6 @@ export function formatReviewDetailsSummary(params: {
         ]
       : [profileLine]),
     `- Contributor experience: ${contributorExperience.text}`,
-    `- Findings: ${findingCounts.critical} critical, ${findingCounts.major} major, ${findingCounts.medium} medium, ${findingCounts.minor} minor`,
     `- Review completed: ${new Date().toISOString()}`,
   ];
 


### PR DESCRIPTION
## Summary
- make timeout partial-review and Review Details output derive analyzed progress, findings, retry state, and phase timing from checkpoint plus visible evidence
- extend `verify:m048:s01`, `verify:m048:s02`, and `verify:m048:s03` plus the review-requested runbook with publication-aware timeout proof
- harden `deploy.sh` / `.dockerignore` so ACR remote builds use a minimal staged context instead of large local workspace artifacts

## Test Plan
- `bun test ./src/handlers/review.test.ts ./src/lib/review-utils.test.ts ./scripts/verify-m048-s01.test.ts ./scripts/verify-m048-s02.test.ts ./scripts/verify-m048-s03.test.ts && bun run tsc --noEmit`