### PR TITLE
test: add m057 webhook proof surface

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "verify:m056:s01": "bun scripts/verify-m056-s01.ts",
     "verify:m056:s02": "bun scripts/verify-m056-s02.ts",
     "verify:m056:s03": "bun scripts/verify-m056-s03.ts",
+    "verify:m057:s01": "bun scripts/verify-m057-s01.ts",
     "verify:m057:s02": "bun scripts/verify-m057-s02.ts",
     "verify:m057:s03": "bun scripts/verify-m057-s03.ts",
     "verify:m057:s04": "bun scripts/verify-m057-s04.ts",

--- a/scripts/verify-m057-s01.test.ts
+++ b/scripts/verify-m057-s01.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import { COMMAND_NAME, runVerifyM057S01 } from "./verify-m057-s01.ts";
+
+describe("runVerifyM057S01", () => {
+  test("runs every command and prints pass output", () => {
+    const calls: readonly string[][] = [];
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+
+    runVerifyM057S01(
+      [
+        ["bun", "test", "./src/webhook/verify.test.ts"],
+        ["bun", "test", "./src/webhook/filters.test.ts"],
+        ["bun", "test", "./src/handlers/review.test.ts", "--test-name-pattern", "skips team-only review requests"],
+      ],
+      (command) => {
+        (calls as string[][]).push([...command]);
+        return { exitCode: 0 };
+      },
+      (message) => stdout.push(message),
+      (message) => stderr.push(message),
+      (code) => {
+        throw new Error(`unexpected exit(${code})`);
+      },
+    );
+
+    expect(calls).toEqual([
+      ["bun", "test", "./src/webhook/verify.test.ts"],
+      ["bun", "test", "./src/webhook/filters.test.ts"],
+      ["bun", "test", "./src/handlers/review.test.ts", "--test-name-pattern", "skips team-only review requests"],
+    ]);
+    expect(stderr).toEqual([]);
+    expect(stdout).toEqual([
+      "→ bun test ./src/webhook/verify.test.ts\n",
+      "→ bun test ./src/webhook/filters.test.ts\n",
+      "→ bun test ./src/handlers/review.test.ts --test-name-pattern skips team-only review requests\n",
+      `${COMMAND_NAME} passed\n`,
+    ]);
+  });
+
+  test("writes failure output and exits on first failing command", () => {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    let exitCode: number | undefined;
+
+    expect(() =>
+      runVerifyM057S01(
+        [
+          ["bun", "test", "./src/webhook/verify.test.ts"],
+          ["bun", "test", "./src/webhook/router.test.ts"],
+          ["bun", "test", "./src/handlers/review.test.ts", "--test-name-pattern", "skips team-only review requests"],
+        ],
+        (command) => ({ exitCode: command[2] === "./src/webhook/router.test.ts" ? 1 : 0 }),
+        (message) => stdout.push(message),
+        (message) => stderr.push(message),
+        (code) => {
+          exitCode = code;
+          throw new Error(`exit(${code})`);
+        },
+      )
+    ).toThrow("exit(1)");
+
+    expect(exitCode).toBe(1);
+    expect(stdout).toEqual([
+      "→ bun test ./src/webhook/verify.test.ts\n",
+      "→ bun test ./src/webhook/router.test.ts\n",
+    ]);
+    expect(stderr).toEqual([
+      `${COMMAND_NAME} failed: bun test ./src/webhook/router.test.ts\n`,
+    ]);
+  });
+});

--- a/scripts/verify-m057-s01.ts
+++ b/scripts/verify-m057-s01.ts
@@ -1,0 +1,59 @@
+const COMMAND_NAME = "verify:m057:s01" as const;
+const TEST_COMMANDS = [
+  ["bun", "test", "./src/webhook/verify.test.ts"],
+  ["bun", "test", "./src/webhook/dedup.test.ts"],
+  ["bun", "test", "./src/webhook/router.test.ts"],
+  ["bun", "test", "./src/webhook/filters.test.ts"],
+  [
+    "bun",
+    "test",
+    "./src/handlers/review.test.ts",
+    "--test-name-pattern",
+    "skips team-only review requests",
+  ],
+] as const;
+
+type TestCommand = readonly string[];
+type SpawnSyncFn = (command: TestCommand) => { exitCode: number | null | undefined };
+type WriteFn = (message: string) => void;
+type ExitFn = (code: number) => never;
+
+function formatCommand(command: TestCommand): string {
+  return command.join(" ");
+}
+
+function defaultSpawnSync(command: TestCommand): { exitCode: number | null } {
+  return Bun.spawnSync({
+    cmd: [...command],
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+}
+
+export function runVerifyM057S01(
+  commands: readonly TestCommand[] = TEST_COMMANDS,
+  spawnSyncFn: SpawnSyncFn = defaultSpawnSync,
+  writeStdout: WriteFn = (message) => process.stdout.write(message),
+  writeStderr: WriteFn = (message) => process.stderr.write(message),
+  exitFn: ExitFn = (code) => process.exit(code),
+): void {
+  for (const command of commands) {
+    const formatted = formatCommand(command);
+    writeStdout(`→ ${formatted}\n`);
+
+    const result = spawnSyncFn(command);
+    if ((result.exitCode ?? 1) !== 0) {
+      writeStderr(`${COMMAND_NAME} failed: ${formatted}\n`);
+      exitFn(result.exitCode ?? 1);
+      return;
+    }
+  }
+
+  writeStdout(`${COMMAND_NAME} passed\n`);
+}
+
+export { COMMAND_NAME, TEST_COMMANDS };
+
+if (import.meta.main) {
+  runVerifyM057S01();
+}


### PR DESCRIPTION
## Summary
- add the missing `verify:m057:s01` proof harness for webhook-layer coverage
- add regression tests for the new verifier script
- wire `verify:m057:s01` into `package.json`

## Verification
- `bun test ./scripts/verify-m057-s01.test.ts`
- `bun run verify:m057:s01`
- `bun run verify:m057:s01 && bun run verify:m057:s02 && bun run verify:m057:s03 && bun run verify:m057:s04`
