### PR TITLE
feat: add Slack webhook relay support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,7 @@ SLACK_BOT_USER_ID=                # (optional) Slack bot user ID for mention det
 SLACK_KODIAI_CHANNEL_ID=          # (optional) Channel ID for KodiAI notifications
 SLACK_DEFAULT_REPO=               # (optional) Default owner/repo for Slack commands
 SLACK_ASSISTANT_MODEL=            # (optional) Model name for Slack assistant responses
+SLACK_WEBHOOK_RELAY_SOURCES=      # (optional) JSON array of webhook relay source definitions (service-level config, not `.kodiai.yml`)
 SLACK_WIKI_CHANNEL_ID=            # (optional) Channel ID for wiki update notifications
 
 # ── Wiki ─────────────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Kodiai is an installable GitHub App that delivers AI-powered code review, conversational assistance, issue intelligence, and Slack integration. One installation replaces per-repo workflow YAML — configure behavior with an optional `.kodiai.yml` file.
 
+Service-level runtime features like Slack webhook relay are configured through environment variables, not `.kodiai.yml`.
+
 29 milestones shipped (v0.1 through v0.29). See [CHANGELOG.md](CHANGELOG.md) for release history.
 
 ## Quick Start
@@ -35,6 +37,7 @@ The server exposes:
 |---|---|
 | `POST /webhooks/github` | GitHub webhook receiver |
 | `POST /webhooks/slack/events` | Slack events receiver |
+| `POST /webhooks/slack/relay/:sourceId` | Verified webhook-to-Slack relay receiver |
 | `GET /healthz` | Liveness probe |
 | `GET /readiness` | Readiness probe |
 
@@ -94,7 +97,7 @@ Full documentation lives in the `docs/` directory:
 
 Kodiai deploys to Azure Container Apps via ACR remote build with zero-downtime rolling deploys, and the deploy script reports the active revision for post-deploy proof.
 
-See [docs/deployment.md](docs/deployment.md) for details. For diagnosing review-request issues, see [docs/runbooks/review-requested-debug.md](docs/runbooks/review-requested-debug.md).
+See [docs/deployment.md](docs/deployment.md) for details. For diagnosing review-request issues, see [docs/runbooks/review-requested-debug.md](docs/runbooks/review-requested-debug.md). For Slack assistant operations, see [docs/runbooks/slack-integration.md](docs/runbooks/slack-integration.md). For webhook relay setup and troubleshooting, see [docs/runbooks/slack-webhook-relay.md](docs/runbooks/slack-webhook-relay.md).
 
 ## Contributing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ Troubleshooting and operations guides in [`runbooks/`](runbooks/):
 - **[Review Requested Debug](runbooks/review-requested-debug.md)** — Debug manual re-request flows that don't trigger reviews
 - **[Scale](runbooks/scale.md)** — Handle large PRs, long threads, and timeout issues
 - **[Slack Integration](runbooks/slack-integration.md)** — Deploy and operate Slack integration
+- **[Slack Webhook Relay](runbooks/slack-webhook-relay.md)** — Configure and troubleshoot verified webhook-to-Slack relay sources
 - **[xbmc/xbmc Cutover](runbooks/xbmc-cutover.md)** — Cut over xbmc/xbmc from GitHub Actions to the Kodiai GitHub App
 - **[xbmc/xbmc Ops](runbooks/xbmc-ops.md)** — Day-2 operations for xbmc/xbmc after cutover
 
@@ -38,5 +39,6 @@ Test evidence and verification records in [`smoke/`](smoke/):
 - **[Phase 74: Reliability Regression Gate](smoke/phase74-reliability-regression-gate.md)** — Pre-release reliability gate for issue write-mode
 - **[Phase 75: Live OPS Verification Closure](smoke/phase75-live-ops-verification-closure.md)** — Release candidate OPS closure procedure
 - **[Phase 80: Slack Operator Hardening](smoke/phase80-slack-operator-hardening.md)** — Slack v1 channel gating and operator verification
+- **[Slack Webhook Relay](smoke/slack-webhook-relay.md)** — Accepted, suppressed, and failed-delivery smoke path for webhook relay
 - **[xbmc/kodiai Write Flow](smoke/xbmc-kodiai-write-flow.md)** — End-to-end write-mode smoke test for xbmc/kodiai
 - **[xbmc/xbmc Write Flow](smoke/xbmc-xbmc-write-flow.md)** — End-to-end write-mode smoke test for xbmc/xbmc

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -163,6 +163,7 @@ These are the fastest operator checks after a deploy:
 - `GET /healthz`
 - `GET /readiness`
 - Deploy output showing the exact proof URLs that were just probed
+- `bun run verify:m052` when Slack webhook relay is enabled
 
 ## Operational Runbooks
 
@@ -196,4 +197,6 @@ Health checks:
 ```bash
 curl -fsS "https://$(az containerapp show --name ca-kodiai --resource-group rg-kodiai --query properties.configuration.ingress.fqdn -o tsv)/healthz"
 curl -fsS "https://$(az containerapp show --name ca-kodiai --resource-group rg-kodiai --query properties.configuration.ingress.fqdn -o tsv)/readiness"
+```
+how --name ca-kodiai --resource-group rg-kodiai --query properties.configuration.ingress.fqdn -o tsv)/readiness"
 ```

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -198,5 +198,3 @@ Health checks:
 curl -fsS "https://$(az containerapp show --name ca-kodiai --resource-group rg-kodiai --query properties.configuration.ingress.fqdn -o tsv)/healthz"
 curl -fsS "https://$(az containerapp show --name ca-kodiai --resource-group rg-kodiai --query properties.configuration.ingress.fqdn -o tsv)/readiness"
 ```
-how --name ca-kodiai --resource-group rg-kodiai --query properties.configuration.ingress.fqdn -o tsv)/readiness"
-```

--- a/docs/runbooks/slack-integration.md
+++ b/docs/runbooks/slack-integration.md
@@ -2,6 +2,8 @@
 
 Use this runbook for deploying and operating Slack integration for Kodiai in `#kodiai`.
 
+For the separate inbound webhook-to-Slack relay surface, use [Slack Webhook Relay](./slack-webhook-relay.md). That feature is service-level runtime config (`SLACK_WEBHOOK_RELAY_SOURCES`), not `.kodiai.yml`.
+
 Primary goal: keep Slack behavior deterministic and thread-only while giving responders a fast path from symptom to root cause.
 
 ## Scope and Contract

--- a/docs/runbooks/slack-webhook-relay.md
+++ b/docs/runbooks/slack-webhook-relay.md
@@ -1,0 +1,235 @@
+# Slack Webhook Relay Runbook
+
+Use this runbook to configure and operate Kodiai's inbound webhook-to-Slack relay surface.
+
+## Scope
+
+This feature is **not** part of `.kodiai.yml`. It is service-level runtime configuration loaded from environment variables at process startup.
+
+Use the relay when you want an external system to POST a small, verified event payload into Kodiai and have Kodiai relay selected events into Slack with explicit filtering and explicit suppression/failure outcomes.
+
+## Route Contract
+
+Inbound relay requests land on:
+
+- `POST /webhooks/slack/relay/:sourceId`
+
+Where `:sourceId` must match one configured relay source in `SLACK_WEBHOOK_RELAY_SOURCES`.
+
+## Runtime Configuration
+
+Configure relay sources with `SLACK_WEBHOOK_RELAY_SOURCES` in the app environment.
+
+Example:
+
+```bash
+SLACK_WEBHOOK_RELAY_SOURCES='[
+  {
+    "id": "buildkite",
+    "targetChannel": "C_BUILD_ALERTS",
+    "auth": {
+      "type": "header_secret",
+      "headerName": "x-relay-secret",
+      "secret": "super-secret"
+    },
+    "filter": {
+      "eventTypes": ["build.failed", "build.finished"],
+      "textIncludes": ["failed"],
+      "textExcludes": ["flaky"]
+    }
+  }
+]'
+```
+
+### Config rules
+
+- `id` — stable source identifier used in the route path
+- `targetChannel` — Slack channel ID for accepted events
+- `auth.type` — currently only `header_secret`
+- `auth.headerName` — request header carrying the shared secret
+- `auth.secret` — expected secret value
+- `filter.eventTypes` — allowlist of event types; empty means any event type
+- `filter.textIncludes` — every listed substring must appear in `text`
+- `filter.textExcludes` — any listed substring suppresses the event
+
+## Payload Contract
+
+The inbound payload must already use Kodiai's generic relay schema:
+
+```json
+{
+  "eventType": "build.failed",
+  "title": "Build failed on main",
+  "summary": "CI failed for xbmc/xbmc after the latest merge.",
+  "url": "https://ci.example.test/builds/123",
+  "text": "Build failed for xbmc/xbmc on main after merge 09f28d7.",
+  "metadata": {
+    "provider": "buildkite",
+    "pipeline": "main"
+  }
+}
+```
+
+Required fields:
+
+- `eventType`
+- `title`
+- `summary`
+- `url` (valid absolute URL)
+- `text`
+
+Optional fields:
+
+- `metadata` (object)
+
+Kodiai does **not** perform source-specific field mapping in the route layer. If your upstream system uses a different payload shape, normalize it before sending the relay request.
+
+## Outcome Vocabulary
+
+The relay surface is intentionally explicit.
+
+### 202 Accepted / Delivered path
+
+```json
+{
+  "ok": true,
+  "verdict": "accept",
+  "sourceId": "buildkite",
+  "eventType": "build.failed",
+  "targetChannel": "C_BUILD_ALERTS"
+}
+```
+
+Meaning: source auth passed, payload was valid, filters allowed it, and Kodiai handed it to Slack delivery.
+
+### 202 Suppressed path
+
+```json
+{
+  "ok": true,
+  "verdict": "suppress",
+  "reason": "text_excluded_substring",
+  "sourceId": "buildkite",
+  "eventType": "build.failed",
+  "detail": "flaky"
+}
+```
+
+Meaning: the event was understood but intentionally filtered out. No Slack post occurs.
+
+Current suppression reasons:
+
+- `event_type_not_allowed`
+- `text_missing_required_substring`
+- `text_excluded_substring`
+
+### 400 Malformed payload
+
+```json
+{
+  "ok": false,
+  "reason": "malformed_payload",
+  "issues": ["text", "url"]
+}
+```
+
+Meaning: the request body parsed as JSON, but it did not satisfy the relay payload contract.
+
+### 400 Invalid JSON
+
+```json
+{
+  "ok": false,
+  "reason": "invalid_json"
+}
+```
+
+### 401 Invalid source auth
+
+```json
+{
+  "ok": false,
+  "reason": "invalid_source_auth"
+}
+```
+
+### 404 Unknown source
+
+```json
+{
+  "ok": false,
+  "reason": "unknown_source"
+}
+```
+
+### 502 Delivery failure
+
+```json
+{
+  "ok": false,
+  "reason": "delivery_failed",
+  "sourceId": "buildkite",
+  "eventType": "build.failed"
+}
+```
+
+Meaning: the event passed auth, parsing, and filtering, but the downstream Slack post failed.
+
+## Message Shape
+
+Accepted events are posted through the shared Slack client as one standalone message:
+
+```text
+*Build failed on main*
+CI failed for xbmc/xbmc after the latest merge.
+Build failed for xbmc/xbmc on main after merge 09f28d7.
+<https://ci.example.test/builds/123|Open event>
+Source: `buildkite` · Event: `build.failed`
+```
+
+## Proof Surfaces
+
+Primary proof command:
+
+```bash
+bun run verify:m052
+```
+
+That command composes the S01 contract verifier and the S02 route+delivery verifier, so it exercises accepted, suppressed, and failed-delivery outcomes from one surface.
+
+Lower-level diagnostics are still available when you need to isolate a layer:
+
+```bash
+bun test ./src/config.test.ts ./src/slack/webhook-relay-config.test.ts
+bun test ./src/slack/webhook-relay.test.ts
+bun test ./src/routes/slack-relay-webhooks.test.ts ./src/slack/webhook-relay-delivery.test.ts
+bun test ./scripts/verify-m052-s01.test.ts ./src/slack/webhook-relay.test.ts
+bun test ./scripts/verify-m052-s02.test.ts ./src/routes/slack-relay-webhooks.test.ts ./src/slack/webhook-relay-delivery.test.ts
+```
+
+## Troubleshooting
+
+### `unknown_source`
+- Check the route path source id matches `SLACK_WEBHOOK_RELAY_SOURCES[].id`.
+- Confirm the process has been restarted after env changes.
+
+### `invalid_source_auth`
+- Check the request includes the configured header name.
+- Check the header value matches the configured secret exactly.
+
+### `invalid_json`
+- The request body was not valid JSON.
+- Re-send with `Content-Type: application/json` and a syntactically valid body.
+
+### `malformed_payload`
+- The JSON body parsed, but required fields are missing or invalid.
+- Inspect the returned `issues` array and fix the payload shape upstream.
+
+### `suppress`
+- The payload was valid, but the source filter blocked it.
+- Check `eventTypes`, `textIncludes`, and `textExcludes` against the returned `reason` and `detail`.
+
+### `delivery_failed`
+- The event passed ingress and filtering but Slack delivery failed.
+- Check Slack bot auth/scopes and the target channel id.
+- Re-run the route/delivery proof bundle to confirm whether the failure is runtime-only or contract drift.

--- a/docs/smoke/slack-webhook-relay.md
+++ b/docs/smoke/slack-webhook-relay.md
@@ -1,0 +1,103 @@
+# Slack Webhook Relay Smoke
+
+Use this smoke path when validating the inbound webhook-to-Slack relay surface from a clean environment.
+
+Primary proof command:
+
+```bash
+bun run verify:m052
+```
+
+Use the curl flows below when you want to exercise the HTTP route directly.
+
+## Preconditions
+
+- `SLACK_WEBHOOK_RELAY_SOURCES` is configured on the target instance.
+- The target source id in this example is `buildkite`.
+- The configured source auth header is `x-relay-secret`.
+- The shared Slack bot config is already valid for the target environment.
+
+## Accepted flow
+
+```bash
+curl -i -X POST http://localhost:3000/webhooks/slack/relay/buildkite \
+  -H 'content-type: application/json' \
+  -H 'x-relay-secret: super-secret' \
+  --data-binary '{
+    "eventType": "build.failed",
+    "title": "Build failed on main",
+    "summary": "CI failed for xbmc/xbmc after the latest merge.",
+    "url": "https://ci.example.test/builds/123",
+    "text": "Build failed for xbmc/xbmc on main after merge 09f28d7.",
+    "metadata": {"provider": "buildkite", "pipeline": "main"}
+  }'
+```
+
+Expected result:
+
+- HTTP `202`
+- JSON body contains `"verdict":"accept"`
+- Slack receives one standalone message in the configured target channel
+
+## Suppressed flow
+
+```bash
+curl -i -X POST http://localhost:3000/webhooks/slack/relay/buildkite \
+  -H 'content-type: application/json' \
+  -H 'x-relay-secret: super-secret' \
+  --data-binary '{
+    "eventType": "build.failed",
+    "title": "Flaky build failure",
+    "summary": "A known flaky test failed in CI.",
+    "url": "https://ci.example.test/builds/124",
+    "text": "Build failed because of a flaky test in the UI suite.",
+    "metadata": {"provider": "buildkite", "pipeline": "main"}
+  }'
+```
+
+Expected result:
+
+- HTTP `202`
+- JSON body contains `"verdict":"suppress"`
+- JSON body contains `"reason":"text_excluded_substring"`
+- No Slack message is posted
+
+## Failed-delivery flow
+
+Use the same accepted payload against a non-production or local environment where Slack delivery is intentionally broken (for example: invalid `SLACK_BOT_TOKEN`, blocked Slack egress, or a mocked failing delivery path in test).
+
+```bash
+curl -i -X POST http://localhost:3000/webhooks/slack/relay/buildkite \
+  -H 'content-type: application/json' \
+  -H 'x-relay-secret: super-secret' \
+  --data-binary '{
+    "eventType": "build.failed",
+    "title": "Build failed on main",
+    "summary": "CI failed for xbmc/xbmc after the latest merge.",
+    "url": "https://ci.example.test/builds/123",
+    "text": "Build failed for xbmc/xbmc on main after merge 09f28d7.",
+    "metadata": {"provider": "buildkite", "pipeline": "main"}
+  }'
+```
+
+Expected result in that intentionally broken environment:
+
+- HTTP `502`
+- JSON body contains `"reason":"delivery_failed"`
+- No successful Slack post occurs
+
+## Route result map
+
+- `accept` — payload was valid, filters allowed it, Slack delivery path ran
+- `suppress` — payload was valid, but filtering intentionally blocked delivery
+- `delivery_failed` — payload passed ingress and filtering, but Slack post failed
+- `invalid_json` — request body was not valid JSON
+- `malformed_payload` — JSON parsed, but required relay fields were missing or invalid
+- `invalid_source_auth` — source auth header missing or wrong
+- `unknown_source` — route source id does not exist in `SLACK_WEBHOOK_RELAY_SOURCES`
+
+## What to cite in issue closure / incident review
+
+- `bun run verify:m052`
+- `docs/runbooks/slack-webhook-relay.md`
+- The exact HTTP result body from the curl smoke flow (`accept`, `suppress`, or `delivery_failed`)

--- a/fixtures/slack-webhook-relay/accepted.json
+++ b/fixtures/slack-webhook-relay/accepted.json
@@ -1,0 +1,11 @@
+{
+  "eventType": "build.failed",
+  "title": "Build failed on main",
+  "summary": "CI failed for xbmc/xbmc after the latest merge.",
+  "url": "https://ci.example.test/builds/123",
+  "text": "Build failed for xbmc/xbmc on main after merge 09f28d7.",
+  "metadata": {
+    "pipeline": "main",
+    "provider": "buildkite"
+  }
+}

--- a/fixtures/slack-webhook-relay/suppressed.json
+++ b/fixtures/slack-webhook-relay/suppressed.json
@@ -1,0 +1,11 @@
+{
+  "eventType": "build.failed",
+  "title": "Flaky build failure",
+  "summary": "A known flaky test failed in CI.",
+  "url": "https://ci.example.test/builds/124",
+  "text": "Build failed because of a flaky test in the UI suite.",
+  "metadata": {
+    "pipeline": "main",
+    "provider": "buildkite"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "verify:m048:s01": "bun scripts/verify-m048-s01.ts",
     "verify:m048:s02": "bun scripts/verify-m048-s02.ts",
     "verify:m048:s03": "bun scripts/verify-m048-s03.ts",
-    "verify:m049:s02": "bun scripts/verify-m049-s02.ts"
+    "verify:m049:s02": "bun scripts/verify-m049-s02.ts",
+    "verify:m052": "bun scripts/verify-m052.ts"
   },
   "devDependencies": {
     "@octokit/webhooks-types": "^7.6.1",

--- a/scripts/backfill-issues.ts
+++ b/scripts/backfill-issues.ts
@@ -137,6 +137,7 @@ async function main() {
       slackKodiaiChannelId: "unused",
       slackDefaultRepo: repo,
       slackAssistantModel: "unused",
+      slackWebhookRelaySources: [],
       port: 0,
       logLevel: "info",
       botAllowList: [],

--- a/scripts/backfill-pr-evidence.ts
+++ b/scripts/backfill-pr-evidence.ts
@@ -176,6 +176,7 @@ async function main() {
       slackKodiaiChannelId: "unused",
       slackDefaultRepo: repo,
       slackAssistantModel: "unused",
+      slackWebhookRelaySources: [],
       port: 0,
       logLevel: "info",
       botAllowList: [],

--- a/scripts/backfill-review-comments.ts
+++ b/scripts/backfill-review-comments.ts
@@ -148,6 +148,7 @@ async function main() {
       slackKodiaiChannelId: "unused",
       slackDefaultRepo: repo,
       slackAssistantModel: "unused",
+      slackWebhookRelaySources: [],
       port: 0,
       logLevel: "info",
       botAllowList: [],

--- a/scripts/cleanup-legacy-branches.ts
+++ b/scripts/cleanup-legacy-branches.ts
@@ -120,6 +120,7 @@ async function main() {
     slackKodiaiChannelId: "unused",
     slackDefaultRepo: "unused",
     slackAssistantModel: "unused",
+    slackWebhookRelaySources: [],
     port: 3000,
     logLevel: "info",
     botAllowList: [],

--- a/scripts/cleanup-wiki-issue.ts
+++ b/scripts/cleanup-wiki-issue.ts
@@ -164,6 +164,7 @@ async function main() {
     slackKodiaiChannelId: "unused",
     slackDefaultRepo: "unused",
     slackAssistantModel: "unused",
+    slackWebhookRelaySources: [],
     port: 3000,
     logLevel: "info",
     botAllowList: [],

--- a/scripts/publish-wiki-updates.ts
+++ b/scripts/publish-wiki-updates.ts
@@ -154,6 +154,7 @@ async function main() {
       slackKodiaiChannelId: "unused",
       slackDefaultRepo: "xbmc/xbmc",
       slackAssistantModel: "unused",
+      slackWebhookRelaySources: [],
       port: 0,
       logLevel: process.env.LOG_LEVEL ?? "info",
       botAllowList: [],

--- a/scripts/sync-triage-reactions.ts
+++ b/scripts/sync-triage-reactions.ts
@@ -135,6 +135,7 @@ async function main(): Promise<void> {
         slackKodiaiChannelId: "unused",
         slackDefaultRepo: "xbmc/xbmc",
         slackAssistantModel: "unused",
+        slackWebhookRelaySources: [],
         port: 0,
         logLevel: "info",
         botAllowList: [],

--- a/scripts/verify-m029-s04.ts
+++ b/scripts/verify-m029-s04.ts
@@ -482,6 +482,7 @@ export async function buildM029S04ProofHarness(opts?: {
           slackKodiaiChannelId: "unused",
           slackDefaultRepo: "unused",
           slackAssistantModel: "unused",
+          slackWebhookRelaySources: [],
           port: 3000,
           logLevel: "silent",
           botAllowList: [],

--- a/scripts/verify-m044-s01.ts
+++ b/scripts/verify-m044-s01.ts
@@ -148,6 +148,7 @@ function buildGitHubAppConfig(repo: string, githubPrivateKey: string) {
     slackKodiaiChannelId: "unused",
     slackDefaultRepo: repo,
     slackAssistantModel: "unused",
+    slackWebhookRelaySources: [],
     port: 0,
     logLevel: "info",
     botAllowList: [],

--- a/scripts/verify-m049-s02.ts
+++ b/scripts/verify-m049-s02.ts
@@ -235,6 +235,7 @@ function buildGitHubAppConfig(repo: string, githubPrivateKey: string) {
     slackKodiaiChannelId: "unused",
     slackDefaultRepo: repo,
     slackAssistantModel: "unused",
+    slackWebhookRelaySources: [],
     port: 0,
     logLevel: "info",
     botAllowList: [],

--- a/scripts/verify-m052-s01.test.ts
+++ b/scripts/verify-m052-s01.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test";
+
+async function loadModule() {
+  return await import("./verify-m052-s01.ts");
+}
+
+describe("verify-m052-s01", () => {
+  test("evaluateM052S01 passes when accepted, suppressed, and malformed proofs match the contract", async () => {
+    const { evaluateM052S01 } = await loadModule();
+
+    const report = await evaluateM052S01({
+      generatedAt: "2026-04-19T04:00:00.000Z",
+    });
+
+    expect(report.command).toBe("verify:m052:s01");
+    expect(report.success).toBe(true);
+    expect(report.status_code).toBe("m052_s01_ok");
+    expect(report.checks.map((check) => [check.id, check.status])).toEqual([
+      ["M052-S01-ACCEPT", "pass"],
+      ["M052-S01-SUPPRESS", "pass"],
+      ["M052-S01-INVALID", "pass"],
+    ]);
+    expect(report.acceptedResult).toMatchObject({
+      verdict: "accept",
+      event: {
+        sourceId: "buildkite",
+        eventType: "build.failed",
+      },
+    });
+    expect(report.suppressedResult).toMatchObject({
+      verdict: "suppress",
+      reason: "text_excluded_substring",
+      sourceId: "buildkite",
+    });
+    expect(report.invalidResult).toEqual({
+      verdict: "invalid",
+      reason: "malformed_payload",
+      sourceId: "buildkite",
+      issues: ["text", "url"],
+    });
+  });
+
+  test("evaluateM052S01 fails loudly when the accepted fixture stops producing an accept verdict", async () => {
+    const { evaluateM052S01 } = await loadModule();
+
+    const report = await evaluateM052S01({
+      generatedAt: "2026-04-19T04:00:00.000Z",
+      acceptedPayload: {
+        eventType: "build.started",
+        title: "Build started",
+        summary: "CI started for xbmc/xbmc.",
+        url: "https://ci.example.test/builds/999",
+        text: "Build started for xbmc/xbmc.",
+      },
+    });
+
+    expect(report.success).toBe(false);
+    expect(report.status_code).toBe("m052_s01_contract_drift");
+    expect(report.checks.find((check) => check.id === "M052-S01-ACCEPT")).toMatchObject({
+      status: "fail",
+    });
+  });
+
+  test("main prints JSON when --json is passed", async () => {
+    const { main } = await loadModule();
+    const stdoutChunks: string[] = [];
+    const stderrChunks: string[] = [];
+
+    const exitCode = await main(["--json"], {
+      stdout: { write: (chunk: string) => void stdoutChunks.push(chunk) },
+      stderr: { write: (chunk: string) => void stderrChunks.push(chunk) },
+      evaluate: async (opts = {}) => ({
+        command: "verify:m052:s01",
+        generated_at: opts.generatedAt ?? "2026-04-19T04:00:00.000Z",
+        success: true,
+        status_code: "m052_s01_ok",
+        checks: [
+          { id: "M052-S01-ACCEPT", status: "pass", detail: "accepted fixture normalized" },
+        ],
+        acceptedResult: { verdict: "accept", event: { sourceId: "buildkite", targetChannel: "C", eventType: "build.failed", title: "t", summary: "s", url: "https://x.test", text: "failed", metadata: {}, filterMetadata: { eventTypes: [], textIncludes: [], textExcludes: [] } } },
+        suppressedResult: { verdict: "suppress", reason: "text_excluded_substring", sourceId: "buildkite", eventType: "build.failed", detail: "flaky" },
+        invalidResult: { verdict: "invalid", reason: "malformed_payload", sourceId: "buildkite", issues: ["text", "url"] },
+        issues: [],
+      }),
+    });
+
+    expect(exitCode).toBe(0);
+    expect(stderrChunks.join("")).toBe("");
+    expect(JSON.parse(stdoutChunks.join("")).status_code).toBe("m052_s01_ok");
+  });
+});

--- a/scripts/verify-m052-s01.ts
+++ b/scripts/verify-m052-s01.ts
@@ -1,0 +1,173 @@
+import { parseWebhookRelaySourcesEnv } from "../src/slack/webhook-relay-config.ts";
+import {
+  evaluateWebhookRelayPayload,
+  type WebhookRelayEvaluationResult,
+} from "../src/slack/webhook-relay.ts";
+
+export type M052S01StatusCode = "m052_s01_ok" | "m052_s01_contract_drift";
+export type M052S01CheckStatus = "pass" | "fail";
+
+export interface M052S01Check {
+  id: "M052-S01-ACCEPT" | "M052-S01-SUPPRESS" | "M052-S01-INVALID";
+  status: M052S01CheckStatus;
+  detail: string;
+}
+
+export interface M052S01Report {
+  command: "verify:m052:s01";
+  generated_at: string;
+  success: boolean;
+  status_code: M052S01StatusCode;
+  checks: M052S01Check[];
+  acceptedResult: WebhookRelayEvaluationResult;
+  suppressedResult: WebhookRelayEvaluationResult;
+  invalidResult: WebhookRelayEvaluationResult;
+  issues: string[];
+}
+
+function buildProofSource() {
+  return parseWebhookRelaySourcesEnv(
+    JSON.stringify([
+      {
+        id: "buildkite",
+        targetChannel: "C_BUILD_ALERTS",
+        auth: {
+          type: "header_secret",
+          headerName: "x-relay-secret",
+          secret: "super-secret",
+        },
+        filter: {
+          eventTypes: ["build.failed", "build.finished"],
+          textIncludes: ["failed"],
+          textExcludes: ["flaky"],
+        },
+      },
+    ]),
+  )[0]!;
+}
+
+async function loadFixture(name: "accepted" | "suppressed"): Promise<unknown> {
+  return await Bun.file(new URL(`../fixtures/slack-webhook-relay/${name}.json`, import.meta.url)).json();
+}
+
+function buildMalformedPayload(): unknown {
+  return {
+    eventType: "build.failed",
+    title: "Missing text",
+    summary: "This payload forgot the required text field.",
+    url: "not-a-url",
+  };
+}
+
+function buildCheck(input: {
+  id: M052S01Check["id"];
+  passed: boolean;
+  detail: string;
+}): M052S01Check {
+  return {
+    id: input.id,
+    status: input.passed ? "pass" : "fail",
+    detail: input.detail,
+  };
+}
+
+export async function evaluateM052S01(opts?: {
+  generatedAt?: string;
+  acceptedPayload?: unknown;
+  suppressedPayload?: unknown;
+  invalidPayload?: unknown;
+}): Promise<M052S01Report> {
+  const source = buildProofSource();
+  const acceptedPayload = opts?.acceptedPayload ?? await loadFixture("accepted");
+  const suppressedPayload = opts?.suppressedPayload ?? await loadFixture("suppressed");
+  const invalidPayload = opts?.invalidPayload ?? buildMalformedPayload();
+
+  const acceptedResult = evaluateWebhookRelayPayload({ source, payload: acceptedPayload });
+  const suppressedResult = evaluateWebhookRelayPayload({ source, payload: suppressedPayload });
+  const invalidResult = evaluateWebhookRelayPayload({ source, payload: invalidPayload });
+
+  const checks: M052S01Check[] = [
+    buildCheck({
+      id: "M052-S01-ACCEPT",
+      passed: acceptedResult.verdict === "accept",
+      detail: acceptedResult.verdict === "accept"
+        ? "accepted fixture normalized into the stable relay event shape"
+        : `expected accept verdict, got ${acceptedResult.verdict}`,
+    }),
+    buildCheck({
+      id: "M052-S01-SUPPRESS",
+      passed: suppressedResult.verdict === "suppress" && suppressedResult.reason === "text_excluded_substring",
+      detail: suppressedResult.verdict === "suppress" && suppressedResult.reason === "text_excluded_substring"
+        ? "suppressed fixture produced the expected exclusion-based suppression reason"
+        : `expected suppress/text_excluded_substring, got ${suppressedResult.verdict}`,
+    }),
+    buildCheck({
+      id: "M052-S01-INVALID",
+      passed: invalidResult.verdict === "invalid"
+        && invalidResult.reason === "malformed_payload"
+        && JSON.stringify(invalidResult.issues) === JSON.stringify(["text", "url"]),
+      detail: invalidResult.verdict === "invalid"
+        ? `invalid payload produced issues: ${invalidResult.issues.join(", ")}`
+        : `expected invalid/malformed_payload, got ${invalidResult.verdict}`,
+    }),
+  ];
+
+  const issues = checks.filter((check) => check.status === "fail").map((check) => `${check.id}: ${check.detail}`);
+
+  return {
+    command: "verify:m052:s01",
+    generated_at: opts?.generatedAt ?? new Date().toISOString(),
+    success: issues.length === 0,
+    status_code: issues.length === 0 ? "m052_s01_ok" : "m052_s01_contract_drift",
+    checks,
+    acceptedResult,
+    suppressedResult,
+    invalidResult,
+    issues,
+  };
+}
+
+function renderHumanReport(report: M052S01Report): string {
+  return [
+    "# verify:m052:s01",
+    "",
+    `status: ${report.status_code}`,
+    `success: ${report.success ? "yes" : "no"}`,
+    "",
+    "checks:",
+    ...report.checks.map((check) => `- [${check.status === "pass" ? "x" : " "}] ${check.id}: ${check.detail}`),
+    ...(report.issues.length > 0 ? ["", "issues:", ...report.issues.map((issue) => `- ${issue}`)] : []),
+    "",
+  ].join("\n");
+}
+
+export async function main(
+  args: string[] = process.argv.slice(2),
+  io?: {
+    stdout?: { write: (chunk: string) => void };
+    stderr?: { write: (chunk: string) => void };
+    evaluate?: typeof evaluateM052S01;
+  },
+): Promise<number> {
+  const stdout = io?.stdout ?? process.stdout;
+  const stderr = io?.stderr ?? process.stderr;
+  const evaluate = io?.evaluate ?? evaluateM052S01;
+
+  try {
+    const report = await evaluate({ generatedAt: new Date().toISOString() });
+    if (args.includes("--json")) {
+      stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    } else {
+      stdout.write(renderHumanReport(report));
+    }
+    return report.success ? 0 : 1;
+  } catch (error) {
+    stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    return 1;
+  }
+}
+
+if (import.meta.main) {
+  const exitCode = await main();
+  process.exit(exitCode);
+}

--- a/scripts/verify-m052-s02.test.ts
+++ b/scripts/verify-m052-s02.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+
+async function loadModule() {
+  return await import("./verify-m052-s02.ts");
+}
+
+describe("verify-m052-s02", () => {
+  test("evaluateM052S02 proves delivered, suppressed, and failed-delivery route outcomes", async () => {
+    const { evaluateM052S02 } = await loadModule();
+
+    const report = await evaluateM052S02({
+      generatedAt: "2026-04-19T05:00:00.000Z",
+    });
+
+    expect(report.command).toBe("verify:m052:s02");
+    expect(report.success).toBe(true);
+    expect(report.status_code).toBe("m052_s02_ok");
+    expect(report.checks.map((check) => [check.id, check.status])).toEqual([
+      ["M052-S02-DELIVERED", "pass"],
+      ["M052-S02-SUPPRESSED", "pass"],
+      ["M052-S02-DELIVERY-FAILED", "pass"],
+    ]);
+    expect(report.delivered.status).toBe(202);
+    expect(report.suppressed.status).toBe(202);
+    expect(report.deliveryFailed.status).toBe(502);
+  });
+
+  test("evaluateM052S02 fails loudly when the delivered case stops returning an accept verdict", async () => {
+    const { evaluateM052S02 } = await loadModule();
+
+    const report = await evaluateM052S02({
+      generatedAt: "2026-04-19T05:00:00.000Z",
+      acceptedPayload: {
+        eventType: "build.started",
+        title: "Build started",
+        summary: "CI started for xbmc/xbmc.",
+        url: "https://ci.example.test/builds/999",
+        text: "Build started for xbmc/xbmc.",
+      },
+    });
+
+    expect(report.success).toBe(false);
+    expect(report.status_code).toBe("m052_s02_integration_drift");
+    expect(report.checks.find((check) => check.id === "M052-S02-DELIVERED")).toMatchObject({
+      status: "fail",
+    });
+  });
+
+  test("main prints JSON when --json is passed", async () => {
+    const { main } = await loadModule();
+    const stdoutChunks: string[] = [];
+    const stderrChunks: string[] = [];
+
+    const exitCode = await main(["--json"], {
+      stdout: { write: (chunk: string) => void stdoutChunks.push(chunk) },
+      stderr: { write: (chunk: string) => void stderrChunks.push(chunk) },
+      evaluate: async (opts = {}) => ({
+        command: "verify:m052:s02",
+        generated_at: opts.generatedAt ?? "2026-04-19T05:00:00.000Z",
+        success: true,
+        status_code: "m052_s02_ok",
+        checks: [
+          { id: "M052-S02-DELIVERED", status: "pass", detail: "delivered" },
+        ],
+        delivered: { status: 202, body: { ok: true, verdict: "accept" } },
+        suppressed: { status: 202, body: { ok: true, verdict: "suppress" } },
+        deliveryFailed: { status: 502, body: { ok: false, reason: "delivery_failed" } },
+        issues: [],
+      }),
+    });
+
+    expect(exitCode).toBe(0);
+    expect(stderrChunks.join("")).toBe("");
+    expect(JSON.parse(stdoutChunks.join("")).status_code).toBe("m052_s02_ok");
+  });
+});

--- a/scripts/verify-m052-s02.ts
+++ b/scripts/verify-m052-s02.ts
@@ -1,0 +1,268 @@
+import { Hono } from "hono";
+import type { AppConfig } from "../src/config.ts";
+import { createSlackRelayWebhookRoutes } from "../src/routes/slack-relay-webhooks.ts";
+import { parseWebhookRelaySourcesEnv } from "../src/slack/webhook-relay-config.ts";
+import { deliverWebhookRelayEvent } from "../src/slack/webhook-relay-delivery.ts";
+import type { SlackClient } from "../src/slack/client.ts";
+import type { NormalizedWebhookRelayEvent } from "../src/slack/webhook-relay.ts";
+
+export type M052S02StatusCode = "m052_s02_ok" | "m052_s02_integration_drift";
+export type M052S02CheckStatus = "pass" | "fail";
+
+export interface M052S02Check {
+  id: "M052-S02-DELIVERED" | "M052-S02-SUPPRESSED" | "M052-S02-DELIVERY-FAILED";
+  status: M052S02CheckStatus;
+  detail: string;
+}
+
+export interface RouteSnapshot {
+  status: number;
+  body: unknown;
+}
+
+export interface M052S02Report {
+  command: "verify:m052:s02";
+  generated_at: string;
+  success: boolean;
+  status_code: M052S02StatusCode;
+  checks: M052S02Check[];
+  delivered: RouteSnapshot;
+  suppressed: RouteSnapshot;
+  deliveryFailed: RouteSnapshot;
+  issues: string[];
+}
+
+function createSilentLogger() {
+  const logger = {
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+    debug: () => undefined,
+    trace: () => undefined,
+    fatal: () => undefined,
+    child: () => logger,
+  };
+
+  return logger;
+}
+
+function buildProofConfig(): AppConfig {
+  return {
+    githubAppId: "12345",
+    githubPrivateKey: "-----BEGIN PRIVATE KEY-----\nTEST\n-----END PRIVATE KEY-----",
+    webhookSecret: "webhook-secret",
+    slackSigningSecret: "slack-signing-secret",
+    slackBotToken: "xoxb-test-token",
+    slackBotUserId: "U123BOT",
+    slackKodiaiChannelId: "C123KODIAI",
+    slackDefaultRepo: "xbmc/xbmc",
+    slackAssistantModel: "claude-3-5-haiku-latest",
+    slackWebhookRelaySources: parseWebhookRelaySourcesEnv(
+      JSON.stringify([
+        {
+          id: "buildkite",
+          targetChannel: "C_BUILD_ALERTS",
+          auth: {
+            type: "header_secret",
+            headerName: "x-relay-secret",
+            secret: "super-secret",
+          },
+          filter: {
+            eventTypes: ["build.failed", "build.finished"],
+            textIncludes: ["failed"],
+            textExcludes: ["flaky"],
+          },
+        },
+      ]),
+    ),
+    port: 3000,
+    logLevel: "info",
+    botAllowList: [],
+    slackWikiChannelId: "",
+    wikiStalenessThresholdDays: 30,
+    wikiGithubOwner: "xbmc",
+    wikiGithubRepo: "xbmc",
+    botUserLogin: "",
+    botUserPat: "",
+    addonRepos: [],
+    mcpInternalBaseUrl: "",
+    acaJobImage: "",
+    acaResourceGroup: "rg-kodiai",
+    acaJobName: "caj-kodiai-agent",
+  };
+}
+
+async function loadFixture(name: "accepted" | "suppressed"): Promise<unknown> {
+  return await Bun.file(new URL(`../fixtures/slack-webhook-relay/${name}.json`, import.meta.url)).json();
+}
+
+function buildApp(params: {
+  postStandaloneMessage: (input: { channel: string; text: string }) => Promise<{ ts: string }>;
+}): Hono {
+  const slackClient: SlackClient = {
+    postStandaloneMessage: params.postStandaloneMessage,
+    postThreadMessage: async () => undefined,
+    addReaction: async () => undefined,
+    removeReaction: async () => undefined,
+    getTokenScopes: async () => [],
+  };
+
+  const app = new Hono();
+  app.route(
+    "/webhooks/slack/relay",
+    createSlackRelayWebhookRoutes({
+      config: buildProofConfig(),
+      logger: createSilentLogger() as never,
+      onAcceptedRelay: async (event: NormalizedWebhookRelayEvent) => {
+        await deliverWebhookRelayEvent({
+          slackClient,
+          event,
+        });
+      },
+    }),
+  );
+  return app;
+}
+
+async function postRelay(app: Hono, payload: unknown): Promise<RouteSnapshot> {
+  const response = await app.request("http://localhost/webhooks/slack/relay/buildkite", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-relay-secret": "super-secret",
+    },
+    body: JSON.stringify(payload),
+  });
+
+  return {
+    status: response.status,
+    body: await response.json(),
+  };
+}
+
+function buildCheck(input: { id: M052S02Check["id"]; passed: boolean; detail: string }): M052S02Check {
+  return {
+    id: input.id,
+    status: input.passed ? "pass" : "fail",
+    detail: input.detail,
+  };
+}
+
+export async function evaluateM052S02(opts?: {
+  generatedAt?: string;
+  acceptedPayload?: unknown;
+  suppressedPayload?: unknown;
+}): Promise<M052S02Report> {
+  const acceptedPayload = opts?.acceptedPayload ?? await loadFixture("accepted");
+  const suppressedPayload = opts?.suppressedPayload ?? await loadFixture("suppressed");
+
+  const delivered = await postRelay(
+    buildApp({
+      postStandaloneMessage: async () => ({ ts: "1700000000.000100" }),
+    }),
+    acceptedPayload,
+  );
+
+  const suppressed = await postRelay(
+    buildApp({
+      postStandaloneMessage: async () => ({ ts: "1700000000.000100" }),
+    }),
+    suppressedPayload,
+  );
+
+  const deliveryFailed = await postRelay(
+    buildApp({
+      postStandaloneMessage: async () => {
+        throw new Error("slack unavailable");
+      },
+    }),
+    acceptedPayload,
+  );
+
+  const checks: M052S02Check[] = [
+    buildCheck({
+      id: "M052-S02-DELIVERED",
+      passed: delivered.status === 202
+        && (delivered.body as Record<string, unknown>).verdict === "accept",
+      detail: delivered.status === 202
+        ? "accepted relay request returned the delivered/accept response"
+        : `expected 202 accept response, got ${delivered.status}`,
+    }),
+    buildCheck({
+      id: "M052-S02-SUPPRESSED",
+      passed: suppressed.status === 202
+        && (suppressed.body as Record<string, unknown>).verdict === "suppress"
+        && (suppressed.body as Record<string, unknown>).reason === "text_excluded_substring",
+      detail: suppressed.status === 202
+        ? "suppressed relay request returned the explicit suppression response"
+        : `expected 202 suppress response, got ${suppressed.status}`,
+    }),
+    buildCheck({
+      id: "M052-S02-DELIVERY-FAILED",
+      passed: deliveryFailed.status === 502
+        && (deliveryFailed.body as Record<string, unknown>).reason === "delivery_failed",
+      detail: deliveryFailed.status === 502
+        ? "delivery failure returned the explicit relay failure response"
+        : `expected 502 delivery_failed response, got ${deliveryFailed.status}`,
+    }),
+  ];
+
+  const issues = checks.filter((check) => check.status === "fail").map((check) => `${check.id}: ${check.detail}`);
+
+  return {
+    command: "verify:m052:s02",
+    generated_at: opts?.generatedAt ?? new Date().toISOString(),
+    success: issues.length === 0,
+    status_code: issues.length === 0 ? "m052_s02_ok" : "m052_s02_integration_drift",
+    checks,
+    delivered,
+    suppressed,
+    deliveryFailed,
+    issues,
+  };
+}
+
+function renderHumanReport(report: M052S02Report): string {
+  return [
+    "# verify:m052:s02",
+    "",
+    `status: ${report.status_code}`,
+    `success: ${report.success ? "yes" : "no"}`,
+    "",
+    "checks:",
+    ...report.checks.map((check) => `- [${check.status === "pass" ? "x" : " "}] ${check.id}: ${check.detail}`),
+    ...(report.issues.length > 0 ? ["", "issues:", ...report.issues.map((issue) => `- ${issue}`)] : []),
+    "",
+  ].join("\n");
+}
+
+export async function main(
+  args: string[] = process.argv.slice(2),
+  io?: {
+    stdout?: { write: (chunk: string) => void };
+    stderr?: { write: (chunk: string) => void };
+    evaluate?: typeof evaluateM052S02;
+  },
+): Promise<number> {
+  const stdout = io?.stdout ?? process.stdout;
+  const stderr = io?.stderr ?? process.stderr;
+  const evaluate = io?.evaluate ?? evaluateM052S02;
+
+  try {
+    const report = await evaluate({ generatedAt: new Date().toISOString() });
+    if (args.includes("--json")) {
+      stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    } else {
+      stdout.write(renderHumanReport(report));
+    }
+    return report.success ? 0 : 1;
+  } catch (error) {
+    stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    return 1;
+  }
+}
+
+if (import.meta.main) {
+  const exitCode = await main();
+  process.exit(exitCode);
+}

--- a/scripts/verify-m052.test.ts
+++ b/scripts/verify-m052.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+
+async function loadModule() {
+  return await import("./verify-m052.ts");
+}
+
+describe("verify-m052", () => {
+  test("evaluateM052 composes the S01 and S02 proof surfaces", async () => {
+    const { evaluateM052 } = await loadModule();
+
+    const report = await evaluateM052({
+      generatedAt: "2026-04-19T06:00:00.000Z",
+    });
+
+    expect(report.command).toBe("verify:m052");
+    expect(report.overallPassed).toBe(true);
+    expect(report.status_code).toBe("m052_ok");
+    expect(report.checks.map((check) => [check.id, check.passed])).toEqual([
+      ["M052-S03-S01-PROOF", true],
+      ["M052-S03-S02-PROOF", true],
+    ]);
+    expect(report.s01?.status_code).toBe("m052_s01_ok");
+    expect(report.s02?.status_code).toBe("m052_s02_ok");
+  });
+
+  test("evaluateM052 fails when the nested S02 proof drifts", async () => {
+    const { evaluateM052 } = await loadModule();
+
+    const report = await evaluateM052({
+      generatedAt: "2026-04-19T06:00:00.000Z",
+      _evaluateS02: async () => ({
+        command: "verify:m052:s02",
+        generated_at: "2026-04-19T06:00:00.000Z",
+        success: false,
+        status_code: "m052_s02_integration_drift",
+        checks: [],
+        delivered: { status: 202, body: { ok: true } },
+        suppressed: { status: 202, body: { ok: true } },
+        deliveryFailed: { status: 502, body: { ok: false } },
+        issues: ["drift"],
+      }),
+    });
+
+    expect(report.overallPassed).toBe(false);
+    expect(report.status_code).toBe("m052_proof_drift");
+    expect(report.checks.find((check) => check.id === "M052-S03-S02-PROOF")).toMatchObject({
+      passed: false,
+    });
+  });
+
+  test("package.json wires verify:m052 to the milestone proof script", async () => {
+    const packageJson = await Bun.file(new URL("../package.json", import.meta.url)).json() as {
+      scripts?: Record<string, string>;
+    };
+
+    expect(packageJson.scripts?.["verify:m052"]).toBe("bun scripts/verify-m052.ts");
+  });
+
+  test("main prints JSON when --json is passed", async () => {
+    const { main } = await loadModule();
+    const stdoutChunks: string[] = [];
+    const stderrChunks: string[] = [];
+
+    const exitCode = await main(["--json"], {
+      stdout: { write: (chunk: string) => void stdoutChunks.push(chunk) },
+      stderr: { write: (chunk: string) => void stderrChunks.push(chunk) },
+      evaluate: async () => ({
+        command: "verify:m052",
+        generatedAt: "2026-04-19T06:00:00.000Z",
+        overallPassed: true,
+        status_code: "m052_ok",
+        checks: [
+          { id: "M052-S03-S01-PROOF", passed: true, detail: "ok" },
+          { id: "M052-S03-S02-PROOF", passed: true, detail: "ok" },
+        ],
+        s01: null,
+        s02: null,
+        issues: [],
+      }),
+    });
+
+    expect(exitCode).toBe(0);
+    expect(stderrChunks.join("")).toBe("");
+    expect(JSON.parse(stdoutChunks.join("")).status_code).toBe("m052_ok");
+  });
+});

--- a/scripts/verify-m052.ts
+++ b/scripts/verify-m052.ts
@@ -1,0 +1,125 @@
+import {
+  evaluateM052S01,
+  type M052S01Report,
+} from "./verify-m052-s01.ts";
+import {
+  evaluateM052S02,
+  type M052S02Report,
+} from "./verify-m052-s02.ts";
+
+export type M052CheckId = "M052-S03-S01-PROOF" | "M052-S03-S02-PROOF";
+
+export interface M052Check {
+  id: M052CheckId;
+  passed: boolean;
+  detail: string;
+}
+
+export interface M052Report {
+  command: "verify:m052";
+  generatedAt: string;
+  overallPassed: boolean;
+  status_code: "m052_ok" | "m052_proof_drift";
+  checks: M052Check[];
+  s01: M052S01Report | null;
+  s02: M052S02Report | null;
+  issues: string[];
+}
+
+function buildCheck(input: { id: M052CheckId; passed: boolean; detail: string }): M052Check {
+  return {
+    id: input.id,
+    passed: input.passed,
+    detail: input.detail,
+  };
+}
+
+export async function evaluateM052(opts?: {
+  generatedAt?: string;
+  _evaluateS01?: typeof evaluateM052S01;
+  _evaluateS02?: typeof evaluateM052S02;
+}): Promise<M052Report> {
+  const generatedAt = opts?.generatedAt ?? new Date().toISOString();
+  const evaluateS01Impl = opts?._evaluateS01 ?? evaluateM052S01;
+  const evaluateS02Impl = opts?._evaluateS02 ?? evaluateM052S02;
+
+  const [s01, s02] = await Promise.all([
+    evaluateS01Impl({ generatedAt }),
+    evaluateS02Impl({ generatedAt }),
+  ]);
+
+  const checks: M052Check[] = [
+    buildCheck({
+      id: "M052-S03-S01-PROOF",
+      passed: s01.success,
+      detail: s01.success
+        ? `S01 proof passed with status ${s01.status_code}`
+        : `S01 proof drifted with status ${s01.status_code}`,
+    }),
+    buildCheck({
+      id: "M052-S03-S02-PROOF",
+      passed: s02.success,
+      detail: s02.success
+        ? `S02 proof passed with status ${s02.status_code}`
+        : `S02 proof drifted with status ${s02.status_code}`,
+    }),
+  ];
+
+  const issues = checks.filter((check) => !check.passed).map((check) => `${check.id}: ${check.detail}`);
+
+  return {
+    command: "verify:m052",
+    generatedAt,
+    overallPassed: issues.length === 0,
+    status_code: issues.length === 0 ? "m052_ok" : "m052_proof_drift",
+    checks,
+    s01,
+    s02,
+    issues,
+  };
+}
+
+function renderHumanReport(report: M052Report): string {
+  return [
+    "# verify:m052",
+    "",
+    `status: ${report.status_code}`,
+    `overallPassed: ${report.overallPassed ? "yes" : "no"}`,
+    "",
+    "checks:",
+    ...report.checks.map((check) => `- [${check.passed ? "x" : " "}] ${check.id}: ${check.detail}`),
+    ...(report.issues.length > 0 ? ["", "issues:", ...report.issues.map((issue) => `- ${issue}`)] : []),
+    "",
+  ].join("\n");
+}
+
+export async function main(
+  args: string[] = process.argv.slice(2),
+  io?: {
+    stdout?: { write: (chunk: string) => void };
+    stderr?: { write: (chunk: string) => void };
+    evaluate?: typeof evaluateM052;
+  },
+): Promise<number> {
+  const stdout = io?.stdout ?? process.stdout;
+  const stderr = io?.stderr ?? process.stderr;
+  const evaluate = io?.evaluate ?? evaluateM052;
+
+  try {
+    const report = await evaluate({ generatedAt: new Date().toISOString() });
+    if (args.includes("--json")) {
+      stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    } else {
+      stdout.write(renderHumanReport(report));
+    }
+    return report.overallPassed ? 0 : 1;
+  } catch (error) {
+    stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    return 1;
+  }
+}
+
+if (import.meta.main) {
+  const exitCode = await main();
+  process.exit(exitCode);
+}

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -22,6 +22,8 @@ beforeEach(() => {
   }
   savedEnv.MCP_INTERNAL_BASE_URL = process.env.MCP_INTERNAL_BASE_URL;
   delete process.env.MCP_INTERNAL_BASE_URL;
+  savedEnv.SLACK_WEBHOOK_RELAY_SOURCES = process.env.SLACK_WEBHOOK_RELAY_SOURCES;
+  delete process.env.SLACK_WEBHOOK_RELAY_SOURCES;
 });
 
 afterEach(() => {
@@ -38,5 +40,44 @@ describe("loadConfig", () => {
   test("defaults MCP internal base URL to the internal ACA app host without the external route suffix or port", async () => {
     const config = await loadConfig();
     expect(config.mcpInternalBaseUrl).toBe("http://ca-kodiai");
+    expect(config.slackWebhookRelaySources).toEqual([]);
+  });
+
+  test("parses Slack webhook relay sources from app config", async () => {
+    process.env.SLACK_WEBHOOK_RELAY_SOURCES = JSON.stringify([
+      {
+        id: "buildkite",
+        targetChannel: "C_BUILD_ALERTS",
+        auth: {
+          type: "header_secret",
+          headerName: "x-relay-secret",
+          secret: "super-secret",
+        },
+        filter: {
+          eventTypes: ["build.failed"],
+          textIncludes: ["failed"],
+          textExcludes: ["flaky"],
+        },
+      },
+    ]);
+
+    const config = await loadConfig();
+
+    expect(config.slackWebhookRelaySources).toEqual([
+      {
+        id: "buildkite",
+        targetChannel: "C_BUILD_ALERTS",
+        auth: {
+          type: "header_secret",
+          headerName: "x-relay-secret",
+          secret: "super-secret",
+        },
+        filter: {
+          eventTypes: ["build.failed"],
+          textIncludes: ["failed"],
+          textExcludes: ["flaky"],
+        },
+      },
+    ]);
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,8 @@
 import { z } from "zod";
+import {
+  parseWebhookRelaySourcesEnv,
+  webhookRelaySourceSchema,
+} from "./slack/webhook-relay-config.ts";
 
 const configSchema = z.object({
   githubAppId: z.string().min(1, "GITHUB_APP_ID is required"),
@@ -10,6 +14,7 @@ const configSchema = z.object({
   slackKodiaiChannelId: z.string().min(1, "SLACK_KODIAI_CHANNEL_ID is required"),
   slackDefaultRepo: z.string().default("xbmc/xbmc"),
   slackAssistantModel: z.string().default("claude-3-5-haiku-latest"),
+  slackWebhookRelaySources: z.array(webhookRelaySourceSchema).default([]),
   port: z.coerce.number().default(3000),
   logLevel: z.string().default("info"),
   botAllowList: z
@@ -87,6 +92,16 @@ export async function loadConfig(): Promise<AppConfig> {
     process.exit(1);
   }
 
+  let slackWebhookRelaySources;
+  try {
+    slackWebhookRelaySources = parseWebhookRelaySourcesEnv(process.env.SLACK_WEBHOOK_RELAY_SOURCES);
+  } catch (err) {
+    console.error(
+      `FATAL: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    process.exit(1);
+  }
+
   const result = configSchema.safeParse({
     githubAppId: process.env.GITHUB_APP_ID,
     githubPrivateKey: privateKey,
@@ -97,6 +112,7 @@ export async function loadConfig(): Promise<AppConfig> {
     slackKodiaiChannelId: process.env.SLACK_KODIAI_CHANNEL_ID,
     slackDefaultRepo: process.env.SLACK_DEFAULT_REPO,
     slackAssistantModel: process.env.SLACK_ASSISTANT_MODEL,
+    slackWebhookRelaySources,
     port: process.env.PORT,
     logLevel: process.env.LOG_LEVEL,
     botAllowList: process.env.BOT_ALLOW_LIST,

--- a/src/contributor/xbmc-fixture-refresh.ts
+++ b/src/contributor/xbmc-fixture-refresh.ts
@@ -1014,6 +1014,7 @@ function buildGitHubAppConfig(repository: string, privateKey: string) {
     slackKodiaiChannelId: "unused",
     slackDefaultRepo: repository,
     slackAssistantModel: "unused",
+    slackWebhookRelaySources: [],
     port: 0,
     logLevel: "info",
     botAllowList: [],

--- a/src/execution/executor.test.ts
+++ b/src/execution/executor.test.ts
@@ -97,6 +97,7 @@ function makeConfig(overrides?: Partial<AppConfig>): AppConfig {
     slackKodiaiChannelId: "C123",
     slackDefaultRepo: "xbmc/xbmc",
     slackAssistantModel: "claude-3-5-haiku-latest",
+    slackWebhookRelaySources: [],
     port: 3000,
     logLevel: "info",
     botAllowList: [],

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,9 @@ import { createDbClient, type Sql } from "./db/client.ts";
 import { runMigrations } from "./db/migrate.ts";
 import { createContributorProfileStore } from "./contributor/index.ts";
 import { createSlackCommandRoutes } from "./routes/slack-commands.ts";
+import { createSlackRelayWebhookRoutes } from "./routes/slack-relay-webhooks.ts";
 import { createSlackClient } from "./slack/client.ts";
+import { deliverWebhookRelayEvent } from "./slack/webhook-relay-delivery.ts";
 import { createSlackAssistantHandler } from "./slack/assistant-handler.ts";
 import { createSlackWriteRunner } from "./slack/write-runner.ts";
 import { createRequestTracker } from "./lifecycle/request-tracker.ts";
@@ -542,6 +544,16 @@ const app = new Hono();
 
 // Mount routes
 app.route("/webhooks", createWebhookRoutes({ config, logger, dedup, githubApp, eventRouter, requestTracker, webhookQueueStore, shutdownManager }));
+app.route("/webhooks/slack/relay", createSlackRelayWebhookRoutes({
+  config,
+  logger,
+  onAcceptedRelay: async (event) => {
+    await deliverWebhookRelayEvent({
+      slackClient,
+      event,
+    });
+  },
+}));
 app.route("/webhooks/slack", createSlackEventRoutes({
   config,
   logger,

--- a/src/routes/slack-commands.test.ts
+++ b/src/routes/slack-commands.test.ts
@@ -38,6 +38,7 @@ function createTestConfig(): AppConfig {
     slackKodiaiChannelId: "C123KODIAI",
     slackDefaultRepo: "xbmc/xbmc",
     slackAssistantModel: "claude-3-5-haiku-latest",
+    slackWebhookRelaySources: [],
     port: 3000,
     logLevel: "info",
     botAllowList: [],

--- a/src/routes/slack-events.test.ts
+++ b/src/routes/slack-events.test.ts
@@ -31,6 +31,7 @@ function createTestConfig(): AppConfig {
     slackKodiaiChannelId: "C123KODIAI",
     slackDefaultRepo: "xbmc/xbmc",
     slackAssistantModel: "claude-3-5-haiku-latest",
+    slackWebhookRelaySources: [],
     port: 3000,
     logLevel: "info",
     botAllowList: [],

--- a/src/routes/slack-relay-webhooks.test.ts
+++ b/src/routes/slack-relay-webhooks.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import type { Logger } from "pino";
+import type { AppConfig } from "../config.ts";
+import { parseWebhookRelaySourcesEnv } from "../slack/webhook-relay-config.ts";
+import type { NormalizedWebhookRelayEvent } from "../slack/webhook-relay.ts";
+import { createSlackRelayWebhookRoutes } from "./slack-relay-webhooks.ts";
+
+function createTestLogger(): Logger {
+  return {
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+    debug: () => undefined,
+    trace: () => undefined,
+    fatal: () => undefined,
+    child: () => createTestLogger(),
+  } as unknown as Logger;
+}
+
+function createTestConfig(): AppConfig {
+  return {
+    githubAppId: "12345",
+    githubPrivateKey: "-----BEGIN PRIVATE KEY-----\nTEST\n-----END PRIVATE KEY-----",
+    webhookSecret: "webhook-secret",
+    slackSigningSecret: "slack-signing-secret",
+    slackBotToken: "xoxb-test-token",
+    slackBotUserId: "U123BOT",
+    slackKodiaiChannelId: "C123KODIAI",
+    slackDefaultRepo: "xbmc/xbmc",
+    slackAssistantModel: "claude-3-5-haiku-latest",
+    slackWebhookRelaySources: parseWebhookRelaySourcesEnv(
+      JSON.stringify([
+        {
+          id: "buildkite",
+          targetChannel: "C_BUILD_ALERTS",
+          auth: {
+            type: "header_secret",
+            headerName: "x-relay-secret",
+            secret: "super-secret",
+          },
+          filter: {
+            eventTypes: ["build.failed", "build.finished"],
+            textIncludes: ["failed"],
+            textExcludes: ["flaky"],
+          },
+        },
+      ]),
+    ),
+    port: 3000,
+    logLevel: "info",
+    botAllowList: [],
+    slackWikiChannelId: "",
+    wikiStalenessThresholdDays: 30,
+    wikiGithubOwner: "xbmc",
+    wikiGithubRepo: "xbmc",
+    botUserLogin: "",
+    botUserPat: "",
+    addonRepos: [],
+    mcpInternalBaseUrl: "",
+    acaJobImage: "",
+    acaResourceGroup: "rg-kodiai",
+    acaJobName: "caj-kodiai-agent",
+  };
+}
+
+async function readFixture(name: "accepted" | "suppressed") {
+  return await Bun.file(new URL(`../../fixtures/slack-webhook-relay/${name}.json`, import.meta.url)).text();
+}
+
+function createApp(onAcceptedRelay?: (event: NormalizedWebhookRelayEvent) => void) {
+  const app = new Hono();
+  app.route(
+    "/webhooks/slack/relay",
+    createSlackRelayWebhookRoutes({
+      config: createTestConfig(),
+      logger: createTestLogger(),
+      onAcceptedRelay,
+    }),
+  );
+  return app;
+}
+
+describe("createSlackRelayWebhookRoutes", () => {
+  test("rejects unknown relay sources", async () => {
+    const app = createApp();
+    const payload = await readFixture("accepted");
+
+    const response = await app.request("http://localhost/webhooks/slack/relay/unknown", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-relay-secret": "super-secret",
+      },
+      body: payload,
+    });
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ ok: false, reason: "unknown_source" });
+  });
+
+  test("rejects requests whose source secret is missing or wrong", async () => {
+    const app = createApp();
+    const payload = await readFixture("accepted");
+
+    const response = await app.request("http://localhost/webhooks/slack/relay/buildkite", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-relay-secret": "wrong-secret",
+      },
+      body: payload,
+    });
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ ok: false, reason: "invalid_source_auth" });
+  });
+
+  test("returns explicit invalid diagnostics for non-JSON request bodies", async () => {
+    const app = createApp();
+
+    const response = await app.request("http://localhost/webhooks/slack/relay/buildkite", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-relay-secret": "super-secret",
+      },
+      body: "{",
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ ok: false, reason: "invalid_json" });
+  });
+
+  test("acknowledges suppressed payloads without calling the accepted callback", async () => {
+    const acceptedEvents: NormalizedWebhookRelayEvent[] = [];
+    const app = createApp((event) => acceptedEvents.push(event));
+    const payload = await readFixture("suppressed");
+
+    const response = await app.request("http://localhost/webhooks/slack/relay/buildkite", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-relay-secret": "super-secret",
+      },
+      body: payload,
+    });
+
+    expect(response.status).toBe(202);
+    expect(await response.json()).toEqual({
+      ok: true,
+      verdict: "suppress",
+      reason: "text_excluded_substring",
+      sourceId: "buildkite",
+      eventType: "build.failed",
+      detail: "flaky",
+    });
+    expect(acceptedEvents).toEqual([]);
+  });
+
+  test("accepts verified payloads and forwards the normalized relay event", async () => {
+    const acceptedEvents: NormalizedWebhookRelayEvent[] = [];
+    const app = createApp((event) => acceptedEvents.push(event));
+    const payload = await readFixture("accepted");
+
+    const response = await app.request("http://localhost/webhooks/slack/relay/buildkite", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-relay-secret": "super-secret",
+      },
+      body: payload,
+    });
+
+    expect(response.status).toBe(202);
+    expect(await response.json()).toEqual({
+      ok: true,
+      verdict: "accept",
+      sourceId: "buildkite",
+      eventType: "build.failed",
+      targetChannel: "C_BUILD_ALERTS",
+    });
+    expect(acceptedEvents).toEqual([
+      {
+        sourceId: "buildkite",
+        targetChannel: "C_BUILD_ALERTS",
+        eventType: "build.failed",
+        title: "Build failed on main",
+        summary: "CI failed for xbmc/xbmc after the latest merge.",
+        url: "https://ci.example.test/builds/123",
+        text: "Build failed for xbmc/xbmc on main after merge 09f28d7.",
+        metadata: {
+          pipeline: "main",
+          provider: "buildkite",
+        },
+        filterMetadata: {
+          eventTypes: ["build.failed", "build.finished"],
+          textIncludes: ["failed"],
+          textExcludes: ["flaky"],
+        },
+      },
+    ]);
+  });
+
+  test("returns an explicit delivery failure when accepted relay delivery throws", async () => {
+    const app = createApp(async () => {
+      throw new Error("slack unavailable");
+    });
+    const payload = await readFixture("accepted");
+
+    const response = await app.request("http://localhost/webhooks/slack/relay/buildkite", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-relay-secret": "super-secret",
+      },
+      body: payload,
+    });
+
+    expect(response.status).toBe(502);
+    expect(await response.json()).toEqual({
+      ok: false,
+      reason: "delivery_failed",
+      sourceId: "buildkite",
+      eventType: "build.failed",
+    });
+  });
+});

--- a/src/routes/slack-relay-webhooks.ts
+++ b/src/routes/slack-relay-webhooks.ts
@@ -1,0 +1,94 @@
+import { timingSafeEqual } from "node:crypto";
+import { Hono } from "hono";
+import type { Logger } from "pino";
+import type { AppConfig } from "../config.ts";
+import {
+  evaluateWebhookRelayPayload,
+  type NormalizedWebhookRelayEvent,
+} from "../slack/webhook-relay.ts";
+
+interface SlackRelayWebhookRouteDeps {
+  config: AppConfig;
+  logger: Logger;
+  onAcceptedRelay?: (event: NormalizedWebhookRelayEvent) => Promise<void> | void;
+}
+
+function secretsMatch(expected: string, provided: string | undefined): boolean {
+  if (!provided) {
+    return false;
+  }
+
+  const expectedBuffer = Buffer.from(expected);
+  const providedBuffer = Buffer.from(provided);
+
+  if (expectedBuffer.length !== providedBuffer.length) {
+    return false;
+  }
+
+  return timingSafeEqual(expectedBuffer, providedBuffer);
+}
+
+export function createSlackRelayWebhookRoutes(deps: SlackRelayWebhookRouteDeps): Hono {
+  const { config, logger, onAcceptedRelay } = deps;
+  const app = new Hono();
+
+  app.post("/:sourceId", async (c) => {
+    const sourceId = c.req.param("sourceId");
+    const source = config.slackWebhookRelaySources.find((candidate) => candidate.id === sourceId);
+
+    if (!source) {
+      logger.warn({ sourceId }, "Slack relay webhook rejected: unknown source");
+      return c.json({ ok: false, reason: "unknown_source" }, 404);
+    }
+
+    const providedSecret = c.req.header(source.auth.headerName);
+    if (!secretsMatch(source.auth.secret, providedSecret)) {
+      logger.warn({ sourceId }, "Slack relay webhook rejected: invalid source auth");
+      return c.json({ ok: false, reason: "invalid_source_auth" }, 401);
+    }
+
+    const rawBody = await c.req.text();
+    let payload: unknown;
+    try {
+      payload = JSON.parse(rawBody) as unknown;
+    } catch {
+      logger.warn({ sourceId }, "Slack relay webhook rejected: invalid JSON");
+      return c.json({ ok: false, reason: "invalid_json" }, 400);
+    }
+
+    const result = evaluateWebhookRelayPayload({ source, payload });
+
+    if (result.verdict === "invalid") {
+      logger.warn({ sourceId, issues: result.issues }, "Slack relay webhook rejected: malformed payload");
+      return c.json({ ok: false, reason: result.reason, issues: result.issues }, 400);
+    }
+
+    if (result.verdict === "suppress") {
+      logger.info({ sourceId, reason: result.reason, eventType: result.eventType, detail: result.detail }, "Slack relay webhook suppressed by filter");
+      return c.json({ ok: true, ...result }, 202);
+    }
+
+    try {
+      await onAcceptedRelay?.(result.event);
+    } catch (error) {
+      logger.error({ err: error, sourceId, eventType: result.event.eventType }, "Slack relay delivery failed");
+      return c.json({
+        ok: false,
+        reason: "delivery_failed",
+        sourceId: result.event.sourceId,
+        eventType: result.event.eventType,
+      }, 502);
+    }
+
+    logger.info({ sourceId, eventType: result.event.eventType, targetChannel: result.event.targetChannel }, "Slack relay webhook accepted");
+    return c.json({
+      ok: true,
+      verdict: "accept",
+      sourceId: result.event.sourceId,
+      eventType: result.event.eventType,
+      targetChannel: result.event.targetChannel,
+    }, 202);
+  });
+
+  return app;
+}

--- a/src/slack/webhook-relay-config.test.ts
+++ b/src/slack/webhook-relay-config.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+import { parseWebhookRelaySourcesEnv } from "./webhook-relay-config.ts";
+
+describe("parseWebhookRelaySourcesEnv", () => {
+  test("returns an empty list when relay sources are not configured", () => {
+    expect(parseWebhookRelaySourcesEnv(undefined)).toEqual([]);
+    expect(parseWebhookRelaySourcesEnv("")).toEqual([]);
+  });
+
+  test("parses a valid relay source definition", () => {
+    const parsed = parseWebhookRelaySourcesEnv(
+      JSON.stringify([
+        {
+          id: "buildkite",
+          targetChannel: "C_BUILD_ALERTS",
+          auth: {
+            type: "header_secret",
+            headerName: "x-relay-secret",
+            secret: "super-secret",
+          },
+          filter: {
+            eventTypes: ["build.failed", "build.finished"],
+            textIncludes: ["failed"],
+            textExcludes: ["flaky"],
+          },
+        },
+      ]),
+    );
+
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]).toEqual({
+      id: "buildkite",
+      targetChannel: "C_BUILD_ALERTS",
+      auth: {
+        type: "header_secret",
+        headerName: "x-relay-secret",
+        secret: "super-secret",
+      },
+      filter: {
+        eventTypes: ["build.failed", "build.finished"],
+        textIncludes: ["failed"],
+        textExcludes: ["flaky"],
+      },
+    });
+  });
+
+  test("fails loudly on malformed JSON", () => {
+    expect(() => parseWebhookRelaySourcesEnv("{"))
+      .toThrow("SLACK_WEBHOOK_RELAY_SOURCES must be valid JSON");
+  });
+
+  test("fails loudly with source-specific diagnostics when a source is malformed", () => {
+    expect(() =>
+      parseWebhookRelaySourcesEnv(
+        JSON.stringify([
+          {
+            id: "buildkite",
+            targetChannel: "",
+            auth: {
+              type: "header_secret",
+              headerName: "x-relay-secret",
+              secret: "super-secret",
+            },
+          },
+        ]),
+      ),
+    ).toThrow('SLACK_WEBHOOK_RELAY_SOURCES source "buildkite" invalid: targetChannel');
+  });
+
+  test("fails loudly when duplicate source ids are configured", () => {
+    expect(() =>
+      parseWebhookRelaySourcesEnv(
+        JSON.stringify([
+          {
+            id: "buildkite",
+            targetChannel: "C_BUILD_ALERTS",
+            auth: {
+              type: "header_secret",
+              headerName: "x-relay-secret",
+              secret: "super-secret",
+            },
+          },
+          {
+            id: "buildkite",
+            targetChannel: "C_OTHER_ALERTS",
+            auth: {
+              type: "header_secret",
+              headerName: "x-relay-secret",
+              secret: "super-secret-2",
+            },
+          },
+        ]),
+      ),
+    ).toThrow('Duplicate Slack webhook relay source id: "buildkite"');
+  });
+});

--- a/src/slack/webhook-relay-config.ts
+++ b/src/slack/webhook-relay-config.ts
@@ -1,0 +1,76 @@
+import { z } from "zod";
+
+const relayFilterSchema = z.object({
+  eventTypes: z.array(z.string().trim().min(1, "eventTypes entries must be non-empty")).default([]),
+  textIncludes: z.array(z.string().trim().min(1, "textIncludes entries must be non-empty")).default([]),
+  textExcludes: z.array(z.string().trim().min(1, "textExcludes entries must be non-empty")).default([]),
+}).default(() => ({
+  eventTypes: [],
+  textIncludes: [],
+  textExcludes: [],
+}));
+
+const headerSecretAuthSchema = z.object({
+  type: z.literal("header_secret"),
+  headerName: z.string().trim().min(1, "headerName is required"),
+  secret: z.string().min(1, "secret is required"),
+});
+
+export const webhookRelaySourceSchema = z.object({
+  id: z.string().trim().min(1, "id is required"),
+  targetChannel: z.string().trim().min(1, "targetChannel is required"),
+  auth: headerSecretAuthSchema,
+  filter: relayFilterSchema,
+});
+
+export type SlackWebhookRelaySource = z.infer<typeof webhookRelaySourceSchema>;
+
+function describeInvalidSourceId(source: unknown, index: number): string {
+  if (
+    typeof source === "object"
+    && source !== null
+    && "id" in source
+    && typeof (source as { id?: unknown }).id === "string"
+    && (source as { id: string }).id.trim().length > 0
+  ) {
+    return (source as { id: string }).id.trim();
+  }
+
+  return `#${index}`;
+}
+
+export function parseWebhookRelaySourcesEnv(rawValue: string | undefined): SlackWebhookRelaySource[] {
+  const trimmed = rawValue?.trim();
+  if (!trimmed) {
+    return [];
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed) as unknown;
+  } catch {
+    throw new Error("SLACK_WEBHOOK_RELAY_SOURCES must be valid JSON");
+  }
+
+  if (!Array.isArray(parsed)) {
+    throw new Error("SLACK_WEBHOOK_RELAY_SOURCES must be a JSON array");
+  }
+
+  const seenIds = new Set<string>();
+
+  return parsed.map((source, index) => {
+    const result = webhookRelaySourceSchema.safeParse(source);
+    if (!result.success) {
+      const fieldPath = result.error.issues[0]?.path.join(".") || "unknown";
+      const sourceId = describeInvalidSourceId(source, index);
+      throw new Error(`SLACK_WEBHOOK_RELAY_SOURCES source "${sourceId}" invalid: ${fieldPath}`);
+    }
+
+    if (seenIds.has(result.data.id)) {
+      throw new Error(`Duplicate Slack webhook relay source id: "${result.data.id}"`);
+    }
+
+    seenIds.add(result.data.id);
+    return result.data;
+  });
+}

--- a/src/slack/webhook-relay-delivery.test.ts
+++ b/src/slack/webhook-relay-delivery.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import type { SlackClient } from "./client.ts";
+import type { NormalizedWebhookRelayEvent } from "./webhook-relay.ts";
+import {
+  deliverWebhookRelayEvent,
+  formatWebhookRelayMessage,
+} from "./webhook-relay-delivery.ts";
+
+function makeEvent(): NormalizedWebhookRelayEvent {
+  return {
+    sourceId: "buildkite",
+    targetChannel: "C_BUILD_ALERTS",
+    eventType: "build.failed",
+    title: "Build failed on main",
+    summary: "CI failed for xbmc/xbmc after the latest merge.",
+    url: "https://ci.example.test/builds/123",
+    text: "Build failed for xbmc/xbmc on main after merge 09f28d7.",
+    metadata: {
+      pipeline: "main",
+      provider: "buildkite",
+    },
+    filterMetadata: {
+      eventTypes: ["build.failed", "build.finished"],
+      textIncludes: ["failed"],
+      textExcludes: ["flaky"],
+    },
+  };
+}
+
+describe("formatWebhookRelayMessage", () => {
+  test("formats one standalone Slack message from the normalized relay event", () => {
+    expect(formatWebhookRelayMessage(makeEvent())).toBe([
+      "*Build failed on main*",
+      "CI failed for xbmc/xbmc after the latest merge.",
+      "Build failed for xbmc/xbmc on main after merge 09f28d7.",
+      "<https://ci.example.test/builds/123|Open event>",
+      "Source: `buildkite` · Event: `build.failed`",
+    ].join("\n"));
+  });
+});
+
+describe("deliverWebhookRelayEvent", () => {
+  test("posts the formatted relay message through SlackClient.postStandaloneMessage", async () => {
+    const calls: Array<{ channel: string; text: string }> = [];
+    const slackClient: SlackClient = {
+      postStandaloneMessage: async (input) => {
+        calls.push(input);
+        return { ts: "1700000000.000100" };
+      },
+      postThreadMessage: async () => undefined,
+      addReaction: async () => undefined,
+      removeReaction: async () => undefined,
+      getTokenScopes: async () => [],
+    };
+
+    const result = await deliverWebhookRelayEvent({
+      slackClient,
+      event: makeEvent(),
+    });
+
+    expect(result).toEqual({
+      channel: "C_BUILD_ALERTS",
+      timestamp: "1700000000.000100",
+      sourceId: "buildkite",
+      eventType: "build.failed",
+    });
+    expect(calls).toEqual([
+      {
+        channel: "C_BUILD_ALERTS",
+        text: [
+          "*Build failed on main*",
+          "CI failed for xbmc/xbmc after the latest merge.",
+          "Build failed for xbmc/xbmc on main after merge 09f28d7.",
+          "<https://ci.example.test/builds/123|Open event>",
+          "Source: `buildkite` · Event: `build.failed`",
+        ].join("\n"),
+      },
+    ]);
+  });
+});

--- a/src/slack/webhook-relay-delivery.ts
+++ b/src/slack/webhook-relay-delivery.ts
@@ -1,0 +1,35 @@
+import type { SlackClient } from "./client.ts";
+import type { NormalizedWebhookRelayEvent } from "./webhook-relay.ts";
+
+export function formatWebhookRelayMessage(event: NormalizedWebhookRelayEvent): string {
+  return [
+    `*${event.title}*`,
+    event.summary,
+    event.text,
+    `<${event.url}|Open event>`,
+    `Source: \`${event.sourceId}\` · Event: \`${event.eventType}\``,
+  ].join("\n");
+}
+
+export async function deliverWebhookRelayEvent(input: {
+  slackClient: SlackClient;
+  event: NormalizedWebhookRelayEvent;
+}): Promise<{
+  channel: string;
+  timestamp: string;
+  sourceId: string;
+  eventType: string;
+}> {
+  const text = formatWebhookRelayMessage(input.event);
+  const result = await input.slackClient.postStandaloneMessage({
+    channel: input.event.targetChannel,
+    text,
+  });
+
+  return {
+    channel: input.event.targetChannel,
+    timestamp: result.ts,
+    sourceId: input.event.sourceId,
+    eventType: input.event.eventType,
+  };
+}

--- a/src/slack/webhook-relay.test.ts
+++ b/src/slack/webhook-relay.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from "bun:test";
+import { parseWebhookRelaySourcesEnv } from "./webhook-relay-config.ts";
+import { evaluateWebhookRelayPayload } from "./webhook-relay.ts";
+
+const relaySource = parseWebhookRelaySourcesEnv(
+  JSON.stringify([
+    {
+      id: "buildkite",
+      targetChannel: "C_BUILD_ALERTS",
+      auth: {
+        type: "header_secret",
+        headerName: "x-relay-secret",
+        secret: "super-secret",
+      },
+      filter: {
+        eventTypes: ["build.failed", "build.finished"],
+        textIncludes: ["failed"],
+        textExcludes: ["flaky"],
+      },
+    },
+  ]),
+)[0]!;
+
+async function readFixture(name: "accepted" | "suppressed") {
+  return Bun.file(new URL(`../../fixtures/slack-webhook-relay/${name}.json`, import.meta.url)).json();
+}
+
+describe("evaluateWebhookRelayPayload", () => {
+  test("accepts a valid relay payload and normalizes it into the stable event shape", async () => {
+    const payload = await readFixture("accepted");
+
+    const result = evaluateWebhookRelayPayload({
+      source: relaySource,
+      payload,
+    });
+
+    expect(result).toEqual({
+      verdict: "accept",
+      event: {
+        sourceId: "buildkite",
+        targetChannel: "C_BUILD_ALERTS",
+        eventType: "build.failed",
+        title: "Build failed on main",
+        summary: "CI failed for xbmc/xbmc after the latest merge.",
+        url: "https://ci.example.test/builds/123",
+        text: "Build failed for xbmc/xbmc on main after merge 09f28d7.",
+        metadata: {
+          pipeline: "main",
+          provider: "buildkite",
+        },
+        filterMetadata: {
+          eventTypes: ["build.failed", "build.finished"],
+          textIncludes: ["failed"],
+          textExcludes: ["flaky"],
+        },
+      },
+    });
+  });
+
+  test("suppresses relay payloads whose text matches an excluded substring", async () => {
+    const payload = await readFixture("suppressed");
+
+    const result = evaluateWebhookRelayPayload({
+      source: relaySource,
+      payload,
+    });
+
+    expect(result).toEqual({
+      verdict: "suppress",
+      reason: "text_excluded_substring",
+      sourceId: "buildkite",
+      eventType: "build.failed",
+      detail: "flaky",
+    });
+  });
+
+  test("suppresses relay payloads whose event type is not allowlisted", () => {
+    const result = evaluateWebhookRelayPayload({
+      source: relaySource,
+      payload: {
+        eventType: "build.started",
+        title: "Build started",
+        summary: "CI started for xbmc/xbmc.",
+        url: "https://ci.example.test/builds/125",
+        text: "Build started for xbmc/xbmc on main.",
+      },
+    });
+
+    expect(result).toEqual({
+      verdict: "suppress",
+      reason: "event_type_not_allowed",
+      sourceId: "buildkite",
+      eventType: "build.started",
+      detail: "build.started",
+    });
+  });
+
+  test("returns explicit invalid diagnostics for malformed payloads", () => {
+    const result = evaluateWebhookRelayPayload({
+      source: relaySource,
+      payload: {
+        eventType: "build.failed",
+        title: "Missing text",
+        summary: "This payload forgot the required text field.",
+        url: "not-a-url",
+      },
+    });
+
+    expect(result).toEqual({
+      verdict: "invalid",
+      reason: "malformed_payload",
+      sourceId: "buildkite",
+      issues: ["text", "url"],
+    });
+  });
+});

--- a/src/slack/webhook-relay.ts
+++ b/src/slack/webhook-relay.ts
@@ -1,0 +1,121 @@
+import { z } from "zod";
+import type { SlackWebhookRelaySource } from "./webhook-relay-config.ts";
+
+const webhookRelayPayloadSchema = z.object({
+  eventType: z.string().trim().min(1, "eventType is required"),
+  title: z.string().trim().min(1, "title is required"),
+  summary: z.string().trim().min(1, "summary is required"),
+  url: z.string().url("url must be a valid URL"),
+  text: z.string().trim().min(1, "text is required"),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+});
+
+export interface NormalizedWebhookRelayEvent {
+  sourceId: string;
+  targetChannel: string;
+  eventType: string;
+  title: string;
+  summary: string;
+  url: string;
+  text: string;
+  metadata: Record<string, unknown>;
+  filterMetadata: SlackWebhookRelaySource["filter"];
+}
+
+export type WebhookRelayEvaluationResult =
+  | { verdict: "accept"; event: NormalizedWebhookRelayEvent }
+  | {
+      verdict: "suppress";
+      reason: "event_type_not_allowed" | "text_missing_required_substring" | "text_excluded_substring";
+      sourceId: string;
+      eventType: string;
+      detail: string;
+    }
+  | {
+      verdict: "invalid";
+      reason: "malformed_payload";
+      sourceId: string;
+      issues: string[];
+    };
+
+function normalizePayloadIssues(payload: unknown): string[] {
+  const result = webhookRelayPayloadSchema.safeParse(payload);
+  if (result.success) {
+    return [];
+  }
+
+  return result.error.issues
+    .map((issue) => issue.path.join("."))
+    .filter((value, index, array) => value.length > 0 && array.indexOf(value) === index)
+    .sort((a, b) => a.localeCompare(b));
+}
+
+export function evaluateWebhookRelayPayload(input: {
+  source: SlackWebhookRelaySource;
+  payload: unknown;
+}): WebhookRelayEvaluationResult {
+  const payloadResult = webhookRelayPayloadSchema.safeParse(input.payload);
+  if (!payloadResult.success) {
+    return {
+      verdict: "invalid",
+      reason: "malformed_payload",
+      sourceId: input.source.id,
+      issues: normalizePayloadIssues(input.payload),
+    };
+  }
+
+  const payload = payloadResult.data;
+  const { filter } = input.source;
+
+  if (filter.eventTypes.length > 0 && !filter.eventTypes.includes(payload.eventType)) {
+    return {
+      verdict: "suppress",
+      reason: "event_type_not_allowed",
+      sourceId: input.source.id,
+      eventType: payload.eventType,
+      detail: payload.eventType,
+    };
+  }
+
+  const normalizedText = payload.text.toLowerCase();
+  const missingRequiredSubstring = filter.textIncludes.find(
+    (substring) => !normalizedText.includes(substring.toLowerCase()),
+  );
+  if (missingRequiredSubstring) {
+    return {
+      verdict: "suppress",
+      reason: "text_missing_required_substring",
+      sourceId: input.source.id,
+      eventType: payload.eventType,
+      detail: missingRequiredSubstring,
+    };
+  }
+
+  const excludedSubstring = filter.textExcludes.find(
+    (substring) => normalizedText.includes(substring.toLowerCase()),
+  );
+  if (excludedSubstring) {
+    return {
+      verdict: "suppress",
+      reason: "text_excluded_substring",
+      sourceId: input.source.id,
+      eventType: payload.eventType,
+      detail: excludedSubstring,
+    };
+  }
+
+  return {
+    verdict: "accept",
+    event: {
+      sourceId: input.source.id,
+      targetChannel: input.source.targetChannel,
+      eventType: payload.eventType,
+      title: payload.title,
+      summary: payload.summary,
+      url: payload.url,
+      text: payload.text,
+      metadata: payload.metadata ?? {},
+      filterMetadata: input.source.filter,
+    },
+  };
+}

--- a/src/slack/webhook-relay.ts
+++ b/src/slack/webhook-relay.ts
@@ -38,13 +38,8 @@ export type WebhookRelayEvaluationResult =
       issues: string[];
     };
 
-function normalizePayloadIssues(payload: unknown): string[] {
-  const result = webhookRelayPayloadSchema.safeParse(payload);
-  if (result.success) {
-    return [];
-  }
-
-  return result.error.issues
+function normalizePayloadIssues(issues: ReadonlyArray<{ path: ReadonlyArray<PropertyKey> }>): string[] {
+  return issues
     .map((issue) => issue.path.join("."))
     .filter((value, index, array) => value.length > 0 && array.indexOf(value) === index)
     .sort((a, b) => a.localeCompare(b));
@@ -60,7 +55,7 @@ export function evaluateWebhookRelayPayload(input: {
       verdict: "invalid",
       reason: "malformed_payload",
       sourceId: input.source.id,
-      issues: normalizePayloadIssues(input.payload),
+      issues: normalizePayloadIssues(payloadResult.error.issues),
     };
   }
 


### PR DESCRIPTION
## Summary
- add service-level Slack webhook relay source config via `SLACK_WEBHOOK_RELAY_SOURCES`
- add relay normalization, filtering, ingress route, and Slack delivery wiring
- add slice and milestone proof harnesses plus rollout/smoke docs for operators

## Verification
- `bun test ./src/config.test.ts ./src/slack/webhook-relay-config.test.ts ./src/slack/webhook-relay.test.ts ./src/slack/webhook-relay-delivery.test.ts ./src/routes/slack-relay-webhooks.test.ts ./scripts/verify-m052-s01.test.ts ./scripts/verify-m052-s02.test.ts ./scripts/verify-m052.test.ts`
- `bun run verify:m052`
- `bun run tsc --noEmit`

## Context
- milestone: `M052`
- issue: `#76`
