### PR TITLE
fix: harden degraded review publication

### DIFF
--- a/src/execution/executor.test.ts
+++ b/src/execution/executor.test.ts
@@ -472,9 +472,14 @@ function createTestableExecutor(deps: {
           !isWriteMode &&
           context.prNumber !== undefined &&
           taskType !== "review.full";
+        const gitDiffInspectionAvailable = context.gitDiffInspectionAvailable !== false;
         const baseTools = isReadOnlyPrMention
-          ? ["Read", "Grep", "Bash(git diff:*)", "Bash(git status:*)"]
-          : ["Read", "Grep", "Glob", "Bash(git diff:*)", "Bash(git log:*)", "Bash(git show:*)", "Bash(git status:*)"];
+          ? gitDiffInspectionAvailable
+            ? ["Read", "Grep", "Bash(git diff:*)", "Bash(git status:*)"]
+            : ["Read", "Grep", "Bash(git status:*)"]
+          : gitDiffInspectionAvailable
+            ? ["Read", "Grep", "Glob", "Bash(git diff:*)", "Bash(git log:*)", "Bash(git show:*)", "Bash(git status:*)"]
+            : ["Read", "Grep", "Glob", "Bash(git status:*)"];
         const writeTools = isWriteMode ? ["Edit", "Write", "MultiEdit"] : [];
         const mcpTools = buildAllowedMcpTools(Object.keys(mcpServers));
         const allowedTools = [...baseTools, ...writeTools, ...mcpTools];
@@ -1176,6 +1181,63 @@ test("ACA dispatch: explicit review mention stages a review bundle transport wit
     baseRef: "main",
     originUrl: "https://github.com/xbmc/xbmc.git",
   });
+});
+
+test("ACA dispatch: degraded review lane strips git diff and history tools", async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), "kodiai-executor-test-"));
+  const sourceRepoDir = await mkdtemp(join(tmpdir(), "kodiai-source-repo-"));
+  await mkdir(join(sourceRepoDir, "src"), { recursive: true });
+  await writeFile(join(sourceRepoDir, "src", "feature.ts"), "export const feature = true;\n");
+  await writeFile(join(sourceRepoDir, ".kodiai.yml"), "review:\n  enabled: true\n");
+
+  await $`git -C ${sourceRepoDir} init`.quiet();
+  await $`git -C ${sourceRepoDir} config user.email test@example.com`.quiet();
+  await $`git -C ${sourceRepoDir} config user.name "Test User"`.quiet();
+  await $`git -C ${sourceRepoDir} remote add origin https://github.com/xbmc/xbmc.git`.quiet();
+  await $`git -C ${sourceRepoDir} add .`.quiet();
+  await $`git -C ${sourceRepoDir} commit -m base`.quiet();
+  await $`git -C ${sourceRepoDir} branch -M main`.quiet();
+  await $`git -C ${sourceRepoDir} checkout -b pr-mention`.quiet();
+  await writeFile(join(sourceRepoDir, "src", "feature.ts"), "export const feature = 'updated';\n");
+  await $`git -C ${sourceRepoDir} commit -am feature`.quiet();
+  await $`git -C ${sourceRepoDir} update-ref refs/remotes/origin/main $(git -C ${sourceRepoDir} rev-parse main)`.quiet();
+
+  const config = makeConfig();
+  const logger = makeLogger();
+  const registry = createMcpJobRegistry();
+
+  const executor = createTestableExecutor({
+    githubApp: makeGithubApp(),
+    logger,
+    config,
+    mcpJobRegistry: registry,
+    launchFn: async () => ({ executionName: "exec-degraded-review-lane" }),
+    pollFn: async () => ({ status: "succeeded", durationMs: 1000 }),
+    readResultFn: async () => makeJobResult(),
+    createWorkspaceDirFn: async () => tmpDir!,
+  });
+
+  await executor.execute(
+    makeContext(sourceRepoDir, {
+      eventType: "pull_request.opened",
+      prNumber: 80,
+      taskType: "review.full",
+      gitDiffInspectionAvailable: false,
+    }),
+  );
+
+  const rawAgentConfig = await readFile(join(tmpDir!, "agent-config.json"), "utf-8");
+  const agentConfig = JSON.parse(rawAgentConfig) as {
+    allowedTools: string[];
+    taskType: string;
+  };
+
+  expect(agentConfig.taskType).toBe("review.full");
+  expect(agentConfig.allowedTools).toContain("Glob");
+  expect(agentConfig.allowedTools).toContain("Bash(git status:*)");
+  expect(agentConfig.allowedTools).not.toContain("Bash(git diff:*)");
+  expect(agentConfig.allowedTools).not.toContain("Bash(git log:*)");
+  expect(agentConfig.allowedTools).not.toContain("Bash(git show:*)");
 });
 
 test("ACA dispatch: conversational PR mention keeps reduced toolset", async () => {

--- a/src/execution/executor.ts
+++ b/src/execution/executor.ts
@@ -430,22 +430,36 @@ export function createExecutor(deps: {
           !isWriteMode &&
           context.prNumber !== undefined &&
           taskType !== "review.full";
+        const gitDiffInspectionAvailable = context.gitDiffInspectionAvailable !== false;
         const baseTools = isReadOnlyPrMention
-          ? [
-              "Read",
-              "Grep",
-              "Bash(git diff:*)",
-              "Bash(git status:*)",
-            ]
-          : [
-              "Read",
-              "Grep",
-              "Glob",
-              "Bash(git diff:*)",
-              "Bash(git log:*)",
-              "Bash(git show:*)",
-              "Bash(git status:*)",
-            ];
+          ? gitDiffInspectionAvailable
+            ? [
+                "Read",
+                "Grep",
+                "Bash(git diff:*)",
+                "Bash(git status:*)",
+              ]
+            : [
+                "Read",
+                "Grep",
+                "Bash(git status:*)",
+              ]
+          : gitDiffInspectionAvailable
+            ? [
+                "Read",
+                "Grep",
+                "Glob",
+                "Bash(git diff:*)",
+                "Bash(git log:*)",
+                "Bash(git show:*)",
+                "Bash(git status:*)",
+              ]
+            : [
+                "Read",
+                "Grep",
+                "Glob",
+                "Bash(git status:*)",
+              ];
 
         const writeTools = isWriteMode ? ["Edit", "Write", "MultiEdit"] : [];
         // Compute server names from the same deps (no instance construction yet)

--- a/src/execution/review-prompt.test.ts
+++ b/src/execution/review-prompt.test.ts
@@ -1843,6 +1843,19 @@ describe("epistemic section placement in buildReviewPrompt", () => {
   });
 });
 
+describe("degraded diff guidance in buildReviewPrompt", () => {
+  test("does not instruct merge-base git commands when local diff inspection is unavailable", () => {
+    const prompt = buildReviewPrompt(baseContext({
+      gitDiffInspectionAvailable: false,
+    }));
+
+    expect(prompt).toContain("Full local merge-base diff access is unavailable in this run.");
+    expect(prompt).toContain("Do not spend turns trying to reconstruct the diff with git history commands.");
+    expect(prompt).not.toContain("To see the full diff: Bash(git diff origin/main...HEAD)");
+    expect(prompt).not.toContain("To see changed files with stats: Bash(git log origin/main..HEAD --stat)");
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Phase 115: Dep-bump rewrites, footnote citations, conventional commit
 // ---------------------------------------------------------------------------

--- a/src/execution/review-prompt.ts
+++ b/src/execution/review-prompt.ts
@@ -1695,6 +1695,7 @@ export function buildReviewPrompt(context: {
   structuralImpact?: StructuralImpactPayload | null;
   reviewBoundedness?: ReviewBoundednessContract | null;
   publishToolNames?: string[];
+  gitDiffInspectionAvailable?: boolean;
 }): string {
   const lines: string[] = [];
   const scaleNotes: string[] = [];
@@ -1855,10 +1856,21 @@ export function buildReviewPrompt(context: {
     "",
     "## Reading the code",
     "",
-    `To see the full diff: Bash(git diff origin/${context.baseBranch}...HEAD)`,
-    `To see changed files with stats: Bash(git log origin/${context.baseBranch}..HEAD --stat)`,
-    "Read the diff carefully before posting any comments.",
   );
+
+  if (context.gitDiffInspectionAvailable === false) {
+    lines.push(
+      "Full local merge-base diff access is unavailable in this run.",
+      "Do not spend turns trying to reconstruct the diff with git history commands.",
+      "Use the changed file list above plus Read/Grep/Glob on those files to complete the review.",
+    );
+  } else {
+    lines.push(
+      `To see the full diff: Bash(git diff origin/${context.baseBranch}...HEAD)`,
+      `To see changed files with stats: Bash(git log origin/${context.baseBranch}..HEAD --stat)`,
+      "Read the diff carefully before posting any comments.",
+    );
+  }
 
   // --- Review instructions ---
   lines.push(

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -70,6 +70,13 @@ export type ExecutionContext = {
   /** Enable review checkpoint MCP tool (save_review_checkpoint). */
   enableCheckpointTool?: boolean;
 
+  /**
+   * False when the local workspace cannot support merge-base diff inspection.
+   * In that mode the agent should stay on changed files surfaced by the handler
+   * instead of spending turns on git diff/log/show reconstruction.
+   */
+  gitDiffInspectionAvailable?: boolean;
+
   /** Optional overrides for MCP tool surfaces (used for retry flows). */
   enableInlineTools?: boolean;
   enableCommentTools?: boolean;

--- a/src/handlers/review.test.ts
+++ b/src/handlers/review.test.ts
@@ -1909,6 +1909,8 @@ describe("createReviewHandler review_requested idempotency", () => {
       cleanupStale: async () => 0,
     };
 
+    let nextIssueCommentId = 70;
+    const issueComments: Array<{ id: number; body: string }> = [];
     const octokit = {
       rest: {
         pulls: {
@@ -1919,6 +1921,7 @@ describe("createReviewHandler review_requested idempotency", () => {
               body: review.body ?? null,
             })),
           }),
+          listCommits: async () => ({ data: [] }),
           createReview: async ({ body }: { body?: string }) => {
             approveCount++;
             createdReviews.push({ body: body ?? null });
@@ -1929,7 +1932,24 @@ describe("createReviewHandler review_requested idempotency", () => {
           createForIssue: async () => ({ data: {} }),
         },
         issues: {
-          listComments: async () => ({ data: [] }),
+          listComments: async () => ({
+            data: issueComments.map((comment) => ({ id: comment.id, body: comment.body })),
+          }),
+          createComment: async ({ body }: { body: string }) => {
+            const comment = { id: nextIssueCommentId++, body };
+            issueComments.push(comment);
+            return { data: comment };
+          },
+          updateComment: async ({ comment_id, body }: { comment_id: number; body: string }) => {
+            const existing = issueComments.find((comment) => comment.id === comment_id);
+            if (existing) {
+              existing.body = body;
+            }
+            return { data: {} };
+          },
+        },
+        search: {
+          issuesAndPullRequests: async () => ({ data: { total_count: 4 } }),
         },
       },
     };
@@ -1946,7 +1966,7 @@ describe("createReviewHandler review_requested idempotency", () => {
         getInstallationToken: async () => "token",
       } as unknown as GitHubApp,
       executor: {
-        execute: async (context: { reviewOutputKey?: string }) => {
+        execute: async () => {
           executeCount++;
           return {
             conclusion: "success",
@@ -1975,6 +1995,7 @@ describe("createReviewHandler review_requested idempotency", () => {
 
     expect(executeCount).toBe(1);
     expect(approveCount).toBe(1);
+    expect(issueComments).toHaveLength(1);
 
     const expectedReviewOutputKey = buildReviewOutputKey({
       installationId: 42,
@@ -1987,18 +2008,21 @@ describe("createReviewHandler review_requested idempotency", () => {
     });
 
     const marker = buildReviewOutputMarker(expectedReviewOutputKey);
+    const finalIssueBody = issueComments[0]!.body;
 
-    expect(createdReviews[0]?.body ?? "").toContain("Decision: APPROVE");
-    expect(createdReviews[0]?.body ?? "").toContain("Issues: none");
-    expect(createdReviews[0]?.body ?? "").toContain("Evidence:");
-    expect(createdReviews[0]?.body ?? "").toContain("- Review prompt covered 1 changed file.");
-    expect(createdReviews[0]?.body ?? "").not.toContain("Merge Confidence:");
-    expect(extractReviewOutputKey(createdReviews[0]?.body)).toBe(expectedReviewOutputKey);
-    // Ensure marker format stays stable inside the visible approval body.
-    expect(createdReviews[0]?.body ?? "").toContain(marker);
+    expect(createdReviews[0]?.body ?? "").toBe("");
+    expect(finalIssueBody).toContain("<summary>kodiai response</summary>");
+    expect(finalIssueBody).toContain("Decision: APPROVE");
+    expect(finalIssueBody).toContain("Issues: none");
+    expect(finalIssueBody).toContain("- Review prompt covered 1 changed file.");
+    expect(finalIssueBody).not.toContain("Merge Confidence:");
+    expect(finalIssueBody).toContain("<summary>Review Details</summary>");
+    expect(finalIssueBody).toContain(marker);
+    expect(finalIssueBody).not.toContain("captured before publication completed");
+    expect(extractReviewOutputKey(finalIssueBody)).toBe(expectedReviewOutputKey);
   });
 
-  test("auto-approve includes dep-bump merge confidence inside the shared approval body", async () => {
+  test("auto-approve includes dep-bump merge confidence inside the shared approval comment", async () => {
     const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
     const workspaceFixture = await createWorkspaceFixture({ autoApprove: true });
 
@@ -2015,6 +2039,8 @@ describe("createReviewHandler review_requested idempotency", () => {
 
     let approveCount = 0;
     const createdReviews: Array<{ body?: string }> = [];
+    let nextIssueCommentId = 170;
+    const issueComments: Array<{ id: number; body: string }> = [];
     const previousFetch = globalThis.fetch;
     globalThis.fetch = mock(async () => new Response("Not Found", { status: 404 })) as unknown as typeof globalThis.fetch;
 
@@ -2056,13 +2082,30 @@ describe("createReviewHandler review_requested idempotency", () => {
           createForIssue: async () => ({ data: {} }),
         },
         issues: {
-          listComments: async () => ({ data: [] }),
+          listComments: async () => ({
+            data: issueComments.map((comment) => ({ id: comment.id, body: comment.body })),
+          }),
+          createComment: async ({ body }: { body: string }) => {
+            const comment = { id: nextIssueCommentId++, body };
+            issueComments.push(comment);
+            return { data: comment };
+          },
+          updateComment: async ({ comment_id, body }: { comment_id: number; body: string }) => {
+            const existing = issueComments.find((comment) => comment.id === comment_id);
+            if (existing) {
+              existing.body = body;
+            }
+            return { data: {} };
+          },
         },
         securityAdvisories: {
           listGlobalAdvisories: async () => ({ data: [] }),
         },
         repos: {
           listReleases: async () => ({ data: [] }),
+        },
+        search: {
+          issuesAndPullRequests: async () => ({ data: { total_count: 4 } }),
         },
       },
     };
@@ -2128,12 +2171,13 @@ describe("createReviewHandler review_requested idempotency", () => {
     }
 
     expect(approveCount).toBe(1);
-    expect(createdReviews[0]?.body ?? "").toContain("Decision: APPROVE");
-    expect(createdReviews[0]?.body ?? "").toContain("Issues: none");
-    expect(createdReviews[0]?.body ?? "").toContain("Evidence:");
-    expect(createdReviews[0]?.body ?? "").toContain("- Review prompt covered 2 changed files.");
-    expect(createdReviews[0]?.body ?? "").toContain("Merge Confidence: High");
-    expect(extractReviewOutputKey(createdReviews[0]?.body)).toBe(
+    expect(issueComments).toHaveLength(1);
+    expect(createdReviews[0]?.body ?? "").toBe("");
+    expect(issueComments[0]!.body).toContain("Decision: APPROVE");
+    expect(issueComments[0]!.body).toContain("Issues: none");
+    expect(issueComments[0]!.body).toContain("- Review prompt covered 2 changed files.");
+    expect(issueComments[0]!.body).toContain("Merge Confidence: High");
+    expect(extractReviewOutputKey(issueComments[0]!.body)).toBe(
       buildReviewOutputKey({
         installationId: 42,
         owner: "acme",
@@ -4401,6 +4445,7 @@ describe("createReviewHandler diff collection resilience", () => {
 
     let executeCount = 0;
     let capturedPrompt = "";
+    let capturedGitDiffInspectionAvailable: boolean | undefined;
 
     const eventRouter: EventRouter = {
       register: (eventKey, handler) => {
@@ -4448,9 +4493,10 @@ describe("createReviewHandler diff collection resilience", () => {
         getInstallationOctokit: async () => octokit as never,
       } as unknown as GitHubApp,
       executor: {
-        execute: async (context: { prompt: string }) => {
+        execute: async (context: { prompt: string; gitDiffInspectionAvailable?: boolean }) => {
           executeCount++;
           capturedPrompt = context.prompt;
+          capturedGitDiffInspectionAvailable = context.gitDiffInspectionAvailable;
           return {
             conclusion: "success",
             published: false,
@@ -4487,6 +4533,10 @@ describe("createReviewHandler diff collection resilience", () => {
 
       expect(executeCount).toBe(1);
       expect(capturedPrompt).toContain("README.md");
+      expect(capturedPrompt).toContain("Full local merge-base diff access is unavailable in this run.");
+      expect(capturedPrompt).not.toContain("To see the full diff: Bash(git diff origin/main...HEAD)");
+      expect(capturedPrompt).not.toContain("To see changed files with stats: Bash(git log origin/main..HEAD --stat)");
+      expect(capturedGitDiffInspectionAvailable).toBe(false);
     } finally {
       await workspaceFixture.cleanup();
     }
@@ -4956,7 +5006,10 @@ describe("createReviewHandler finding extraction", () => {
     const deletedCommentIds: number[] = [];
     let listCommentsCalls = 0;
     let createCommentCalls = 0;
+    let updateCommentCalls = 0;
     let detailsCommentBody: string | undefined;
+    let nextIssueCommentId = 500;
+    const issueComments: Array<{ id: number; body: string }> = [];
 
     const eventRouter: EventRouter = {
       register: (eventKey, handler) => {
@@ -4997,6 +5050,7 @@ describe("createReviewHandler finding extraction", () => {
       headSha: "abcdef1234567890",
     });
     const marker = buildReviewOutputMarker(reviewOutputKey);
+    const reviewDetailsMarker = `<!-- kodiai:review-details:${reviewOutputKey} -->`;
 
     const octokit = {
       rest: {
@@ -5059,14 +5113,26 @@ describe("createReviewHandler finding extraction", () => {
         issues: {
           listComments: async () => {
             listCommentsCalls += 1;
-            return { data: [] };
+            return {
+              data: issueComments.map((comment) => ({ id: comment.id, body: comment.body })),
+            };
           },
           createComment: async (params: { body: string }) => {
             createCommentCalls += 1;
+            const comment = { id: nextIssueCommentId++, body: params.body };
+            issueComments.push(comment);
             detailsCommentBody = params.body;
+            return { data: comment };
+          },
+          updateComment: async ({ comment_id, body }: { comment_id: number; body: string }) => {
+            updateCommentCalls += 1;
+            const existing = issueComments.find((comment) => comment.id === comment_id);
+            if (existing) {
+              existing.body = body;
+            }
+            detailsCommentBody = body;
             return { data: {} };
           },
-          updateComment: async () => ({ data: {} }),
         },
         reactions: {
           createForIssue: async () => ({ data: {} }),
@@ -5115,7 +5181,9 @@ describe("createReviewHandler finding extraction", () => {
     expect(deletedCommentIds).toEqual([41, 42]);
     expect(listCommentsCalls).toBeGreaterThanOrEqual(1);
     expect(createCommentCalls).toBe(1);
+    expect(updateCommentCalls).toBe(1);
     expect(detailsCommentBody).toContain("<summary>Review Details</summary>");
+    expect(detailsCommentBody).toContain(reviewDetailsMarker);
     expect(detailsCommentBody).toContain("Files reviewed:");
     expect(detailsCommentBody).toMatch(/Lines changed: \+\d+ -\d+/);
     expect(detailsCommentBody).toMatch(/Findings: \d+ critical, \d+ major, \d+ medium, \d+ minor/);
@@ -5128,7 +5196,8 @@ describe("createReviewHandler finding extraction", () => {
     expect(detailsCommentBody).toContain("executor handoff: 50ms");
     expect(detailsCommentBody).toContain("remote runtime: 500ms");
     expect(detailsCommentBody).toContain("publication:");
-    expect(detailsCommentBody).toContain("degraded:");
+    expect(detailsCommentBody).not.toContain("captured before publication completed");
+    expect(detailsCommentBody).not.toContain("degraded:");
     expect(detailsCommentBody).not.toContain("Suppressions applied:");
     expect(detailsCommentBody).not.toContain("Estimated review time saved:");
     expect(detailsCommentBody).not.toContain("Low Confidence Findings");
@@ -9693,6 +9762,106 @@ describe("createReviewHandler timeout resilience", () => {
     ).toBeTrue();
 
     await workspaceFixture.cleanup();
+  });
+});
+
+describe("createReviewHandler execution failure publication", () => {
+  test("posts a visible turn-budget fallback when review execution ends with error_max_turns", async () => {
+    const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
+    const workspaceFixture = await createWorkspaceFixture();
+
+    const createdCommentBodies: string[] = [];
+
+    const eventRouter: EventRouter = {
+      register: (eventKey, handler) => {
+        handlers.set(eventKey, handler);
+      },
+      dispatch: async () => undefined,
+    };
+
+    const jobQueue: JobQueue = {
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
+      getQueueSize: () => 0,
+      getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
+    };
+
+    const workspaceManager: WorkspaceManager = {
+      create: async () => ({
+        dir: workspaceFixture.dir,
+        cleanup: async () => undefined,
+      }),
+      cleanupStale: async () => 0,
+    };
+
+    const octokit = {
+      rest: {
+        pulls: {
+          listReviewComments: async () => ({ data: [] }),
+          listReviews: async () => ({ data: [] }),
+          listCommits: async () => ({ data: [] }),
+        },
+        issues: {
+          listComments: async () => ({ data: [] }),
+          createComment: async (params: { body: string }) => {
+            createdCommentBodies.push(params.body);
+            return { data: { id: 901 } };
+          },
+          updateComment: async () => ({ data: {} }),
+        },
+        reactions: {
+          createForIssue: async () => ({ data: {} }),
+        },
+      },
+    };
+
+    createReviewHandler({
+      eventRouter,
+      jobQueue,
+      workspaceManager,
+      githubApp: {
+        getAppSlug: () => "kodiai",
+        getInstallationOctokit: async () => octokit as never,
+      } as unknown as GitHubApp,
+      executor: {
+        execute: async () => ({
+          conclusion: "failure",
+          published: false,
+          failureSubtype: "error_max_turns",
+          stopReason: "tool_use",
+          costUsd: 0,
+          numTurns: 26,
+          durationMs: 1,
+          sessionId: "session-review-max-turns",
+          model: "test-model",
+          inputTokens: 0,
+          outputTokens: 0,
+          cacheReadTokens: 0,
+          cacheCreationTokens: 0,
+          errorMessage: undefined,
+        }),
+      } as never,
+      telemetryStore: noopTelemetryStore,
+      logger: createNoopLogger(),
+    });
+
+    const handler = handlers.get("pull_request.review_requested");
+    expect(handler).toBeDefined();
+
+    try {
+      await handler!(
+        buildReviewRequestedEvent({
+          requested_reviewer: { login: "kodiai[bot]" },
+        }),
+      );
+
+      expect(createdCommentBodies).toHaveLength(1);
+      expect(createdCommentBodies[0]).toContain("Kodiai ran out of steps while reviewing this PR");
+      expect(createdCommentBodies[0]).toContain("Stop reason: tool_use");
+      expect(createdCommentBodies[0]).toContain("Failure subtype: error_max_turns");
+    } finally {
+      await workspaceFixture.cleanup();
+    }
   });
 });
 

--- a/src/handlers/review.test.ts
+++ b/src/handlers/review.test.ts
@@ -2010,7 +2010,7 @@ describe("createReviewHandler review_requested idempotency", () => {
     const marker = buildReviewOutputMarker(expectedReviewOutputKey);
     const finalIssueBody = issueComments[0]!.body;
 
-    expect(createdReviews[0]?.body ?? "").toBe("");
+    expect(createdReviews[0]?.body).toBe(marker);
     expect(finalIssueBody).toContain("<summary>kodiai response</summary>");
     expect(finalIssueBody).toContain("Decision: APPROVE");
     expect(finalIssueBody).toContain("Issues: none");
@@ -2020,6 +2020,131 @@ describe("createReviewHandler review_requested idempotency", () => {
     expect(finalIssueBody).toContain(marker);
     expect(finalIssueBody).not.toContain("captured before publication completed");
     expect(extractReviewOutputKey(finalIssueBody)).toBe(expectedReviewOutputKey);
+  });
+
+  test("skips duplicate clean approvals when only the approval review marker survived", async () => {
+    const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
+    const workspaceFixture = await createWorkspaceFixture({ autoApprove: true });
+    const { logger, entries } = createCaptureLogger();
+
+    const createdReviews: Array<{ body?: string | null }> = [];
+    let executeCount = 0;
+    let approveCount = 0;
+    let createCommentCalls = 0;
+
+    const eventRouter: EventRouter = {
+      register: (eventKey, handler) => {
+        handlers.set(eventKey, handler);
+      },
+      dispatch: async () => undefined,
+    };
+
+    const jobQueue: JobQueue = {
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
+      getQueueSize: () => 0,
+      getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
+    };
+
+    const workspaceManager: WorkspaceManager = {
+      create: async () => ({
+        dir: workspaceFixture.dir,
+        cleanup: async () => undefined,
+      }),
+      cleanupStale: async () => 0,
+    };
+
+    const octokit = {
+      rest: {
+        pulls: {
+          listReviewComments: async () => ({ data: [] }),
+          listReviews: async () => ({
+            data: createdReviews.map((review, index) => ({
+              id: index + 1,
+              body: review.body ?? null,
+            })),
+          }),
+          listCommits: async () => ({ data: [] }),
+          createReview: async ({ body }: { body?: string }) => {
+            approveCount++;
+            createdReviews.push({ body: body ?? null });
+            return { data: {} };
+          },
+        },
+        reactions: {
+          createForIssue: async () => ({ data: {} }),
+        },
+        issues: {
+          listComments: async () => ({ data: [] }),
+          createComment: async () => {
+            createCommentCalls += 1;
+            throw new Error("issue comment publication failed");
+          },
+        },
+      },
+    };
+
+    createReviewHandler({
+      eventRouter,
+      jobQueue,
+      workspaceManager,
+      githubApp: {
+        getAppSlug: () => "kodiai",
+        getInstallationOctokit: async () => octokit as never,
+        initialize: async () => undefined,
+        checkConnectivity: async () => true,
+        getInstallationToken: async () => "token",
+      } as unknown as GitHubApp,
+      executor: {
+        execute: async () => {
+          executeCount++;
+          return {
+            conclusion: "success",
+            costUsd: 0,
+            numTurns: 1,
+            durationMs: 1,
+            sessionId: "session-clean-review-marker-only",
+          };
+        },
+      } as never,
+      telemetryStore: noopTelemetryStore,
+      logger: logger as never,
+    });
+
+    const handler = handlers.get("pull_request.review_requested");
+    expect(handler).toBeDefined();
+
+    const event = buildReviewRequestedEvent({
+      requested_reviewer: { login: "kodiai[bot]" },
+    });
+
+    await handler!(event);
+    await handler!(event);
+
+    await workspaceFixture.cleanup();
+
+    const expectedReviewOutputKey = buildReviewOutputKey({
+      installationId: 42,
+      owner: "acme",
+      repo: "repo",
+      prNumber: 101,
+      action: "review_requested",
+      deliveryId: "delivery-123",
+      headSha: "abcdef1234567890",
+    });
+
+    expect(executeCount).toBe(1);
+    expect(approveCount).toBe(1);
+    expect(createCommentCalls).toBeGreaterThanOrEqual(1);
+    expect(createdReviews[0]?.body).toBe(buildReviewOutputMarker(expectedReviewOutputKey));
+    expect(
+      entries.some((entry) =>
+        entry.data?.gate === "review-output-idempotency"
+        && entry.data?.gateResult === "skipped"
+        && entry.data?.skipReason === "already-published"
+        && entry.data?.existingLocation === "review"
+      ),
+    ).toBe(true);
   });
 
   test("auto-approve includes dep-bump merge confidence inside the shared approval comment", async () => {
@@ -2172,7 +2297,19 @@ describe("createReviewHandler review_requested idempotency", () => {
 
     expect(approveCount).toBe(1);
     expect(issueComments).toHaveLength(1);
-    expect(createdReviews[0]?.body ?? "").toBe("");
+    expect(createdReviews[0]?.body).toBe(
+      buildReviewOutputMarker(
+        buildReviewOutputKey({
+          installationId: 42,
+          owner: "acme",
+          repo: "repo",
+          prNumber: 101,
+          action: "review_requested",
+          deliveryId: "delivery-123",
+          headSha: "abcdef1234567890",
+        }),
+      ),
+    );
     expect(issueComments[0]!.body).toContain("Decision: APPROVE");
     expect(issueComments[0]!.body).toContain("Issues: none");
     expect(issueComments[0]!.body).toContain("- Review prompt covered 2 changed files.");
@@ -5008,6 +5145,7 @@ describe("createReviewHandler finding extraction", () => {
     let createCommentCalls = 0;
     let updateCommentCalls = 0;
     let detailsCommentBody: string | undefined;
+    let initialDetailsCommentBody: string | undefined;
     let nextIssueCommentId = 500;
     const issueComments: Array<{ id: number; body: string }> = [];
 
@@ -5121,7 +5259,9 @@ describe("createReviewHandler finding extraction", () => {
             createCommentCalls += 1;
             const comment = { id: nextIssueCommentId++, body: params.body };
             issueComments.push(comment);
+            initialDetailsCommentBody = params.body;
             detailsCommentBody = params.body;
+            await new Promise((resolve) => setTimeout(resolve, 25));
             return { data: comment };
           },
           updateComment: async ({ comment_id, body }: { comment_id: number; body: string }) => {
@@ -5182,6 +5322,7 @@ describe("createReviewHandler finding extraction", () => {
     expect(listCommentsCalls).toBeGreaterThanOrEqual(1);
     expect(createCommentCalls).toBe(1);
     expect(updateCommentCalls).toBe(1);
+    expect(initialDetailsCommentBody).toBeDefined();
     expect(detailsCommentBody).toContain("<summary>Review Details</summary>");
     expect(detailsCommentBody).toContain(reviewDetailsMarker);
     expect(detailsCommentBody).toContain("Files reviewed:");
@@ -5201,6 +5342,11 @@ describe("createReviewHandler finding extraction", () => {
     expect(detailsCommentBody).not.toContain("Suppressions applied:");
     expect(detailsCommentBody).not.toContain("Estimated review time saved:");
     expect(detailsCommentBody).not.toContain("Low Confidence Findings");
+
+    const initialCompletedAt = initialDetailsCommentBody?.match(/- Review completed: (.+)/)?.[1];
+    const finalCompletedAt = detailsCommentBody?.match(/- Review completed: (.+)/)?.[1];
+    expect(initialCompletedAt).toBeDefined();
+    expect(finalCompletedAt).toBe(initialCompletedAt);
 
     const detailsAttemptLog = entries.find((entry) =>
       entry.data?.gate === "review-details-output" && entry.data?.gateResult === "attempt"
@@ -11928,6 +12074,161 @@ describe("createReviewHandler Review Details phase timing publication", () => {
     expect(updatedSummaryBody).toContain("remote runtime: 500ms");
     expect(updatedSummaryBody).toContain("publication:");
     expect(updatedSummaryBody).toContain(buildReviewOutputMarker(reviewOutputKey));
+
+    await workspaceFixture.cleanup();
+  });
+
+  test("rechecks publish rights before the finalized Review Details timing refresh", async () => {
+    const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
+    const workspaceFixture = await createWorkspaceFixture();
+    const { logger, entries } = createCaptureLogger();
+
+    let issueCommentListCalls = 0;
+    let updateCommentCalls = 0;
+    const updatedBodies: string[] = [];
+    const completedAttemptIds: string[] = [];
+
+    const reviewOutputKey = buildReviewOutputKey({
+      installationId: 42,
+      owner: "acme",
+      repo: "repo",
+      prNumber: 101,
+      action: "review_requested",
+      deliveryId: "delivery-123",
+      headSha: "abcdef1234567890",
+    });
+
+    const summaryBody = [
+      "<details>",
+      "<summary>Review summary</summary>",
+      "",
+      "No inline findings were published.",
+      "",
+      "</details>",
+      "",
+      buildReviewOutputMarker(reviewOutputKey),
+    ].join("\n");
+
+    const eventRouter: EventRouter = {
+      register: (eventKey, handler) => {
+        handlers.set(eventKey, handler);
+      },
+      dispatch: async () => undefined,
+    };
+
+    const jobQueue: JobQueue = {
+      enqueue: async <T>(
+        _installationId: number,
+        fn: (metadata: JobQueueRunMetadata) => Promise<T>,
+      ) => fn(createQueueRunMetadata()),
+      getQueueSize: () => 0,
+      getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
+    };
+
+    const workspaceManager: WorkspaceManager = {
+      create: async () => ({
+        dir: workspaceFixture.dir,
+        cleanup: async () => undefined,
+      }),
+      cleanupStale: async () => 0,
+    };
+
+    const octokit = {
+      rest: {
+        pulls: {
+          listReviewComments: async () => ({ data: [] }),
+          listReviews: async () => ({ data: [] }),
+          listCommits: async () => ({ data: [] }),
+        },
+        issues: {
+          listComments: async () => {
+            issueCommentListCalls += 1;
+            return issueCommentListCalls === 1
+              ? { data: [] }
+              : { data: [{ id: 77, body: updatedBodies.at(-1) ?? summaryBody }] };
+          },
+          createComment: async () => {
+            throw new Error("standalone fallback should not run");
+          },
+          updateComment: async (params: { body: string }) => {
+            updateCommentCalls += 1;
+            updatedBodies.push(params.body);
+            return { data: {} };
+          },
+        },
+        reactions: {
+          createForIssue: async () => ({ data: {} }),
+        },
+        search: {
+          issuesAndPullRequests: async () => ({ data: { total_count: 4 } }),
+        },
+      },
+    };
+
+    createReviewHandler({
+      eventRouter,
+      jobQueue,
+      workspaceManager,
+      githubApp: {
+        getAppSlug: () => "kodiai",
+        getInstallationOctokit: async () => octokit as never,
+      } as unknown as GitHubApp,
+      executor: {
+        execute: async () => ({
+          conclusion: "success",
+          published: true,
+          costUsd: 0,
+          numTurns: 1,
+          durationMs: 1,
+          sessionId: "session-review-details-finalized-recheck",
+          executorPhaseTimings: [
+            { name: "executor handoff", status: "completed", durationMs: 50 },
+            { name: "remote runtime", status: "completed", durationMs: 500 },
+          ],
+        }),
+      } as never,
+      telemetryStore: noopTelemetryStore,
+      reviewWorkCoordinator: {
+        claim: (claim: Record<string, unknown>) => ({
+          attemptId: "attempt-review-details-finalized-recheck-1",
+          familyKey: claim.familyKey as string,
+          source: claim.source as "automatic-review",
+          lane: claim.lane as "review",
+          deliveryId: claim.deliveryId as string,
+          phase: claim.phase as "claimed",
+          claimedAtMs: 100,
+          lastProgressAtMs: 100,
+        }),
+        canPublish: () => updateCommentCalls === 0,
+        setPhase: () => null,
+        getSnapshot: () => null,
+        release: () => undefined,
+        complete: (attemptId: string) => {
+          completedAttemptIds.push(attemptId);
+        },
+      } as never,
+      logger: logger as never,
+    });
+
+    const handler = handlers.get("pull_request.review_requested");
+    expect(handler).toBeDefined();
+
+    await handler!(
+      buildReviewRequestedEvent({
+        requested_reviewer: { login: "kodiai[bot]" },
+      }),
+    );
+
+    expect(issueCommentListCalls).toBeGreaterThanOrEqual(1);
+    expect(updateCommentCalls).toBe(1);
+    expect(updatedBodies[0]).toContain("captured before publication completed");
+    expect(
+      entries.some((entry) =>
+        entry.message === "Skipping finalized Review Details timing update because publish rights were superseded"
+      ),
+    ).toBeTrue();
+    expect(completedAttemptIds).toEqual(["attempt-review-details-finalized-recheck-1"]);
 
     await workspaceFixture.cleanup();
   });

--- a/src/handlers/review.ts
+++ b/src/handlers/review.ts
@@ -582,7 +582,10 @@ async function appendReviewDetailsToSummary(params: {
   const reviewDetailsMarker = buildReviewDetailsMarker(reviewOutputKey);
   const reviewDetailsHeader = "<details>\n<summary>Review Details</summary>";
   const existingDetailsStart = summaryBody.indexOf(reviewDetailsHeader);
-  const existingDetailsMarkerIndex = summaryBody.indexOf(reviewDetailsMarker);
+  const existingDetailsMarkerIndex = summaryBody.indexOf(
+    reviewDetailsMarker,
+    Math.max(existingDetailsStart, 0),
+  );
 
   // Insert or replace the Review Details block INSIDE the summary's <details>
   // block (before the last </details> tag) so it renders as a nested
@@ -3779,6 +3782,7 @@ export function createReviewHandler(deps: {
           (diffAnalysis?.metrics.totalLinesAdded ?? 0) +
           (diffAnalysis?.metrics.totalLinesRemoved ?? 0);
 
+        const reviewCompletedAt = new Date().toISOString();
         const buildReviewDetailsBody = (timeoutProgress?: TimeoutReviewDetailsProgress): string => {
           const reviewDetailsBody = formatReviewDetailsSummary({
             reviewOutputKey,
@@ -3807,6 +3811,7 @@ export function createReviewHandler(deps: {
               totalPhaseStartAt,
             }),
             timeoutProgress,
+            completedAt: reviewCompletedAt,
           });
 
           const suppressedSection = formatSuppressedFindingsSection(filterResult.filtered);
@@ -3859,6 +3864,7 @@ export function createReviewHandler(deps: {
                 repo: apiRepo,
                 pull_number: pr.number,
                 event: "APPROVE",
+                body: buildReviewOutputMarker(reviewOutputKey),
               });
               await octokit.rest.issues.createComment({
                 owner: apiOwner,
@@ -4006,6 +4012,8 @@ export function createReviewHandler(deps: {
                   botHandles: [githubApp.getAppSlug(), "claude"],
                   requireDegradationDisclosure: authorClassification.searchEnrichment.degraded,
                   reviewBoundedness,
+                  recheckCanPublish: () =>
+                    canPublishVisibleOutput("finalized Review Details timing update"),
                 });
               } else {
                 setReviewWorkPhase("publish");
@@ -4017,6 +4025,8 @@ export function createReviewHandler(deps: {
                   reviewOutputKey,
                   body: finalizedDetailsBody,
                   botHandles: [githubApp.getAppSlug(), "claude"],
+                  recheckCanPublish: () =>
+                    canPublishVisibleOutput("finalized Review Details timing update"),
                 });
               }
             }

--- a/src/handlers/review.ts
+++ b/src/handlers/review.ts
@@ -478,7 +478,7 @@ async function upsertReviewDetailsComment(params: {
   body: string;
   botHandles: string[];
   recheckCanPublish?: () => boolean;
-}): Promise<void> {
+}): Promise<boolean> {
   const { octokit, owner, repo, prNumber, reviewOutputKey, body, botHandles } = params;
   const marker = buildReviewDetailsMarker(reviewOutputKey);
   const sanitizedBody = sanitizeOutgoingMentions(body, botHandles);
@@ -497,7 +497,7 @@ async function upsertReviewDetailsComment(params: {
   );
 
   if (params.recheckCanPublish && !params.recheckCanPublish()) {
-    return;
+    return false;
   }
 
   if (existingComment) {
@@ -507,7 +507,7 @@ async function upsertReviewDetailsComment(params: {
       comment_id: existingComment.id,
       body: sanitizedBody,
     });
-    return;
+    return true;
   }
 
   await octokit.rest.issues.createComment({
@@ -516,6 +516,7 @@ async function upsertReviewDetailsComment(params: {
     issue_number: prNumber,
     body: sanitizedBody,
   });
+  return true;
 }
 
 async function appendReviewDetailsToSummary(params: {
@@ -529,7 +530,7 @@ async function appendReviewDetailsToSummary(params: {
   requireDegradationDisclosure: boolean;
   reviewBoundedness?: ReviewBoundednessContract | null;
   recheckCanPublish?: () => boolean;
-}): Promise<void> {
+}): Promise<boolean> {
   const { octokit, owner, repo, prNumber, reviewOutputKey, botHandles } = params;
   let updatedReviewDetails = params.reviewDetailsBlock;
   const marker = buildReviewOutputMarker(reviewOutputKey);
@@ -578,24 +579,39 @@ async function appendReviewDetailsToSummary(params: {
     );
   }
 
-  // Insert review details block INSIDE the summary's <details> block (before
-  // the last </details> tag) so it renders as a nested collapsible.  The review
-  // output marker (<!-- kodiai:review-output-key:... -->) that follows the
-  // summary's </details> stays outside both blocks.
-  const closingTag = '</details>';
-  const lastCloseIdx = summaryBody.lastIndexOf(closingTag);
+  const reviewDetailsMarker = buildReviewDetailsMarker(reviewOutputKey);
+  const reviewDetailsHeader = "<details>\n<summary>Review Details</summary>";
+  const existingDetailsStart = summaryBody.indexOf(reviewDetailsHeader);
+  const existingDetailsMarkerIndex = summaryBody.indexOf(reviewDetailsMarker);
+
+  // Insert or replace the Review Details block INSIDE the summary's <details>
+  // block (before the last </details> tag) so it renders as a nested
+  // collapsible. The review output marker that follows the summary's </details>
+  // stays outside both blocks.
   let updatedBody: string;
-  if (lastCloseIdx === -1) {
-    // Fallback: append as before if structure is unexpected
-    updatedBody = `${summaryBody}\n\n${updatedReviewDetails}`;
+  if (
+    existingDetailsStart !== -1 &&
+    existingDetailsMarkerIndex !== -1 &&
+    existingDetailsStart < existingDetailsMarkerIndex
+  ) {
+    const before = summaryBody.slice(0, existingDetailsStart).replace(/\s*$/, "");
+    const after = summaryBody.slice(existingDetailsMarkerIndex + reviewDetailsMarker.length).replace(/^\s*/, "");
+    updatedBody = `${before}\n\n${updatedReviewDetails}\n\n${after}`;
   } else {
-    const before = summaryBody.slice(0, lastCloseIdx);
-    const after = summaryBody.slice(lastCloseIdx);
-    updatedBody = `${before}\n\n${updatedReviewDetails}\n${after}`;
+    const closingTag = '</details>';
+    const lastCloseIdx = summaryBody.lastIndexOf(closingTag);
+    if (lastCloseIdx === -1) {
+      // Fallback: append as before if structure is unexpected
+      updatedBody = `${summaryBody}\n\n${updatedReviewDetails}`;
+    } else {
+      const before = summaryBody.slice(0, lastCloseIdx);
+      const after = summaryBody.slice(lastCloseIdx);
+      updatedBody = `${before}\n\n${updatedReviewDetails}\n${after}`;
+    }
   }
 
   if (params.recheckCanPublish && !params.recheckCanPublish()) {
-    return;
+    return false;
   }
 
   await octokit.rest.issues.updateComment({
@@ -604,6 +620,7 @@ async function appendReviewDetailsToSummary(params: {
     comment_id: summaryComment.id,
     body: sanitizeOutgoingMentions(updatedBody, botHandles),
   });
+  return true;
 }
 
 async function resolveAuthorTier(params: {
@@ -3086,6 +3103,7 @@ export function createReviewHandler(deps: {
         }
 
         setReviewWorkPhase("prompt-build");
+        const gitDiffInspectionAvailable = diffContext.strategy !== "github-file-list-fallback";
         // Build review prompt
         const reviewPrompt = buildReviewPrompt({
           owner: apiOwner,
@@ -3174,6 +3192,7 @@ export function createReviewHandler(deps: {
           graphBlastRadius: graphBlastRadius ?? undefined,
           structuralImpact: structuralImpactForReview,
           reviewBoundedness,
+          gitDiffInspectionAvailable,
         });
         reviewPhaseTimings.set(
           "retrieval/context assembly",
@@ -3207,6 +3226,7 @@ export function createReviewHandler(deps: {
           dynamicTimeoutSeconds: config.timeout.dynamicScaling !== false
             ? timeoutEstimate.dynamicTimeoutSeconds
             : undefined,
+          gitDiffInspectionAvailable,
         });
         executorResult = result;
         executorPhaseTimings = result.executorPhaseTimings ?? buildExecutorUnavailablePhases(
@@ -3795,6 +3815,93 @@ export function createReviewHandler(deps: {
             : reviewDetailsBody;
         };
 
+        let cleanApprovalSummaryPublished = false;
+
+        if (config.review.autoApprove && result.conclusion === "success" && !(result.published ?? false)) {
+          try {
+            const octokit = await githubApp.getInstallationOctokit(event.installationId);
+            const appSlug = githubApp.getAppSlug();
+
+            // Double-check via a scan for the review output marker. This provides
+            // defense-in-depth if the executor didn't report published=true.
+            const idempotencyCheck = await ensureReviewOutputNotPublished({
+              octokit,
+              owner: apiOwner,
+              repo: apiRepo,
+              prNumber: pr.number,
+              reviewOutputKey,
+            });
+
+            if (!idempotencyCheck.shouldPublish) {
+              logger.info(
+                {
+                  prNumber: pr.number,
+                  gate: "auto-approve",
+                  gateResult: "skipped",
+                  skipReason: "output-marker-present",
+                  existingLocation: idempotencyCheck.existingLocation,
+                },
+                "Skipping auto-approval because review output marker was published",
+              );
+            } else if (!canPublishVisibleOutput("auto-approval")) {
+              // publish-rights helper already logged the skip reason
+            } else {
+              setReviewWorkPhase("publish");
+              const approvalEvidence = [
+                `Review prompt covered ${promptFiles.length} changed file${promptFiles.length === 1 ? "" : "s"}.`,
+              ];
+              const approvalConfidence = depBumpContext?.mergeConfidence
+                ? renderApprovalConfidence(depBumpContext.mergeConfidence)
+                : null;
+
+              await octokit.rest.pulls.createReview({
+                owner: apiOwner,
+                repo: apiRepo,
+                pull_number: pr.number,
+                event: "APPROVE",
+              });
+              await octokit.rest.issues.createComment({
+                owner: apiOwner,
+                repo: apiRepo,
+                issue_number: pr.number,
+                body: sanitizeOutgoingMentions(
+                  buildApprovedReviewBody({
+                    reviewOutputKey,
+                    evidence: approvalEvidence,
+                    approvalConfidence,
+                  }),
+                  [appSlug, "claude"],
+                ),
+              });
+              cleanApprovalSummaryPublished = true;
+
+              logger.info(
+                {
+                  evidenceType: "review",
+                  outcome: "submitted-approval",
+                  deliveryId: event.id,
+                  installationId: event.installationId,
+                  owner: apiOwner,
+                  repoName: apiRepo,
+                  repo: `${apiOwner}/${apiRepo}`,
+                  prNumber: pr.number,
+                  reviewOutputKey,
+                },
+                "Evidence bundle",
+              );
+              logger.info(
+                { prNumber: pr.number, reviewOutputKey },
+                "Submitted silent approval (no issues found)",
+              );
+            }
+          } catch (err) {
+            logger.error(
+              { err, prNumber: pr.number },
+              "Failed to submit approval",
+            );
+          }
+        }
+
         if (shouldProcessReviewOutput) {
           logger.info(
             {
@@ -3811,52 +3918,96 @@ export function createReviewHandler(deps: {
           );
 
           try {
-            const fullDetailsBody = buildReviewDetailsBody();
-
-            if (result.published) {
-              // Summary comment was posted -- append Review Details to it
-              if (canPublishVisibleOutput("deterministic Review Details append")) {
-                try {
-                  setReviewWorkPhase("publish");
-                  await appendReviewDetailsToSummary({
-                    octokit: extractionOctokit,
-                    owner: apiOwner,
-                    repo: apiRepo,
-                    prNumber: pr.number,
-                    reviewOutputKey,
-                    reviewDetailsBlock: fullDetailsBody,
-                    botHandles: [githubApp.getAppSlug(), "claude"],
-                    requireDegradationDisclosure: authorClassification.searchEnrichment.degraded,
-                    reviewBoundedness,
-                    recheckCanPublish: () =>
-                      canPublishVisibleOutput("deterministic Review Details append"),
-                  });
-                } catch (appendErr) {
-                  // Fallback: post standalone if append fails (e.g., summary comment not found yet)
-                  logger.warn(
-                    { ...baseLog, gate: "review-details-output", gateResult: "append-fallback", err: appendErr },
-                    "Failed to append Review Details to summary comment; posting standalone",
-                  );
-                  if (canPublishVisibleOutput("deterministic Review Details standalone comment")) {
+            const publishReviewDetails = async (detailsBody: string): Promise<"append" | "standalone" | null> => {
+              if (result.published || cleanApprovalSummaryPublished) {
+                if (canPublishVisibleOutput("deterministic Review Details append")) {
+                  try {
                     setReviewWorkPhase("publish");
-                    await upsertReviewDetailsComment({
+                    const appended = await appendReviewDetailsToSummary({
                       octokit: extractionOctokit,
                       owner: apiOwner,
                       repo: apiRepo,
                       prNumber: pr.number,
                       reviewOutputKey,
-                      body: fullDetailsBody,
+                      reviewDetailsBlock: detailsBody,
                       botHandles: [githubApp.getAppSlug(), "claude"],
+                      requireDegradationDisclosure: authorClassification.searchEnrichment.degraded,
+                      reviewBoundedness,
                       recheckCanPublish: () =>
-                        canPublishVisibleOutput("deterministic Review Details standalone comment"),
+                        canPublishVisibleOutput("deterministic Review Details append"),
                     });
+                    return appended ? "append" : null;
+                  } catch (appendErr) {
+                    logger.warn(
+                      { ...baseLog, gate: "review-details-output", gateResult: "append-fallback", err: appendErr },
+                      "Failed to append Review Details to summary comment; posting standalone",
+                    );
+                    if (canPublishVisibleOutput("deterministic Review Details standalone comment")) {
+                      setReviewWorkPhase("publish");
+                      const publishedStandalone = await upsertReviewDetailsComment({
+                        octokit: extractionOctokit,
+                        owner: apiOwner,
+                        repo: apiRepo,
+                        prNumber: pr.number,
+                        reviewOutputKey,
+                        body: detailsBody,
+                        botHandles: [githubApp.getAppSlug(), "claude"],
+                        recheckCanPublish: () =>
+                          canPublishVisibleOutput("deterministic Review Details standalone comment"),
+                      });
+                      return publishedStandalone ? "standalone" : null;
+                    }
                   }
                 }
+                return null;
               }
-            } else {
-              // No summary comment (clean review) -- post standalone Review Details
-              // FORMAT-11 exemption: no summary exists to embed into; standalone preserves metrics visibility
+
               if (canPublishVisibleOutput("deterministic Review Details standalone comment")) {
+                setReviewWorkPhase("publish");
+                const publishedStandalone = await upsertReviewDetailsComment({
+                  octokit: extractionOctokit,
+                  owner: apiOwner,
+                  repo: apiRepo,
+                  prNumber: pr.number,
+                  reviewOutputKey,
+                  body: detailsBody,
+                  botHandles: [githubApp.getAppSlug(), "claude"],
+                  recheckCanPublish: () =>
+                    canPublishVisibleOutput("deterministic Review Details standalone comment"),
+                });
+                return publishedStandalone ? "standalone" : null;
+              }
+
+              return null;
+            };
+
+            const publicationMode = await publishReviewDetails(buildReviewDetailsBody());
+
+            if (publicationMode && publicationPhaseStartedAt !== undefined) {
+              reviewPhaseTimings.set(
+                "publication",
+                createReviewPhaseTiming({
+                  name: "publication",
+                  status: "completed",
+                  durationMs: Math.max(0, Date.now() - publicationPhaseStartedAt),
+                }),
+              );
+
+              const finalizedDetailsBody = buildReviewDetailsBody();
+              if (publicationMode === "append") {
+                setReviewWorkPhase("publish");
+                await appendReviewDetailsToSummary({
+                  octokit: extractionOctokit,
+                  owner: apiOwner,
+                  repo: apiRepo,
+                  prNumber: pr.number,
+                  reviewOutputKey,
+                  reviewDetailsBlock: finalizedDetailsBody,
+                  botHandles: [githubApp.getAppSlug(), "claude"],
+                  requireDegradationDisclosure: authorClassification.searchEnrichment.degraded,
+                  reviewBoundedness,
+                });
+              } else {
                 setReviewWorkPhase("publish");
                 await upsertReviewDetailsComment({
                   octokit: extractionOctokit,
@@ -3864,10 +4015,8 @@ export function createReviewHandler(deps: {
                   repo: apiRepo,
                   prNumber: pr.number,
                   reviewOutputKey,
-                  body: fullDetailsBody,
+                  body: finalizedDetailsBody,
                   botHandles: [githubApp.getAppSlug(), "claude"],
-                  recheckCanPublish: () =>
-                    canPublishVisibleOutput("deterministic Review Details standalone comment"),
                 });
               }
             }
@@ -4632,6 +4781,7 @@ export function createReviewHandler(deps: {
                       // PR-issue linking (PRLINK-03) — reuse from initial review
                       linkedIssues: linkedIssueResult,
                       structuralImpact: structuralImpactForReview,
+                      gitDiffInspectionAvailable,
                     });
 
                     setReviewWorkPhaseForAttempt(retryReviewWorkAttempt.attemptId, "executor-dispatch");
@@ -4654,6 +4804,7 @@ export function createReviewHandler(deps: {
                       totalFiles: timeoutTotalFiles,
                       enableCheckpointTool: retryCheckpointEnabled,
                       enableCommentTools: false,
+                      gitDiffInspectionAvailable,
                     });
 
                       const retryCheckpoint = (await knowledgeStore?.getCheckpoint?.(retryReviewOutputKey)) ?? null;
@@ -4867,106 +5018,42 @@ export function createReviewHandler(deps: {
           }
         }
 
-        // Auto-approval: only when autoApprove is enabled AND execution succeeded AND
-        // the model produced zero GitHub-visible output (no summary comment, no inline comments).
-        if (config.review.autoApprove && result.conclusion === "success") {
-          try {
-            // If the review execution published any output (summary comment, inline comments, etc.),
-            // do NOT auto-approve. Auto-approval is only valid when the bot produced zero output.
-            if (result.published) {
-              logger.info(
-                {
-                  prNumber: pr.number,
-                  gate: "auto-approve",
-                  gateResult: "skipped",
-                  skipReason: "output-published",
-                },
-                "Skipping auto-approval because review output was published",
-              );
-              return;
-            }
+        if (result.conclusion === "failure" && !(result.published ?? false)) {
+          const exhaustedTurnBudget =
+            result.stopReason === "max_turns" ||
+            result.failureSubtype === "error_max_turns";
+          const failureBody = exhaustedTurnBudget
+            ? [
+                "> **Kodiai ran out of steps while reviewing this PR**",
+                "",
+                "_The review run ended before it could publish comments or an approval._",
+                "",
+                ...(result.stopReason ? [`Stop reason: ${result.stopReason}`] : []),
+                ...(result.failureSubtype ? [`Failure subtype: ${result.failureSubtype}`] : []),
+                "",
+                "Try requesting another review after narrowing the scope or improving the available review context.",
+              ].join("\n")
+            : [
+                "> **Kodiai completed the review run but could not publish review output**",
+                "",
+                ...(result.stopReason ? [`Stop reason: ${result.stopReason}`] : []),
+                ...(result.failureSubtype ? [`Failure subtype: ${result.failureSubtype}`] : []),
+                ...(result.errorMessage ? [result.errorMessage] : []),
+                "",
+                "Try requesting another review if you want a fresh attempt.",
+              ].join("\n");
 
-            const octokit = await githubApp.getInstallationOctokit(event.installationId);
-            const appSlug = githubApp.getAppSlug();
-
-            // Double-check via a scan for the review output marker. This provides
-            // defense-in-depth if the executor didn't report published=true.
-            const idempotencyCheck = await ensureReviewOutputNotPublished({
-              octokit,
+          const octokit = await githubApp.getInstallationOctokit(event.installationId);
+          if (canPublishVisibleOutput("failure fallback comment")) {
+            setReviewWorkPhase("publish");
+            await postOrUpdateErrorComment(octokit, {
               owner: apiOwner,
               repo: apiRepo,
-              prNumber: pr.number,
-              reviewOutputKey,
-            });
-
-            if (!idempotencyCheck.shouldPublish) {
-              logger.info(
-                {
-                  prNumber: pr.number,
-                  gate: "auto-approve",
-                  gateResult: "skipped",
-                  skipReason: "output-marker-present",
-                  existingLocation: idempotencyCheck.existingLocation,
-                },
-                "Skipping auto-approval because review output marker was published",
-              );
-              return;
-            }
-
-            {
-              if (!canPublishVisibleOutput("auto-approval")) {
-                return;
-              }
-
-              setReviewWorkPhase("publish");
-              const approvalEvidence = [
-                `Review prompt covered ${promptFiles.length} changed file${promptFiles.length === 1 ? "" : "s"}.`,
-              ];
-              const approvalConfidence = depBumpContext?.mergeConfidence
-                ? renderApprovalConfidence(depBumpContext.mergeConfidence)
-                : null;
-
-              await octokit.rest.pulls.createReview({
-                owner: apiOwner,
-                repo: apiRepo,
-                pull_number: pr.number,
-                event: "APPROVE",
-                body: sanitizeOutgoingMentions(
-                  buildApprovedReviewBody({
-                    reviewOutputKey,
-                    evidence: approvalEvidence,
-                    approvalConfidence,
-                  }),
-                  [appSlug, "claude"],
-                ),
-              });
-
-              logger.info(
-                {
-                  evidenceType: "review",
-                  outcome: "submitted-approval",
-                  deliveryId: event.id,
-                  installationId: event.installationId,
-                  owner: apiOwner,
-                  repoName: apiRepo,
-                  repo: `${apiOwner}/${apiRepo}`,
-                  prNumber: pr.number,
-                  reviewOutputKey,
-                },
-                "Evidence bundle",
-              );
-              logger.info(
-                { prNumber: pr.number, reviewOutputKey },
-                "Submitted silent approval (no issues found)",
-              );
-            }
-          } catch (err) {
-            logger.error(
-              { err, prNumber: pr.number },
-              "Failed to submit approval",
-            );
+              issueNumber: pr.number,
+            }, sanitizeOutgoingMentions(failureBody, [githubApp.getAppSlug(), "claude"]), logger);
           }
         }
+
       } catch (err) {
         if (!reviewPhaseTimings.has("workspace preparation") && workspacePhaseStartedAt !== undefined) {
           reviewPhaseTimings.set(

--- a/src/lib/review-utils.test.ts
+++ b/src/lib/review-utils.test.ts
@@ -82,6 +82,15 @@ describe("formatReviewDetailsSummary", () => {
     }
   });
 
+  it("uses an explicit completedAt timestamp when provided", () => {
+    const result = formatReviewDetailsSummary({
+      ...BASE_PARAMS,
+      completedAt: "2026-04-20T03:21:00.000Z",
+    });
+
+    expect(result).toContain("- Review completed: 2026-04-20T03:21:00.000Z");
+  });
+
   it("renders usage line when usageLimit is present", () => {
     const result = formatReviewDetailsSummary({
       ...BASE_PARAMS,

--- a/src/lib/review-utils.ts
+++ b/src/lib/review-utils.ts
@@ -386,6 +386,7 @@ export function formatReviewDetailsSummary(params: {
   structuralImpact?: StructuralImpactPayload | null;
   phaseTimingSummary?: ReviewDetailsPhaseTimingSummary | null;
   timeoutProgress?: TimeoutReviewDetailsProgress | null;
+  completedAt?: string;
 }): string {
   const {
     reviewOutputKey,
@@ -405,6 +406,7 @@ export function formatReviewDetailsSummary(params: {
     structuralImpact,
     phaseTimingSummary,
     timeoutProgress,
+    completedAt,
   } = params;
 
   const formatProfileLine = (label: string, profile: ResolvedReviewProfile): string => {
@@ -460,7 +462,7 @@ export function formatReviewDetailsSummary(params: {
         ]
       : [profileLine]),
     `- Contributor experience: ${contributorExperience.text}`,
-    `- Review completed: ${new Date().toISOString()}`,
+    `- Review completed: ${completedAt ?? new Date().toISOString()}`,
   ];
 
   if (phaseTimingSummary) {


### PR DESCRIPTION
## Summary
- stop degraded review lanes from advertising or exposing git diff/history tools when local diff inspection is unavailable
- publish a visible fallback when automatic review execution dies on max-turn/tool-use failures instead of leaving the PR silent
- collapse clean approvals into one marker-backed issue comment with Review Details refreshed after publication timing is known

## Root cause
On `github-file-list-fallback` runs, the review prompt and tool surface still encouraged merge-base git commands that the degraded workspace could not reliably support. The model could spend turns chasing an impossible diff and end in `error_max_turns` without any visible publication. Clean approval flows also split output across the approval review and a separate Review Details comment, with timing captured before publication completed.

## Verification
- `bun test ./src/handlers/review.test.ts ./src/execution/review-prompt.test.ts ./src/execution/executor.test.ts`
- `bun run tsc --noEmit`