### PR TITLE
fix: unify review details onto one canonical review surface

### DIFF
--- a/src/handlers/review-idempotency.test.ts
+++ b/src/handlers/review-idempotency.test.ts
@@ -243,6 +243,39 @@ describe("review idempotency helpers", () => {
     expect(result).toContain("<summary>kodiai response</summary>");
   });
 
+  test("buildApprovedReviewBody can inline Review Details while preserving canonical marker discovery", () => {
+    const reviewOutputKey = buildReviewOutputKey({
+      installationId: 42,
+      owner: "acme",
+      repo: "repo",
+      prNumber: 101,
+      action: "mention-review",
+      deliveryId: "delivery-123",
+      headSha: "abcdef1234",
+    });
+
+    const result = buildApprovedReviewBody({
+      reviewOutputKey,
+      evidence: ["Reviewed only source files."],
+      approvalConfidence: null,
+      reviewDetailsBlock: [
+        "<details>",
+        "<summary>Review Details</summary>",
+        "",
+        "- Total wall-clock: 1ms",
+        "",
+        "</details>",
+        "",
+        `<!-- kodiai:review-details:${reviewOutputKey} -->`,
+      ].join("\n"),
+    });
+
+    expect(result).toContain("Decision: APPROVE");
+    expect(result).toContain("<summary>Review Details</summary>");
+    expect(result).toContain(`<!-- kodiai:review-details:${reviewOutputKey} -->`);
+    expect(extractReviewOutputKey(result)).toBe(reviewOutputKey);
+  });
+
   test("buildApprovedReviewBody preserves exactly three normalized evidence bullets without approval confidence", () => {
     const reviewOutputKey = buildReviewOutputKey({
       installationId: 42,

--- a/src/handlers/review-idempotency.ts
+++ b/src/handlers/review-idempotency.ts
@@ -298,6 +298,7 @@ export function buildApprovedReviewBody(params: {
   reviewOutputKey: string;
   evidence?: string[];
   approvalConfidence?: string | null;
+  reviewDetailsBlock?: string | null;
 }): string {
   const marker = buildReviewOutputMarker(params.reviewOutputKey);
   const evidence = buildApprovedReviewEvidence(params);
@@ -311,8 +312,11 @@ export function buildApprovedReviewBody(params: {
     ].join("\n"),
     "kodiai response",
   );
+  const reviewDetailsBlock = params.reviewDetailsBlock?.trim();
 
-  return [collapsedBody, "", marker].join("\n");
+  return reviewDetailsBlock
+    ? [collapsedBody, "", reviewDetailsBlock, "", marker].join("\n")
+    : [collapsedBody, "", marker].join("\n");
 }
 
 export async function ensureReviewOutputNotPublished(deps: {

--- a/src/handlers/review.test.ts
+++ b/src/handlers/review.test.ts
@@ -2226,7 +2226,7 @@ describe("createReviewHandler review_requested idempotency", () => {
     const workspaceFixture = await createWorkspaceFixture({ autoApprove: false });
 
     let issueCommentUpdateCount = 0;
-    let issueCommentUpdateId: number | undefined;
+    const issueCommentUpdateIds: number[] = [];
     let createReviewCount = 0;
     let updateReviewCount = 0;
 
@@ -2244,7 +2244,10 @@ describe("createReviewHandler review_requested idempotency", () => {
     const issueCommentBodiesByCall = [
       [{ id: 901, body: `existing issue comment\n\n${marker}` }],
       [{ id: 901, body: `existing issue comment\n\n${marker}` }],
-      [{ id: 901, body: `existing issue comment\n\n${marker}` }],
+      [
+        { id: 900, body: `older issue comment\n\n${marker}` },
+        { id: 901, body: `existing issue comment\n\n${marker}` },
+      ],
     ] as const;
     const reviewBodiesByCall = [
       [{ id: 902, body: `existing pull review\n\n${marker}` }],
@@ -2301,7 +2304,7 @@ describe("createReviewHandler review_requested idempotency", () => {
           createComment: async (params: { body: string }) => ({ data: { id: 901, body: params.body } }),
           updateComment: async ({ comment_id, body }: { comment_id: number; body: string }) => {
             issueCommentUpdateCount += 1;
-            issueCommentUpdateId = comment_id;
+            issueCommentUpdateIds.push(comment_id);
             expect(body).toContain("<summary>Review Details</summary>");
             return { data: { id: comment_id, body } };
           },
@@ -2353,8 +2356,8 @@ describe("createReviewHandler review_requested idempotency", () => {
 
     await workspaceFixture.cleanup();
 
-    expect(issueCommentUpdateId).toBe(901);
-    expect(issueCommentUpdateCount).toBe(1);
+    expect(issueCommentUpdateIds).toEqual([901, 901]);
+    expect(issueCommentUpdateCount).toBe(2);
     expect(createReviewCount).toBe(0);
     expect(updateReviewCount).toBe(0);
     expect(listReviewsCallCount).toBe(0);
@@ -9599,6 +9602,172 @@ describe("createReviewHandler timeout resilience", () => {
     expect(
       entries.some((entry) => entry.message === "Skipping timeout canonical Review Details merge because publish rights were superseded"),
     ).toBeTrue();
+
+    await workspaceFixture.cleanup();
+  });
+
+  test("timeout canonical Review Details merge refreshes the same bounded partial comment when older marker-matching comments exist", async () => {
+    const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
+    const workspaceFixture = await createWorkspaceFixture();
+
+    const reviewOutputKey = buildReviewOutputKey({
+      installationId: 42,
+      owner: "acme",
+      repo: "repo",
+      prNumber: 101,
+      action: "review_requested",
+      deliveryId: "delivery-123",
+      headSha: "abcdef1234567890",
+    });
+    const marker = buildReviewOutputMarker(reviewOutputKey);
+
+    const issueComments = new Map<number, string>([
+      [700, `older timeout comment\n\n${marker}`],
+    ]);
+    let nextCommentId = 701;
+    let timeoutPartialCommentId: number | undefined;
+    let timeoutCanonicalUpdateId: number | undefined;
+
+    const eventRouter: EventRouter = {
+      register: (eventKey, handler) => {
+        handlers.set(eventKey, handler);
+      },
+      dispatch: async () => undefined,
+    };
+
+    const jobQueue: JobQueue = {
+      enqueue: async <T>(
+        _installationId: number,
+        fn: (metadata: JobQueueRunMetadata) => Promise<T>,
+        context?: { action?: string },
+      ) => {
+        if (context?.action === "review-retry") {
+          return undefined as T;
+        }
+        return fn(createQueueRunMetadata());
+      },
+      getQueueSize: () => 0,
+      getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
+    };
+
+    const workspaceManager: WorkspaceManager = {
+      create: async () => ({
+        dir: workspaceFixture.dir,
+        cleanup: async () => undefined,
+      }),
+      cleanupStale: async () => 0,
+    };
+
+    const octokit = {
+      rest: {
+        pulls: {
+          listReviewComments: async () => ({ data: [] }),
+          listReviews: async () => ({ data: [] }),
+          listCommits: async () => ({ data: [] }),
+        },
+        issues: {
+          listComments: async () => ({
+            data: Array.from(issueComments.entries()).map(([id, body]) => ({ id, body })),
+          }),
+          createComment: async (params: { body: string }) => {
+            const id = nextCommentId++;
+            issueComments.set(id, params.body);
+            if (params.body.includes("**Bounded first-pass review**")) {
+              timeoutPartialCommentId = id;
+            }
+            return { data: { id } };
+          },
+          updateComment: async (params: { comment_id: number; body: string }) => {
+            if (params.body.includes("<summary>Review Details</summary>")) {
+              timeoutCanonicalUpdateId = params.comment_id;
+            }
+            issueComments.set(params.comment_id, params.body);
+            return { data: {} };
+          },
+        },
+        reactions: {
+          createForIssue: async () => ({ data: {} }),
+        },
+      },
+    };
+
+    createReviewHandler({
+      eventRouter,
+      jobQueue,
+      workspaceManager,
+      githubApp: {
+        getAppSlug: () => "kodiai",
+        getInstallationOctokit: async () => octokit as never,
+      } as unknown as GitHubApp,
+      executor: {
+        execute: async () => ({
+          conclusion: "error",
+          isTimeout: true,
+          published: false,
+          errorMessage: "timeout",
+          costUsd: 0,
+          numTurns: 1,
+          durationMs: 1,
+          sessionId: "session-timeout-review-details-canonical-id",
+          model: "test-model",
+          inputTokens: 0,
+          outputTokens: 0,
+          cacheReadTokens: 0,
+          cacheCreationTokens: 0,
+          stopReason: "timeout",
+        }),
+      } as never,
+      telemetryStore: noopTelemetryStore,
+      knowledgeStore: createKnowledgeStoreStub({
+        getCheckpoint: async () => ({
+          reviewOutputKey: "unused-in-test",
+          repo: "acme/repo",
+          prNumber: 101,
+          filesReviewed: ["README.md"],
+          findingCount: 1,
+          summaryDraft: "Found one issue before timeout.",
+          totalFiles: 1,
+        }),
+        updateCheckpointCommentId: () => undefined,
+        deleteCheckpoint: () => undefined,
+      }) as never,
+      logger: createNoopLogger(),
+    });
+
+    const handler = handlers.get("pull_request.review_requested");
+    expect(handler).toBeDefined();
+
+    await handler!(
+      buildReviewRequestedEvent({
+        requested_reviewer: { login: "kodiai[bot]" },
+        pull_request: {
+          number: 101,
+          draft: false,
+          title: "Timeout canonical id pinning",
+          body: "",
+          commits: 0,
+          additions: 1,
+          deletions: 0,
+          user: { login: "octocat" },
+          base: { ref: "main", sha: "mainsha" },
+          head: {
+            sha: "abcdef1234567890",
+            ref: "feature",
+            repo: {
+              full_name: "acme/repo",
+              name: "repo",
+              owner: { login: "acme" },
+            },
+          },
+          labels: [],
+        },
+      }),
+    );
+
+    expect(timeoutPartialCommentId).toBeDefined();
+    expect(timeoutCanonicalUpdateId).toBe(timeoutPartialCommentId);
+    expect(timeoutCanonicalUpdateId).not.toBe(700);
 
     await workspaceFixture.cleanup();
   });

--- a/src/handlers/review.test.ts
+++ b/src/handlers/review.test.ts
@@ -5509,7 +5509,7 @@ describe("createReviewHandler finding extraction", () => {
     await workspaceFixture.cleanup();
   });
 
-  test("suppresses Review Details append when publish rights were superseded", async () => {
+  test("suppresses canonical Review Details merge when publish rights were superseded", async () => {
     const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
     const workspaceFixture = await createWorkspaceFixture();
     const { logger, entries } = createCaptureLogger();
@@ -5788,7 +5788,7 @@ describe("createReviewHandler finding extraction", () => {
     await workspaceFixture.cleanup();
   });
 
-  test("rechecks Review Details append publish rights after summary lookup", async () => {
+  test("rechecks canonical Review Details merge publish rights after summary lookup", async () => {
     const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
     const workspaceFixture = await createWorkspaceFixture();
     const { logger, entries } = createCaptureLogger();
@@ -14816,7 +14816,7 @@ describe("createReviewHandler phase timing logging", () => {
 });
 
 describe("createReviewHandler Review Details phase timing publication", () => {
-  test("appends Review Details timings into the published summary comment", async () => {
+  test("merges Review Details timings into the published canonical visible surface", async () => {
     const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
     const workspaceFixture = await createWorkspaceFixture();
 

--- a/src/handlers/review.test.ts
+++ b/src/handlers/review.test.ts
@@ -2054,13 +2054,15 @@ describe("createReviewHandler review_requested idempotency", () => {
     expect(extractReviewOutputKey(reviewDetailsBlock)).toBe(expectedReviewOutputKey);
   });
 
-  test("auto-approve finalization updates the canonical pull review when mixed surfaces exist after a review-surface idempotency accept", async () => {
+  test("auto-approve finalization keeps Review Details on the issue-comment path when mixed surfaces exist after a review-surface idempotency accept", async () => {
     const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
     const workspaceFixture = await createWorkspaceFixture({ autoApprove: true });
 
     let approveCount = 0;
+    let issueCommentCreateCount = 0;
     let issueCommentUpdateCount = 0;
     let updatedReviewId: number | undefined;
+    const createdIssueComments: Array<{ id: number; body: string }> = [];
     const createdReviews: Array<{ id: number; body?: string | null }> = [];
 
     const reviewOutputKey = buildReviewOutputKey({
@@ -2135,7 +2137,12 @@ describe("createReviewHandler review_requested idempotency", () => {
             listCommentsCallCount += 1;
             return { data };
           },
-          createComment: async (params: { body: string }) => ({ data: { id: 901, body: params.body } }),
+          createComment: async (params: { body: string }) => {
+            issueCommentCreateCount += 1;
+            const comment = { id: 901, body: params.body };
+            createdIssueComments.push(comment);
+            return { data: comment };
+          },
           updateComment: async ({ comment_id }: { comment_id: number; body: string }) => {
             issueCommentUpdateCount += 1;
             return { data: { id: comment_id } };
@@ -2196,11 +2203,14 @@ describe("createReviewHandler review_requested idempotency", () => {
     await workspaceFixture.cleanup();
 
     expect(approveCount).toBe(1);
-    expect(updatedReviewId).toBe(902);
-    expect(issueCommentUpdateCount).toBe(0);
+    expect(updatedReviewId).toBeUndefined();
+    expect(issueCommentCreateCount).toBe(1);
+    expect(issueCommentUpdateCount).toBe(1);
     expect(createdReviews).toHaveLength(1);
     expect(createdReviews[0]?.body).toContain("Decision: APPROVE");
-    expect(createdReviews[0]?.body).toContain("<summary>Review Details</summary>");
+    expect(createdReviews[0]?.body).not.toContain("<summary>Review Details</summary>");
+    expect(createdIssueComments).toHaveLength(1);
+    expect(createdIssueComments[0]?.body).toContain("<summary>Review Details</summary>");
   });
 
   test("published-output finalization updates only the canonical issue comment when mixed surfaces exist after an issue-comment idempotency accept", async () => {
@@ -11423,6 +11433,7 @@ describe("createReviewHandler timeout resilience", () => {
     const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
     const workspaceFixture = await createWorkspaceFixture();
     const { logger, entries } = createCaptureLogger();
+    const canonicalWrites: Array<Record<string, unknown>> = [];
 
     const checkpointState = new Map<string, {
       partialCommentId?: number;
@@ -11668,6 +11679,9 @@ describe("createReviewHandler timeout resilience", () => {
         deleteCheckpoint: (key: string) => {
           checkpointState.delete(key);
         },
+        upsertContinuationFamilyState: async (record: Record<string, unknown>) => {
+          canonicalWrites.push(record);
+        },
       }) as never,
       diffContextCollector: async () => ({
         changedFiles: ["README.md", "src/a.ts", "src/b.ts"],
@@ -11737,6 +11751,18 @@ describe("createReviewHandler timeout resilience", () => {
       body.includes("<summary>Review Details</summary>") && !body.includes("Retry complete -- analyzed 2 of 3 files total after a reduced-scope follow-up.")
     );
     expect(standaloneReviewDetails).toContain("<summary>Review Details</summary>");
+    expect(canonicalWrites.at(-1)).toMatchObject({
+      familyKey: buildReviewFamilyKey("acme", "repo", 101),
+      authoritativeAttemptId: "review-work-2",
+      authoritativeAttemptOrdinal: 2,
+      authoritativeOutcome: "merged",
+      finalStopReason: "merged-continuation-results",
+      projectionStatus: "degraded",
+      supersededByAttemptId: null,
+    });
+    expect(
+      entries.some((entry) => entry.message === "Retry complete -- updated partial review comment with merged results; Review Details published via standalone fallback" && entry.data?.projectionStatus === "degraded"),
+    ).toBeTrue();
     expect(
       entries.some((entry) => entry.data?.gate === "review-details-output" && entry.data?.gateResult === "degraded-fallback"),
     ).toBeTrue();

--- a/src/handlers/review.test.ts
+++ b/src/handlers/review.test.ts
@@ -1903,7 +1903,7 @@ describe("createReviewHandler review_requested idempotency", () => {
     ).toBe(true);
   });
 
-  test("clean approval uses the approval review body as the only canonical visible surface", async () => {
+  test("clean approval keeps Review Details on the issue-comment path and leaves the approval review body clean", async () => {
     const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
     const workspaceFixture = await createWorkspaceFixture({ autoApprove: true });
     const { logger } = createCaptureLogger();
@@ -1958,7 +1958,7 @@ describe("createReviewHandler review_requested idempotency", () => {
           listComments: async () => ({ data: [] }),
           createComment: async (params: { body: string }) => {
             createdIssueComments.push(params.body);
-            return { data: {} };
+            return { data: { id: createdIssueComments.length } };
           },
           updateComment: async () => ({ data: {} }),
         },
@@ -2014,7 +2014,6 @@ describe("createReviewHandler review_requested idempotency", () => {
     });
 
     await handler!(event);
-    await handler!(event);
 
     await workspaceFixture.cleanup();
 
@@ -2034,23 +2033,25 @@ describe("createReviewHandler review_requested idempotency", () => {
     const marker = buildReviewOutputMarker(expectedReviewOutputKey);
 
     const approvalBody = createdReviews[0]?.body ?? "";
-    const reviewDetailsBlock = extractReviewDetailsBlock(approvalBody);
-
     expect(approvalBody).toContain("Decision: APPROVE");
     expect(approvalBody).toContain("Issues: none");
     expect(approvalBody).toContain("Evidence:");
     expect(approvalBody).toContain("- Review prompt covered 1 changed file.");
+    expect(approvalBody).not.toContain("<summary>Review Details</summary>");
+    expect(approvalBody).not.toContain("Merge Confidence:");
+    expect(extractReviewOutputKey(approvalBody)).toBe(expectedReviewOutputKey);
+    expect(approvalBody).toContain(marker);
+
+    expect(createdIssueComments).toHaveLength(1);
+    const reviewDetailsBody = createdIssueComments[0] ?? "";
+    const reviewDetailsBlock = extractReviewDetailsBlock(reviewDetailsBody);
     expect(reviewDetailsBlock).toContain("<summary>Review Details</summary>");
     expect(reviewDetailsBlock).toContain("- Total wall-clock:");
     expect(reviewDetailsBlock).toContain("- Phase timings:");
     expect(reviewDetailsBlock).toContain("executor handoff: 50ms");
     expect(reviewDetailsBlock).toContain("remote runtime: 500ms");
     expect(reviewDetailsBlock).toContain("publication:");
-    expect(approvalBody).not.toContain("Merge Confidence:");
-    expect(createdIssueComments).toHaveLength(0);
-    expect(extractReviewOutputKey(approvalBody)).toBe(expectedReviewOutputKey);
-    // Ensure marker format stays stable inside the visible approval body.
-    expect(approvalBody).toContain(marker);
+    expect(extractReviewOutputKey(reviewDetailsBlock)).toBe(expectedReviewOutputKey);
   });
 
   test("auto-approve finalization updates the canonical pull review when mixed surfaces exist after a review-surface idempotency accept", async () => {
@@ -9584,6 +9585,170 @@ describe("createReviewHandler timeout resilience", () => {
     await workspaceFixture.cleanup();
   });
 
+  test("falls back to standalone Review Details when timeout canonical comment rebuild fails", async () => {
+    const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
+    const workspaceFixture = await createWorkspaceFixture();
+    const { logger, entries } = createCaptureLogger();
+
+    const issueComments = new Map<number, string>();
+    let nextCommentId = 700;
+    let failCanonicalUpdate = true;
+
+    const eventRouter: EventRouter = {
+      register: (eventKey, handler) => {
+        handlers.set(eventKey, handler);
+      },
+      dispatch: async () => undefined,
+    };
+
+    const jobQueue: JobQueue = {
+      enqueue: async <T>(
+        _installationId: number,
+        fn: (metadata: JobQueueRunMetadata) => Promise<T>,
+        context?: {
+          action?: string;
+        },
+      ) => {
+        if (context?.action === "review-retry") {
+          return undefined as T;
+        }
+        return fn(createQueueRunMetadata());
+      },
+      getQueueSize: () => 0,
+      getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
+    };
+
+    const workspaceManager: WorkspaceManager = {
+      create: async () => ({
+        dir: workspaceFixture.dir,
+        cleanup: async () => undefined,
+      }),
+      cleanupStale: async () => 0,
+    };
+
+    const octokit = {
+      rest: {
+        pulls: {
+          listReviewComments: async () => ({ data: [] }),
+          listReviews: async () => ({ data: [] }),
+          listCommits: async () => ({ data: [] }),
+        },
+        issues: {
+          listComments: async () => ({
+            data: Array.from(issueComments.entries()).map(([id, body]) => ({ id, body })),
+          }),
+          createComment: async (params: { body: string }) => {
+            const id = nextCommentId++;
+            issueComments.set(id, params.body);
+            return { data: { id } };
+          },
+          updateComment: async (params: { comment_id: number; body: string }) => {
+            if (failCanonicalUpdate) {
+              failCanonicalUpdate = false;
+              throw new Error("timeout canonical update failed");
+            }
+            issueComments.set(params.comment_id, params.body);
+            return { data: {} };
+          },
+        },
+        reactions: {
+          createForIssue: async () => ({ data: {} }),
+        },
+      },
+    };
+
+    createReviewHandler({
+      eventRouter,
+      jobQueue,
+      workspaceManager,
+      githubApp: {
+        getAppSlug: () => "kodiai",
+        getInstallationOctokit: async () => octokit as never,
+      } as unknown as GitHubApp,
+      executor: {
+        execute: async () => ({
+          conclusion: "error",
+          isTimeout: true,
+          published: false,
+          errorMessage: "timeout",
+          costUsd: 0,
+          numTurns: 1,
+          durationMs: 1,
+          sessionId: "session-timeout-review-details-fallback",
+          model: "test-model",
+          inputTokens: 0,
+          outputTokens: 0,
+          cacheReadTokens: 0,
+          cacheCreationTokens: 0,
+          stopReason: "timeout",
+        }),
+      } as never,
+      telemetryStore: noopTelemetryStore,
+      knowledgeStore: createKnowledgeStoreStub({
+        getCheckpoint: async () => ({
+          reviewOutputKey: "unused-in-test",
+          repo: "acme/repo",
+          prNumber: 101,
+          filesReviewed: ["README.md"],
+          findingCount: 1,
+          summaryDraft: "Found one issue before timeout.",
+          totalFiles: 1,
+        }),
+        updateCheckpointCommentId: () => undefined,
+        deleteCheckpoint: () => undefined,
+      }) as never,
+      logger: logger as never,
+    });
+
+    const handler = handlers.get("pull_request.review_requested");
+    expect(handler).toBeDefined();
+
+    await handler!(
+      buildReviewRequestedEvent({
+        requested_reviewer: { login: "kodiai[bot]" },
+        pull_request: {
+          number: 101,
+          draft: false,
+          title: "Timeout review details fallback",
+          body: "",
+          commits: 0,
+          additions: 1,
+          deletions: 0,
+          user: { login: "octocat" },
+          base: { ref: "main", sha: "mainsha" },
+          head: {
+            sha: "abcdef1234567890",
+            ref: "feature",
+            repo: {
+              full_name: "acme/repo",
+              name: "repo",
+              owner: { login: "acme" },
+            },
+          },
+          labels: [],
+        },
+      }),
+    );
+
+    const timeoutSummary = Array.from(issueComments.values()).find((body) =>
+      body.includes("**Bounded first-pass review**")
+    );
+    const standaloneReviewDetails = Array.from(issueComments.values()).find((body) =>
+      body.includes("<summary>Review Details</summary>") && body !== timeoutSummary
+    );
+
+    expect(timeoutSummary).toBeDefined();
+    expect(timeoutSummary).not.toContain("<summary>Review Details</summary>");
+    expect(standaloneReviewDetails).toBeDefined();
+    expect(standaloneReviewDetails).toContain("<summary>Review Details</summary>");
+    expect(
+      entries.some((entry) => entry.data?.gate === "review-details-output" && entry.data?.gateResult === "degraded-fallback"),
+    ).toBeTrue();
+
+    await workspaceFixture.cleanup();
+  });
+
   test("queued retry keeps publish rights after the parent attempt unwinds", async () => {
     const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
     const workspaceFixture = await createWorkspaceFixture();
@@ -11250,6 +11415,332 @@ describe("createReviewHandler timeout resilience", () => {
     expect(issueComments.get(900)).toContain("Retry complete -- analyzed 2 of 3 files total after a reduced-scope follow-up.");
     expect(issueComments.get(900)).toContain("<summary>Review Details</summary>");
     expect(issueComments.get(901)).toBeUndefined();
+
+    await workspaceFixture.cleanup();
+  });
+
+  test("retry merge falls back to standalone Review Details when canonical comment refresh fails", async () => {
+    const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
+    const workspaceFixture = await createWorkspaceFixture();
+    const { logger, entries } = createCaptureLogger();
+
+    const checkpointState = new Map<string, {
+      partialCommentId?: number;
+      findingCount?: number;
+      filesReviewed?: string[];
+      summaryDraft?: string;
+      totalFiles?: number;
+    }>();
+
+    const reviewOutputKey = buildReviewOutputKey({
+      installationId: 42,
+      owner: "acme",
+      repo: "repo",
+      prNumber: 101,
+      action: "review_requested",
+      deliveryId: "delivery-123",
+      headSha: "abcdef1234567890",
+    });
+    const retryReviewOutputKey = `${reviewOutputKey}-retry-1`;
+    checkpointState.set(reviewOutputKey, {
+      findingCount: 2,
+      filesReviewed: ["README.md"],
+      summaryDraft: "Found two issues before timeout.",
+      totalFiles: 3,
+    });
+    checkpointState.set(retryReviewOutputKey, {
+      findingCount: 1,
+      filesReviewed: ["src/a.ts"],
+      summaryDraft: "Retry found one more issue.",
+      totalFiles: 3,
+    });
+
+    let queuedRetryJob: ((metadata: JobQueueRunMetadata) => Promise<unknown>) | undefined;
+    let nextCommentId = 980;
+    const issueComments = new Map<number, string>();
+    let failCanonicalUpdate = false;
+    let exposeContinuationReviewComments = false;
+    let retryExecutionStarted = false;
+
+    const eventRouter: EventRouter = {
+      register: (eventKey, handler) => {
+        handlers.set(eventKey, handler);
+      },
+      dispatch: async () => undefined,
+    };
+
+    const queueMetadata = createQueueRunMetadata();
+    const jobQueue: JobQueue = {
+      enqueue: async <T>(
+        _installationId: number,
+        fn: (metadata: JobQueueRunMetadata) => Promise<T>,
+        context?: {
+          action?: string;
+        },
+      ) => {
+        if (context?.action === "review-retry") {
+          queuedRetryJob = fn as (metadata: JobQueueRunMetadata) => Promise<unknown>;
+          return undefined as T;
+        }
+        return fn(queueMetadata);
+      },
+      getQueueSize: () => 0,
+      getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
+    };
+
+    const workspaceManager: WorkspaceManager = {
+      create: async () => ({
+        dir: workspaceFixture.dir,
+        cleanup: async () => undefined,
+      }),
+      cleanupStale: async () => 0,
+    };
+
+    const octokit = {
+      rest: {
+        pulls: {
+          listReviewComments: async () => ({
+            data: exposeContinuationReviewComments
+              ? [
+                  {
+                    id: 9801,
+                    path: "README.md",
+                    body: [
+                      "```yaml",
+                      "severity: major",
+                      "category: correctness",
+                      "```",
+                      "**Carry forward timeout finding**",
+                      "",
+                      buildReviewOutputMarker(reviewOutputKey),
+                    ].join("\n"),
+                  },
+                  {
+                    id: 9802,
+                    path: "src/a.ts",
+                    body: [
+                      "```yaml",
+                      "severity: medium",
+                      "category: correctness",
+                      "```",
+                      "**New continuation finding**",
+                      "",
+                      buildReviewOutputMarker(reviewOutputKey),
+                    ].join("\n"),
+                  },
+                ]
+              : [],
+          }),
+          listReviews: async () => ({ data: [] }),
+          listCommits: async () => ({ data: [] }),
+        },
+        issues: {
+          listComments: async () => ({
+            data: Array.from(issueComments.entries()).map(([id, body]) => ({ id, body })),
+          }),
+          createComment: async (params: { body: string }) => {
+            const id = nextCommentId++;
+            issueComments.set(id, params.body);
+            return { data: { id } };
+          },
+          updateComment: async (params: { comment_id: number; body: string }) => {
+            if (failCanonicalUpdate) {
+              failCanonicalUpdate = false;
+              throw new Error("retry canonical update failed");
+            }
+            issueComments.set(params.comment_id, params.body);
+            return { data: {} };
+          },
+        },
+        reactions: {
+          createForIssue: async () => ({ data: {} }),
+        },
+      },
+    };
+
+    createReviewHandler({
+      eventRouter,
+      jobQueue,
+      workspaceManager,
+      githubApp: {
+        getAppSlug: () => "kodiai",
+        getInstallationOctokit: async () => octokit as never,
+      } as unknown as GitHubApp,
+      executor: {
+        execute: async (context: { eventType: string }) => {
+          if (context.eventType === "pull_request.review-retry") {
+            retryExecutionStarted = true;
+            exposeContinuationReviewComments = true;
+            return {
+              conclusion: "success",
+              published: false,
+              costUsd: 0,
+              numTurns: 1,
+              durationMs: 1,
+              sessionId: "session-timeout-retry-details-fallback",
+              model: "test-model",
+              inputTokens: 0,
+              outputTokens: 0,
+              cacheReadTokens: 0,
+              cacheCreationTokens: 0,
+              stopReason: "end_turn",
+            };
+          }
+          return {
+            conclusion: "error",
+            isTimeout: true,
+            published: false,
+            errorMessage: "timeout",
+            costUsd: 0,
+            numTurns: 1,
+            durationMs: 1,
+            sessionId: "session-timeout-root-details-fallback",
+            model: "test-model",
+            inputTokens: 0,
+            outputTokens: 0,
+            cacheReadTokens: 0,
+            cacheCreationTokens: 0,
+            stopReason: "timeout",
+          };
+        },
+      } as never,
+      telemetryStore: noopTelemetryStore,
+      knowledgeStore: createKnowledgeStoreStub({
+        saveCheckpoint: async (checkpoint: {
+          reviewOutputKey: string;
+          partialCommentId?: number;
+          findingCount?: number;
+          filesReviewed?: string[];
+          summaryDraft?: string;
+          totalFiles?: number;
+        }) => {
+          checkpointState.set(checkpoint.reviewOutputKey, {
+            partialCommentId: checkpoint.partialCommentId,
+            findingCount: checkpoint.findingCount,
+            filesReviewed: checkpoint.filesReviewed,
+            summaryDraft: checkpoint.summaryDraft,
+            totalFiles: checkpoint.totalFiles,
+          });
+        },
+        getCheckpoint: async (key: string) => {
+          const checkpoint = checkpointState.get(key);
+          if (!checkpoint || !checkpoint.filesReviewed || !checkpoint.summaryDraft || !checkpoint.totalFiles) {
+            return null;
+          }
+          return {
+            reviewOutputKey: key,
+            repo: "acme/repo",
+            prNumber: 101,
+            filesReviewed: checkpoint.filesReviewed,
+            findingCount: checkpoint.findingCount ?? 0,
+            summaryDraft: checkpoint.summaryDraft,
+            totalFiles: checkpoint.totalFiles,
+            partialCommentId: checkpoint.partialCommentId,
+          };
+        },
+        getPriorReviewFindings: async () => [
+          {
+            filePath: "README.md",
+            title: "Carry forward timeout finding",
+            titleFingerprint: "fp-46cc3f1d",
+            severity: "major",
+            category: "correctness",
+            startLine: 1,
+            endLine: 1,
+            commentId: 501,
+          },
+          {
+            filePath: "src/b.ts",
+            title: "Resolved timeout finding",
+            titleFingerprint: "fp-c56af86d",
+            severity: "medium",
+            category: "correctness",
+            startLine: 1,
+            endLine: 1,
+            commentId: 502,
+          },
+        ],
+        updateCheckpointCommentId: (key: string, partialCommentId: number) => {
+          const current = checkpointState.get(key) ?? {};
+          checkpointState.set(key, { ...current, partialCommentId });
+        },
+        deleteCheckpoint: (key: string) => {
+          checkpointState.delete(key);
+        },
+      }) as never,
+      diffContextCollector: async () => ({
+        changedFiles: ["README.md", "src/a.ts", "src/b.ts"],
+        numstatLines: [],
+        diffContent: undefined,
+        strategy: "github-file-list-fallback",
+        mergeBaseRecovered: false,
+        deepenAttempts: 0,
+        unshallowAttempted: false,
+        diffRange: "github-api:file-list",
+      }),
+      reviewWorkCoordinator: {
+        claim: (claim: Record<string, unknown>) => ({
+          attemptId: claim.deliveryId === "delivery-123-retry-1" ? "review-work-2" : "review-work-1",
+          familyKey: claim.familyKey as string,
+          source: claim.source as "automatic-review",
+          lane: claim.lane as "review",
+          deliveryId: claim.deliveryId as string,
+          phase: claim.phase as "claimed",
+          claimedAtMs: 100,
+          lastProgressAtMs: 100,
+        }),
+        canPublish: () => true,
+        setPhase: () => null,
+        getSnapshot: () => null,
+        release: () => undefined,
+        complete: () => undefined,
+      } as never,
+      logger: logger as never,
+    });
+
+    await handlers.get("pull_request.review_requested")!(
+      buildReviewRequestedEvent({
+        requested_reviewer: { login: "kodiai[bot]" },
+        pull_request: {
+          number: 101,
+          draft: false,
+          title: "Timeout retry details fallback after summary merge",
+          body: "",
+          commits: 0,
+          additions: 3,
+          deletions: 0,
+          user: { login: "octocat" },
+          base: { ref: "main", sha: "mainsha" },
+          head: {
+            sha: "abcdef1234567890",
+            ref: "feature",
+            repo: {
+              full_name: "acme/repo",
+              name: "repo",
+              owner: { login: "acme" },
+            },
+          },
+          labels: [],
+        },
+      }),
+    );
+
+    expect(queuedRetryJob).toBeDefined();
+    const initialCanonicalComment = issueComments.get(980);
+    expect(initialCanonicalComment).toContain("<summary>Review Details</summary>");
+
+    failCanonicalUpdate = true;
+    await queuedRetryJob!(queueMetadata);
+
+    const standaloneReviewDetails = Array.from(issueComments.values()).find((body) =>
+      body.includes("<summary>Review Details</summary>") && !body.includes("Retry complete -- analyzed 2 of 3 files total after a reduced-scope follow-up.")
+    );
+    expect(standaloneReviewDetails).toContain("<summary>Review Details</summary>");
+    expect(
+      entries.some((entry) => entry.data?.gate === "review-details-output" && entry.data?.gateResult === "degraded-fallback"),
+    ).toBeTrue();
+    expect(retryExecutionStarted).toBeTrue();
 
     await workspaceFixture.cleanup();
   });
@@ -15093,7 +15584,137 @@ describe("createReviewHandler failure fallback publication", () => {
     expect(standaloneReviewDetails).toBeUndefined();
 
     await workspaceFixture.cleanup();
+  });  test("falls back to standalone Review Details when max-turns canonical comment rebuild fails", async () => {
+    const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
+    const workspaceFixture = await createWorkspaceFixture();
+    const { logger, entries } = createCaptureLogger();
+
+    const issueComments = new Map<number, string>();
+    let nextCommentId = 620;
+    let failCanonicalUpdate = true;
+
+    createReviewHandler({
+      eventRouter: {
+        register: (eventKey, handler) => {
+          handlers.set(eventKey, handler);
+        },
+        dispatch: async () => undefined,
+      },
+      jobQueue: {
+        enqueue: async <T>(
+          _installationId: number,
+          fn: (metadata: JobQueueRunMetadata) => Promise<T>,
+        ) => fn(createQueueRunMetadata()),
+        getQueueSize: () => 0,
+        getPendingCount: () => 0,
+        getActiveJobs: getEmptyActiveJobs,
+      } as unknown as JobQueue,
+      workspaceManager: {
+        create: async () => ({
+          dir: workspaceFixture.dir,
+          cleanup: async () => undefined,
+        }),
+        cleanupStale: async () => 0,
+      } as WorkspaceManager,
+      githubApp: {
+        getAppSlug: () => "kodiai",
+        getInstallationOctokit: async () => ({
+          rest: {
+            pulls: {
+              listReviewComments: async () => ({ data: [] }),
+              listReviews: async () => ({ data: [] }),
+              listCommits: async () => ({ data: [] }),
+              createReview: async () => ({ data: {} }),
+            },
+            issues: {
+              listComments: async () => ({
+                data: Array.from(issueComments.entries()).map(([id, body]) => ({ id, body })),
+              }),
+              createComment: async (params: { body: string }) => {
+                const id = nextCommentId++;
+                issueComments.set(id, params.body);
+                return { data: { id } };
+              },
+              updateComment: async (params: { comment_id: number; body: string }) => {
+                if (failCanonicalUpdate) {
+                  failCanonicalUpdate = false;
+                  throw new Error("max-turns canonical update failed");
+                }
+                issueComments.set(params.comment_id, params.body);
+                return { data: {} };
+              },
+            },
+            reactions: {
+              createForIssue: async () => ({ data: {} }),
+            },
+            search: {
+              issuesAndPullRequests: async () => ({ data: { total_count: 4 } }),
+            },
+          },
+        }) as never,
+      } as unknown as GitHubApp,
+      executor: {
+        execute: async () => ({
+          conclusion: "failure",
+          published: false,
+          stopReason: "max_turns",
+          failureSubtype: "error_max_turns",
+          durationMs: 1,
+          numTurns: 25,
+          sessionId: "session-failure-bounded-first-pass-fallback",
+          costUsd: 0,
+        }),
+      } as never,
+      telemetryStore: noopTelemetryStore,
+      knowledgeStore: createKnowledgeStoreStub({
+        getCheckpoint: async () => ({
+          reviewOutputKey: "unused-in-test",
+          repo: "acme/repo",
+          prNumber: 101,
+          filesReviewed: ["README.md"],
+          findingCount: 2,
+          summaryDraft: "Found two issues before max-turns.",
+          totalFiles: 3,
+        }),
+      }) as never,
+      diffContextCollector: async () => ({
+        changedFiles: ["README.md", "src/a.ts", "src/b.ts"],
+        numstatLines: [],
+        diffContent: undefined,
+        strategy: "github-file-list-fallback",
+        mergeBaseRecovered: false,
+        deepenAttempts: 0,
+        unshallowAttempted: false,
+        diffRange: "github-api:file-list",
+      }),
+      logger: logger as never,
+    });
+
+    const handler = handlers.get("pull_request.review_requested");
+    expect(handler).toBeDefined();
+
+    await handler!(
+      buildReviewRequestedEvent({
+        requested_reviewer: { login: "kodiai[bot]" },
+      }),
+    );
+
+    const boundedComment = Array.from(issueComments.values()).find((body) => body.includes("**Bounded first-pass review**"));
+    const standaloneReviewDetails = Array.from(issueComments.values()).find((body) =>
+      body.includes("<summary>Review Details</summary>") && body !== boundedComment
+    );
+
+    expect(boundedComment).toBeDefined();
+    expect(boundedComment).not.toContain("<summary>Review Details</summary>");
+    expect(standaloneReviewDetails).toBeDefined();
+    expect(standaloneReviewDetails).toContain("<summary>Review Details</summary>");
+    expect(
+      entries.some((entry) => entry.data?.gate === "review-details-output" && entry.data?.gateResult === "degraded-fallback"),
+    ).toBeTrue();
+
+    await workspaceFixture.cleanup();
   });
+
 
   test("formats split timeout budget wording for plain timeout error comments", () => {
     const detail = formatTimeoutErrorDetail({

--- a/src/handlers/review.test.ts
+++ b/src/handlers/review.test.ts
@@ -1880,12 +1880,13 @@ describe("createReviewHandler review_requested idempotency", () => {
     ).toBe(true);
   });
 
-  test("replaying a clean PR review_requested does not create duplicate approvals", async () => {
+  test("replaying a clean PR review_requested keeps the approval body as the only canonical visible surface", async () => {
     const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
     const workspaceFixture = await createWorkspaceFixture({ autoApprove: true });
     const { logger } = createCaptureLogger();
 
     const createdReviews: Array<{ body?: string | null }> = [];
+    const createdIssueComments: string[] = [];
     let executeCount = 0;
     let approveCount = 0;
 
@@ -1932,6 +1933,11 @@ describe("createReviewHandler review_requested idempotency", () => {
         },
         issues: {
           listComments: async () => ({ data: [] }),
+          createComment: async (params: { body: string }) => {
+            createdIssueComments.push(params.body);
+            return { data: {} };
+          },
+          updateComment: async () => ({ data: {} }),
         },
       },
     };
@@ -1995,6 +2001,7 @@ describe("createReviewHandler review_requested idempotency", () => {
     expect(createdReviews[0]?.body ?? "").toContain("Evidence:");
     expect(createdReviews[0]?.body ?? "").toContain("- Review prompt covered 1 changed file.");
     expect(createdReviews[0]?.body ?? "").not.toContain("Merge Confidence:");
+    expect(createdIssueComments).toHaveLength(0);
     expect(extractReviewOutputKey(createdReviews[0]?.body)).toBe(expectedReviewOutputKey);
     // Ensure marker format stays stable inside the visible approval body.
     expect(createdReviews[0]?.body ?? "").toContain(marker);
@@ -13949,7 +13956,7 @@ describe("createReviewHandler phase timing logging", () => {
 });
 
 describe("createReviewHandler Review Details phase timing publication", () => {
-  test("appends Review Details timings into the published summary comment", async () => {
+  test("keeps findings Review Details off a second visible comment when the canonical summary is not yet discoverable", async () => {
     const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
     const workspaceFixture = await createWorkspaceFixture();
 
@@ -13958,6 +13965,137 @@ describe("createReviewHandler Review Details phase timing publication", () => {
     let createCommentCalls = 0;
     let updateCommentCalls = 0;
     let issueCommentListCalls = 0;
+
+    const reviewOutputKey = buildReviewOutputKey({
+      installationId: 42,
+      owner: "acme",
+      repo: "repo",
+      prNumber: 101,
+      action: "review_requested",
+      deliveryId: "delivery-123",
+      headSha: "abcdef1234567890",
+    });
+
+    const summaryBody = [
+      "<details>",
+      "<summary>Kodiai Review Summary</summary>",
+      "",
+      "## What Changed",
+      "- Found one correctness issue worth fixing before merge.",
+      "",
+      "</details>",
+      "",
+      buildReviewOutputMarker(reviewOutputKey),
+    ].join("\n");
+
+    const eventRouter: EventRouter = {
+      register: (eventKey, handler) => {
+        handlers.set(eventKey, handler);
+      },
+      dispatch: async () => undefined,
+    };
+
+    const jobQueue: JobQueue = {
+      enqueue: async <T>(
+        _installationId: number,
+        fn: (metadata: JobQueueRunMetadata) => Promise<T>,
+      ) => fn(createQueueRunMetadata()),
+      getQueueSize: () => 0,
+      getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
+    };
+
+    const workspaceManager: WorkspaceManager = {
+      create: async () => ({
+        dir: workspaceFixture.dir,
+        cleanup: async () => undefined,
+      }),
+      cleanupStale: async () => 0,
+    };
+
+    const octokit = {
+      rest: {
+        pulls: {
+          listReviewComments: async () => ({ data: [] }),
+          listReviews: async () => ({ data: [] }),
+          listCommits: async () => ({ data: [] }),
+        },
+        issues: {
+          listComments: async () => {
+            issueCommentListCalls += 1;
+            return { data: [] };
+          },
+          createComment: async (params: { body: string }) => {
+            createCommentCalls += 1;
+            standaloneDetailsBody = params.body;
+            return { data: { id: 88 } };
+          },
+          updateComment: async (params: { body: string }) => {
+            updateCommentCalls += 1;
+            updatedSummaryBody = params.body;
+            return { data: {} };
+          },
+        },
+        reactions: {
+          createForIssue: async () => ({ data: {} }),
+        },
+        search: {
+          issuesAndPullRequests: async () => ({ data: { total_count: 4 } }),
+        },
+      },
+    };
+
+    createReviewHandler({
+      eventRouter,
+      jobQueue,
+      workspaceManager,
+      githubApp: {
+        getAppSlug: () => "kodiai",
+        getInstallationOctokit: async () => octokit as never,
+      } as unknown as GitHubApp,
+      executor: {
+        execute: async () => ({
+          conclusion: "success",
+          published: true,
+          costUsd: 0,
+          numTurns: 1,
+          durationMs: 1,
+          sessionId: "session-review-details-append",
+          executorPhaseTimings: [
+            { name: "executor handoff", status: "completed", durationMs: 50 },
+            { name: "remote runtime", status: "completed", durationMs: 500 },
+          ],
+        }),
+      } as never,
+      telemetryStore: noopTelemetryStore,
+      logger: createNoopLogger(),
+    });
+
+    const handler = handlers.get("pull_request.review_requested");
+    expect(handler).toBeDefined();
+
+    await handler!(
+      buildReviewRequestedEvent({
+        requested_reviewer: { login: "kodiai[bot]" },
+      }),
+    );
+
+    expect(issueCommentListCalls).toBeGreaterThanOrEqual(1);
+    expect(createCommentCalls).toBe(0);
+    expect(updateCommentCalls).toBe(0);
+    expect(standaloneDetailsBody).toBeUndefined();
+    expect(updatedSummaryBody).toBeUndefined();
+
+    await workspaceFixture.cleanup();
+  });
+
+  test("uses standalone Review Details only after canonical summary update failure and logs gateResult='degraded-fallback'", async () => {
+    const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
+    const workspaceFixture = await createWorkspaceFixture();
+    const { logger, entries } = createCaptureLogger();
+
+    let standaloneDetailsBody: string | undefined;
+    let updateCommentCalls = 0;
 
     const reviewOutputKey = buildReviewOutputKey({
       installationId: 42,
@@ -14013,132 +14151,14 @@ describe("createReviewHandler Review Details phase timing publication", () => {
           listCommits: async () => ({ data: [] }),
         },
         issues: {
-          listComments: async () => {
-            issueCommentListCalls += 1;
-            return issueCommentListCalls === 1
-              ? { data: [] }
-              : { data: [{ id: 77, body: summaryBody }] };
-          },
-          createComment: async (params: { body: string }) => {
-            createCommentCalls += 1;
-            standaloneDetailsBody = params.body;
-            return { data: { id: 88 } };
-          },
-          updateComment: async (params: { body: string }) => {
-            updatedSummaryBody = params.body;
-            return { data: {} };
-          },
-        },
-        reactions: {
-          createForIssue: async () => ({ data: {} }),
-        },
-        search: {
-          issuesAndPullRequests: async () => ({ data: { total_count: 4 } }),
-        },
-      },
-    };
-
-    createReviewHandler({
-      eventRouter,
-      jobQueue,
-      workspaceManager,
-      githubApp: {
-        getAppSlug: () => "kodiai",
-        getInstallationOctokit: async () => octokit as never,
-      } as unknown as GitHubApp,
-      executor: {
-        execute: async () => ({
-          conclusion: "success",
-          published: true,
-          costUsd: 0,
-          numTurns: 1,
-          durationMs: 1,
-          sessionId: "session-review-details-append",
-          executorPhaseTimings: [
-            { name: "executor handoff", status: "completed", durationMs: 50 },
-            { name: "remote runtime", status: "completed", durationMs: 500 },
-          ],
-        }),
-      } as never,
-      telemetryStore: noopTelemetryStore,
-      logger: createNoopLogger(),
-    });
-
-    const handler = handlers.get("pull_request.review_requested");
-    expect(handler).toBeDefined();
-
-    await handler!(
-      buildReviewRequestedEvent({
-        requested_reviewer: { login: "kodiai[bot]" },
-      }),
-    );
-
-    expect(createCommentCalls).toBe(0);
-    expect(updatedSummaryBody).toBeDefined();
-    expect(standaloneDetailsBody).toBeUndefined();
-    expect(updatedSummaryBody).toBeDefined();
-    expect(updatedSummaryBody).toContain("<summary>Review Details</summary>");
-    expect(updatedSummaryBody).toContain("- Total wall-clock:");
-    expect(updatedSummaryBody).toContain("- Phase timings:");
-    expect(updatedSummaryBody).toContain("queue wait: 250ms");
-    expect(updatedSummaryBody).toContain("workspace preparation:");
-    expect(updatedSummaryBody).toContain("retrieval/context assembly:");
-    expect(updatedSummaryBody).toContain("executor handoff: 50ms");
-    expect(updatedSummaryBody).toContain("remote runtime: 500ms");
-    expect(updatedSummaryBody).toContain("publication:");
-    expect(updatedSummaryBody).toContain(buildReviewOutputMarker(reviewOutputKey));
-
-    await workspaceFixture.cleanup();
-  });
-
-  test("falls back to standalone Review Details timings when append cannot find the summary comment", async () => {
-    const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
-    const workspaceFixture = await createWorkspaceFixture();
-
-    let standaloneDetailsBody: string | undefined;
-    let updateCommentCalls = 0;
-
-    const eventRouter: EventRouter = {
-      register: (eventKey, handler) => {
-        handlers.set(eventKey, handler);
-      },
-      dispatch: async () => undefined,
-    };
-
-    const jobQueue: JobQueue = {
-      enqueue: async <T>(
-        _installationId: number,
-        fn: (metadata: JobQueueRunMetadata) => Promise<T>,
-      ) => fn(createQueueRunMetadata()),
-      getQueueSize: () => 0,
-      getPendingCount: () => 0,
-      getActiveJobs: getEmptyActiveJobs,
-    };
-
-    const workspaceManager: WorkspaceManager = {
-      create: async () => ({
-        dir: workspaceFixture.dir,
-        cleanup: async () => undefined,
-      }),
-      cleanupStale: async () => 0,
-    };
-
-    const octokit = {
-      rest: {
-        pulls: {
-          listReviewComments: async () => ({ data: [] }),
-          listReviews: async () => ({ data: [] }),
-          listCommits: async () => ({ data: [] }),
-        },
-        issues: {
-          listComments: async () => ({ data: [] }),
+          listComments: async () => ({ data: [{ id: 77, body: summaryBody }] }),
           createComment: async (params: { body: string }) => {
             standaloneDetailsBody = params.body;
             return { data: { id: 188 } };
           },
-          updateComment: async (params: { body: string }) => {
+          updateComment: async (_params: { body: string }) => {
             updateCommentCalls += 1;
-            return { data: {} };
+            throw new Error("canonical update failed");
           },
         },
         reactions: {
@@ -14173,7 +14193,7 @@ describe("createReviewHandler Review Details phase timing publication", () => {
         }),
       } as never,
       telemetryStore: noopTelemetryStore,
-      logger: createNoopLogger(),
+      logger,
     });
 
     const handler = handlers.get("pull_request.review_requested");
@@ -14185,7 +14205,6 @@ describe("createReviewHandler Review Details phase timing publication", () => {
       }),
     );
 
-    expect(updateCommentCalls).toBe(1);
     expect(standaloneDetailsBody).toBeDefined();
     expect(standaloneDetailsBody).toContain("<summary>Review Details</summary>");
     expect(standaloneDetailsBody).toContain("- Total wall-clock:");
@@ -14194,6 +14213,9 @@ describe("createReviewHandler Review Details phase timing publication", () => {
     expect(standaloneDetailsBody).toContain("executor handoff: 50ms");
     expect(standaloneDetailsBody).toContain("remote runtime: 500ms");
     expect(standaloneDetailsBody).toContain("publication:");
+    expect(
+      entries.some((entry) => entry.data?.gate === "review-details-output" && entry.data?.gateResult === "degraded-fallback"),
+    ).toBeTrue();
 
     await workspaceFixture.cleanup();
   });

--- a/src/handlers/review.test.ts
+++ b/src/handlers/review.test.ts
@@ -2053,6 +2053,10 @@ describe("createReviewHandler review_requested idempotency", () => {
     expect(reviewDetailsBlock).toContain("remote runtime: 500ms");
     expect(reviewDetailsBlock).toContain("publication:");
     expect(extractReviewOutputKey(reviewDetailsBlock)).toBe(expectedReviewOutputKey);
+    expect(approvalBody.match(/<summary>Review Details<\/summary>/g) ?? []).toHaveLength(1);
+    expect(approvalBody.match(/<details>/g) ?? []).toHaveLength(
+      (approvalBody.match(/<\/details>/g) ?? []).length,
+    );
 
     expect(createdIssueComments).toHaveLength(0);
   });

--- a/src/handlers/review.test.ts
+++ b/src/handlers/review.test.ts
@@ -76,6 +76,29 @@ function createCaptureLogger() {
   return { logger, entries };
 }
 
+function extractReviewDetailsBlock(body: string): string {
+  const summary = "<summary>Review Details</summary>";
+  const summaryIndex = body.indexOf(summary);
+
+  expect(summaryIndex).toBeGreaterThanOrEqual(0);
+
+  const start = body.lastIndexOf("<details>", summaryIndex);
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(start).toBeLessThanOrEqual(summaryIndex);
+
+  const end = body.indexOf("</details>", summaryIndex);
+  expect(end).toBeGreaterThanOrEqual(0);
+
+  const detailsEnd = end + "</details>".length;
+  const markerMatch = body
+    .slice(detailsEnd)
+    .match(/^\s*(<!--\s*kodiai:review-details:[^>]+-->)/);
+
+  return markerMatch
+    ? `${body.slice(start, detailsEnd)}\n\n${markerMatch[1]}`
+    : body.slice(start, detailsEnd);
+}
+
 describe("createReviewHandler coordinator wiring", () => {
   test("logs when the review handler falls back to a private coordinator", () => {
     const { logger, entries } = createCaptureLogger();
@@ -2001,17 +2024,18 @@ describe("createReviewHandler review_requested idempotency", () => {
     const marker = buildReviewOutputMarker(expectedReviewOutputKey);
 
     const approvalBody = createdReviews[0]?.body ?? "";
+    const reviewDetailsBlock = extractReviewDetailsBlock(approvalBody);
 
     expect(approvalBody).toContain("Decision: APPROVE");
     expect(approvalBody).toContain("Issues: none");
     expect(approvalBody).toContain("Evidence:");
     expect(approvalBody).toContain("- Review prompt covered 1 changed file.");
-    expect(approvalBody).toContain("<summary>Review Details</summary>");
-    expect(approvalBody).toContain("- Total wall-clock:");
-    expect(approvalBody).toContain("- Phase timings:");
-    expect(approvalBody).toContain("executor handoff: 50ms");
-    expect(approvalBody).toContain("remote runtime: 500ms");
-    expect(approvalBody).toContain("publication:");
+    expect(reviewDetailsBlock).toContain("<summary>Review Details</summary>");
+    expect(reviewDetailsBlock).toContain("- Total wall-clock:");
+    expect(reviewDetailsBlock).toContain("- Phase timings:");
+    expect(reviewDetailsBlock).toContain("executor handoff: 50ms");
+    expect(reviewDetailsBlock).toContain("remote runtime: 500ms");
+    expect(reviewDetailsBlock).toContain("publication:");
     expect(approvalBody).not.toContain("Merge Confidence:");
     expect(createdIssueComments).toHaveLength(0);
     expect(extractReviewOutputKey(approvalBody)).toBe(expectedReviewOutputKey);
@@ -14095,13 +14119,16 @@ describe("createReviewHandler Review Details phase timing publication", () => {
     expect(updatedSummaryBody).toContain("<summary>Kodiai Review Summary</summary>");
     expect(updatedSummaryBody).toContain("## What Changed");
     expect(updatedSummaryBody).toContain("- Found one correctness issue worth fixing before merge.");
-    expect(updatedSummaryBody).toContain("<summary>Review Details</summary>");
-    expect(updatedSummaryBody).toContain("- Total wall-clock:");
-    expect(updatedSummaryBody).toContain("- Phase timings:");
-    expect(updatedSummaryBody).toContain("queue wait: 250ms");
-    expect(updatedSummaryBody).toContain("executor handoff: 50ms");
-    expect(updatedSummaryBody).toContain("remote runtime: 500ms");
-    expect(updatedSummaryBody).toContain("publication:");
+
+    const reviewDetailsBlock = extractReviewDetailsBlock(updatedSummaryBody ?? "");
+
+    expect(reviewDetailsBlock).toContain("<summary>Review Details</summary>");
+    expect(reviewDetailsBlock).toContain("- Total wall-clock:");
+    expect(reviewDetailsBlock).toContain("- Phase timings:");
+    expect(reviewDetailsBlock).toContain("queue wait: 250ms");
+    expect(reviewDetailsBlock).toContain("executor handoff: 50ms");
+    expect(reviewDetailsBlock).toContain("remote runtime: 500ms");
+    expect(reviewDetailsBlock).toContain("publication:");
     expect(updatedSummaryBody?.indexOf("<summary>Kodiai Review Summary</summary>")).toBeLessThan(
       updatedSummaryBody?.indexOf("<summary>Review Details</summary>") ?? Number.POSITIVE_INFINITY,
     );
@@ -14229,18 +14256,24 @@ describe("createReviewHandler Review Details phase timing publication", () => {
 
     expect(updateCommentCalls).toBe(1);
     expect(createdCommentBodies).toHaveLength(1);
-    expect(createdCommentBodies[0]).toContain("<summary>Review Details</summary>");
-    expect(createdCommentBodies[0]).toContain("Files reviewed:");
-    expect(createdCommentBodies[0]).toMatch(/Lines changed: \+\d+ -\d+/);
-    expect(createdCommentBodies[0]).toMatch(/Findings: \d+ critical, \d+ major, \d+ medium, \d+ minor/);
-    expect(createdCommentBodies[0]).toMatch(/Review completed: \d{4}-\d{2}-\d{2}T/);
-    expect(createdCommentBodies[0]).toContain("- Total wall-clock:");
-    expect(createdCommentBodies[0]).toContain("- Phase timings:");
-    expect(createdCommentBodies[0]).toContain("queue wait: 250ms");
-    expect(createdCommentBodies[0]).toContain("executor handoff: 50ms");
-    expect(createdCommentBodies[0]).toContain("remote runtime: 500ms");
-    expect(createdCommentBodies[0]).toContain("publication:");
-    expect(createdCommentBodies[0]).toContain("degraded:");
+
+    const fallbackCommentBody = createdCommentBodies[0] ?? "";
+    const reviewDetailsBlock = extractReviewDetailsBlock(fallbackCommentBody);
+
+    expect(reviewDetailsBlock).toContain("<summary>Review Details</summary>");
+    expect(reviewDetailsBlock).toContain(`<!-- kodiai:review-details:${reviewOutputKey} -->`);
+    expect(extractReviewOutputKey(reviewDetailsBlock)).toBe(reviewOutputKey);
+    expect(reviewDetailsBlock).toContain("- Files reviewed: 1");
+    expect(reviewDetailsBlock).toContain("- Lines changed: +1 -0");
+    expect(reviewDetailsBlock).toContain("- Findings: 0 critical, 0 major, 0 medium, 0 minor");
+    expect(reviewDetailsBlock).toContain("- Total wall-clock:");
+    expect(reviewDetailsBlock).toContain("- Phase timings:");
+    expect(reviewDetailsBlock).toContain("queue wait: 250ms");
+    expect(reviewDetailsBlock).toContain("executor handoff: 50ms");
+    expect(reviewDetailsBlock).toContain("remote runtime: 500ms");
+    expect(reviewDetailsBlock).toContain("publication:");
+    expect(reviewDetailsBlock).toContain("degraded:");
+    expect(reviewDetailsBlock).toMatch(/- Review completed: \d{4}-\d{2}-\d{2}T/);
     expect(
       entries.some((entry) => entry.data?.gate === "review-details-output" && entry.data?.gateResult === "degraded-fallback"),
     ).toBeTrue();

--- a/src/handlers/review.test.ts
+++ b/src/handlers/review.test.ts
@@ -2054,6 +2054,7 @@ describe("createReviewHandler review_requested idempotency", () => {
     expect(reviewDetailsBlock).toContain("publication:");
     expect(extractReviewOutputKey(reviewDetailsBlock)).toBe(expectedReviewOutputKey);
     expect(approvalBody.match(/<summary>Review Details<\/summary>/g) ?? []).toHaveLength(1);
+    expect(approvalBody.match(/<!--\s*kodiai:review-details:[^>]+-->/g) ?? []).toHaveLength(1);
     expect(approvalBody.match(/<details>/g) ?? []).toHaveLength(
       (approvalBody.match(/<\/details>/g) ?? []).length,
     );
@@ -2061,7 +2062,7 @@ describe("createReviewHandler review_requested idempotency", () => {
     expect(createdIssueComments).toHaveLength(0);
   });
 
-  test("auto-approve finalization refreshes the canonical approval review body instead of creating or updating issue comments", async () => {
+  test("auto-approval finalization refreshes the same canonical approval review id when older marker-matching reviews exist", async () => {
     const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
     const workspaceFixture = await createWorkspaceFixture({ autoApprove: true });
 
@@ -2083,12 +2084,6 @@ describe("createReviewHandler review_requested idempotency", () => {
     });
     const marker = buildReviewOutputMarker(reviewOutputKey);
 
-    const reviewBodiesByCall = [
-      [{ id: 902, body: `existing pull review\n\n${marker}` }],
-      [{ id: 902, body: `existing pull review\n\n${marker}` }],
-      [],
-      [{ id: 902, body: `existing pull review\n\n${marker}` }],
-    ] as const;
     const issueCommentBodiesByCall = [
       [],
       [],
@@ -2123,8 +2118,13 @@ describe("createReviewHandler review_requested idempotency", () => {
         pulls: {
           listReviewComments: async () => ({ data: [] }),
           listReviews: async () => {
-            const data = reviewBodiesByCall[listReviewsCallCount] ?? [];
             listReviewsCallCount += 1;
+            const data = approveCount === 0
+              ? []
+              : [
+                { id: 902, body: `older pull review\n\n${marker}` },
+                { id: 951, body: `canonical approval review\n\n${marker}` },
+              ];
             return { data };
           },
           listCommits: async () => ({ data: [] }),
@@ -2217,6 +2217,7 @@ describe("createReviewHandler review_requested idempotency", () => {
     expect(createdReviews[0]?.body).toContain("Decision: APPROVE");
     expect(createdReviews[0]?.body).toContain("<summary>Review Details</summary>");
     expect(createdReviews[0]?.body).toContain("publication:");
+    expect(createdReviews[0]?.body?.match(/<!--\s*kodiai:review-details:[^>]+-->/g) ?? []).toHaveLength(1);
     expect(createdIssueComments).toHaveLength(0);
   });
 

--- a/src/handlers/review.test.ts
+++ b/src/handlers/review.test.ts
@@ -1954,7 +1954,7 @@ describe("createReviewHandler review_requested idempotency", () => {
         getInstallationToken: async () => "token",
       } as unknown as GitHubApp,
       executor: {
-        execute: async (context: { reviewOutputKey?: string }) => {
+        execute: async () => {
           executeCount++;
           return {
             conclusion: "success",
@@ -1962,6 +1962,10 @@ describe("createReviewHandler review_requested idempotency", () => {
             numTurns: 1,
             durationMs: 1,
             sessionId: "session-clean",
+            executorPhaseTimings: [
+              { name: "executor handoff", status: "completed", durationMs: 50 },
+              { name: "remote runtime", status: "completed", durationMs: 500 },
+            ],
           };
         },
       } as never,
@@ -1996,16 +2000,23 @@ describe("createReviewHandler review_requested idempotency", () => {
 
     const marker = buildReviewOutputMarker(expectedReviewOutputKey);
 
-    expect(createdReviews[0]?.body ?? "").toContain("Decision: APPROVE");
-    expect(createdReviews[0]?.body ?? "").toContain("Issues: none");
-    expect(createdReviews[0]?.body ?? "").toContain("Evidence:");
-    expect(createdReviews[0]?.body ?? "").toContain("- Review prompt covered 1 changed file.");
-    expect(createdReviews[0]?.body ?? "").toContain("<summary>Review Details</summary>");
-    expect(createdReviews[0]?.body ?? "").not.toContain("Merge Confidence:");
+    const approvalBody = createdReviews[0]?.body ?? "";
+
+    expect(approvalBody).toContain("Decision: APPROVE");
+    expect(approvalBody).toContain("Issues: none");
+    expect(approvalBody).toContain("Evidence:");
+    expect(approvalBody).toContain("- Review prompt covered 1 changed file.");
+    expect(approvalBody).toContain("<summary>Review Details</summary>");
+    expect(approvalBody).toContain("- Total wall-clock:");
+    expect(approvalBody).toContain("- Phase timings:");
+    expect(approvalBody).toContain("executor handoff: 50ms");
+    expect(approvalBody).toContain("remote runtime: 500ms");
+    expect(approvalBody).toContain("publication:");
+    expect(approvalBody).not.toContain("Merge Confidence:");
     expect(createdIssueComments).toHaveLength(0);
-    expect(extractReviewOutputKey(createdReviews[0]?.body)).toBe(expectedReviewOutputKey);
+    expect(extractReviewOutputKey(approvalBody)).toBe(expectedReviewOutputKey);
     // Ensure marker format stays stable inside the visible approval body.
-    expect(createdReviews[0]?.body ?? "").toContain(marker);
+    expect(approvalBody).toContain(marker);
   });
 
   test("auto-approve includes dep-bump merge confidence inside the shared approval body", async () => {
@@ -14081,10 +14092,19 @@ describe("createReviewHandler Review Details phase timing publication", () => {
 
     expect(issueCommentListCalls).toBeGreaterThanOrEqual(1);
     expect(updatedSummaryCommentId).toBe(77);
+    expect(updatedSummaryBody).toContain("<summary>Kodiai Review Summary</summary>");
+    expect(updatedSummaryBody).toContain("## What Changed");
+    expect(updatedSummaryBody).toContain("- Found one correctness issue worth fixing before merge.");
     expect(updatedSummaryBody).toContain("<summary>Review Details</summary>");
+    expect(updatedSummaryBody).toContain("- Total wall-clock:");
+    expect(updatedSummaryBody).toContain("- Phase timings:");
     expect(updatedSummaryBody).toContain("queue wait: 250ms");
     expect(updatedSummaryBody).toContain("executor handoff: 50ms");
     expect(updatedSummaryBody).toContain("remote runtime: 500ms");
+    expect(updatedSummaryBody).toContain("publication:");
+    expect(updatedSummaryBody?.indexOf("<summary>Kodiai Review Summary</summary>")).toBeLessThan(
+      updatedSummaryBody?.indexOf("<summary>Review Details</summary>") ?? Number.POSITIVE_INFINITY,
+    );
     expect(updatedSummaryBody).toContain(buildReviewOutputMarker(reviewOutputKey));
     expect(createdCommentBodies).toHaveLength(0);
 
@@ -14210,9 +14230,17 @@ describe("createReviewHandler Review Details phase timing publication", () => {
     expect(updateCommentCalls).toBe(1);
     expect(createdCommentBodies).toHaveLength(1);
     expect(createdCommentBodies[0]).toContain("<summary>Review Details</summary>");
+    expect(createdCommentBodies[0]).toContain("Files reviewed:");
+    expect(createdCommentBodies[0]).toMatch(/Lines changed: \+\d+ -\d+/);
+    expect(createdCommentBodies[0]).toMatch(/Findings: \d+ critical, \d+ major, \d+ medium, \d+ minor/);
+    expect(createdCommentBodies[0]).toMatch(/Review completed: \d{4}-\d{2}-\d{2}T/);
+    expect(createdCommentBodies[0]).toContain("- Total wall-clock:");
+    expect(createdCommentBodies[0]).toContain("- Phase timings:");
     expect(createdCommentBodies[0]).toContain("queue wait: 250ms");
     expect(createdCommentBodies[0]).toContain("executor handoff: 50ms");
     expect(createdCommentBodies[0]).toContain("remote runtime: 500ms");
+    expect(createdCommentBodies[0]).toContain("publication:");
+    expect(createdCommentBodies[0]).toContain("degraded:");
     expect(
       entries.some((entry) => entry.data?.gate === "review-details-output" && entry.data?.gateResult === "degraded-fallback"),
     ).toBeTrue();

--- a/src/handlers/review.test.ts
+++ b/src/handlers/review.test.ts
@@ -1903,7 +1903,7 @@ describe("createReviewHandler review_requested idempotency", () => {
     ).toBe(true);
   });
 
-  test("clean approval keeps Review Details on the issue-comment path and leaves the approval review body clean", async () => {
+  test("clean approval keeps Review Details inline in the canonical approval review body without creating an issue comment", async () => {
     const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
     const workspaceFixture = await createWorkspaceFixture({ autoApprove: true });
     const { logger } = createCaptureLogger();
@@ -1912,6 +1912,7 @@ describe("createReviewHandler review_requested idempotency", () => {
     const createdIssueComments: string[] = [];
     let executeCount = 0;
     let approveCount = 0;
+    let updatedReviewId: number | undefined;
 
     const eventRouter: EventRouter = {
       register: (eventKey, handler) => {
@@ -1967,6 +1968,7 @@ describe("createReviewHandler review_requested idempotency", () => {
         _route: string,
         params: { review_id: number; body: string },
       ) => {
+        updatedReviewId = params.review_id;
         const review = createdReviews[params.review_id - 1];
         if (review) {
           review.body = params.body;
@@ -2019,6 +2021,7 @@ describe("createReviewHandler review_requested idempotency", () => {
 
     expect(executeCount).toBe(1);
     expect(approveCount).toBe(1);
+    expect(updatedReviewId).toBe(1);
 
     const expectedReviewOutputKey = buildReviewOutputKey({
       installationId: 42,
@@ -2037,14 +2040,12 @@ describe("createReviewHandler review_requested idempotency", () => {
     expect(approvalBody).toContain("Issues: none");
     expect(approvalBody).toContain("Evidence:");
     expect(approvalBody).toContain("- Review prompt covered 1 changed file.");
-    expect(approvalBody).not.toContain("<summary>Review Details</summary>");
+    expect(approvalBody).toContain("<summary>Review Details</summary>");
     expect(approvalBody).not.toContain("Merge Confidence:");
     expect(extractReviewOutputKey(approvalBody)).toBe(expectedReviewOutputKey);
     expect(approvalBody).toContain(marker);
 
-    expect(createdIssueComments).toHaveLength(1);
-    const reviewDetailsBody = createdIssueComments[0] ?? "";
-    const reviewDetailsBlock = extractReviewDetailsBlock(reviewDetailsBody);
+    const reviewDetailsBlock = extractReviewDetailsBlock(approvalBody);
     expect(reviewDetailsBlock).toContain("<summary>Review Details</summary>");
     expect(reviewDetailsBlock).toContain("- Total wall-clock:");
     expect(reviewDetailsBlock).toContain("- Phase timings:");
@@ -2052,9 +2053,11 @@ describe("createReviewHandler review_requested idempotency", () => {
     expect(reviewDetailsBlock).toContain("remote runtime: 500ms");
     expect(reviewDetailsBlock).toContain("publication:");
     expect(extractReviewOutputKey(reviewDetailsBlock)).toBe(expectedReviewOutputKey);
+
+    expect(createdIssueComments).toHaveLength(0);
   });
 
-  test("auto-approve finalization keeps Review Details on the issue-comment path when mixed surfaces exist after a review-surface idempotency accept", async () => {
+  test("auto-approve finalization refreshes the canonical approval review body instead of creating or updating issue comments", async () => {
     const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
     const workspaceFixture = await createWorkspaceFixture({ autoApprove: true });
 
@@ -2203,14 +2206,14 @@ describe("createReviewHandler review_requested idempotency", () => {
     await workspaceFixture.cleanup();
 
     expect(approveCount).toBe(1);
-    expect(updatedReviewId).toBeUndefined();
-    expect(issueCommentCreateCount).toBe(1);
-    expect(issueCommentUpdateCount).toBe(1);
+    expect(updatedReviewId).toBe(950 + approveCount);
+    expect(issueCommentCreateCount).toBe(0);
+    expect(issueCommentUpdateCount).toBe(0);
     expect(createdReviews).toHaveLength(1);
     expect(createdReviews[0]?.body).toContain("Decision: APPROVE");
-    expect(createdReviews[0]?.body).not.toContain("<summary>Review Details</summary>");
-    expect(createdIssueComments).toHaveLength(1);
-    expect(createdIssueComments[0]?.body).toContain("<summary>Review Details</summary>");
+    expect(createdReviews[0]?.body).toContain("<summary>Review Details</summary>");
+    expect(createdReviews[0]?.body).toContain("publication:");
+    expect(createdIssueComments).toHaveLength(0);
   });
 
   test("published-output finalization updates only the canonical issue comment when mixed surfaces exist after an issue-comment idempotency accept", async () => {

--- a/src/handlers/review.test.ts
+++ b/src/handlers/review.test.ts
@@ -5657,7 +5657,7 @@ describe("createReviewHandler finding extraction", () => {
     expect(createCommentCalls).toBe(0);
     expect(completedAttemptIds).toEqual(["attempt-review-details-append-1"]);
     expect(
-      entries.some((entry) => entry.message === "Skipping deterministic Review Details append because publish rights were superseded"),
+      entries.some((entry) => entry.message === "Skipping canonical Review Details merge because publish rights were superseded"),
     ).toBeTrue();
 
     await workspaceFixture.cleanup();
@@ -5782,7 +5782,7 @@ describe("createReviewHandler finding extraction", () => {
     expect(updateCommentCalls).toBe(0);
     expect(completedAttemptIds).toEqual(["attempt-review-details-standalone-1"]);
     expect(
-      entries.some((entry) => entry.message === "Skipping deterministic Review Details standalone comment because publish rights were superseded"),
+      entries.some((entry) => entry.message === "Skipping degraded Review Details fallback comment because publish rights were superseded"),
     ).toBeTrue();
 
     await workspaceFixture.cleanup();
@@ -5939,7 +5939,7 @@ describe("createReviewHandler finding extraction", () => {
     expect(createCommentCalls).toBe(0);
     expect(completedAttemptIds).toEqual(["attempt-review-details-append-recheck-1"]);
     expect(
-      entries.some((entry) => entry.message === "Skipping deterministic Review Details append because publish rights were superseded"),
+      entries.some((entry) => entry.message === "Skipping canonical Review Details merge because publish rights were superseded"),
     ).toBeTrue();
 
     await workspaceFixture.cleanup();
@@ -6071,7 +6071,7 @@ describe("createReviewHandler finding extraction", () => {
     expect(updateCommentCalls).toBe(0);
     expect(completedAttemptIds).toEqual(["attempt-review-details-standalone-recheck-1"]);
     expect(
-      entries.some((entry) => entry.message === "Skipping deterministic Review Details standalone comment because publish rights were superseded"),
+      entries.some((entry) => entry.message === "Skipping degraded Review Details fallback comment because publish rights were superseded"),
     ).toBeTrue();
 
     await workspaceFixture.cleanup();
@@ -9597,7 +9597,7 @@ describe("createReviewHandler timeout resilience", () => {
     expect(reviewDetails).toBeUndefined();
     expect(completedAttemptIds).toEqual(["attempt-timeout-details-1"]);
     expect(
-      entries.some((entry) => entry.message === "Skipping timeout Review Details comment because publish rights were superseded"),
+      entries.some((entry) => entry.message === "Skipping timeout canonical Review Details merge because publish rights were superseded"),
     ).toBeTrue();
 
     await workspaceFixture.cleanup();
@@ -11769,7 +11769,7 @@ describe("createReviewHandler timeout resilience", () => {
       supersededByAttemptId: null,
     });
     expect(
-      entries.some((entry) => entry.message === "Retry complete -- updated partial review comment with merged results; Review Details published via standalone fallback" && entry.data?.projectionStatus === "degraded"),
+      entries.some((entry) => entry.message === "Retry complete -- updated partial review comment with merged results; Review Details published via degraded fallback comment" && entry.data?.projectionStatus === "degraded"),
     ).toBeTrue();
     expect(
       entries.some((entry) => entry.data?.gate === "review-details-output" && entry.data?.gateResult === "degraded-fallback"),
@@ -14962,7 +14962,7 @@ describe("createReviewHandler Review Details phase timing publication", () => {
     await workspaceFixture.cleanup();
   });
 
-  test("falls back to standalone Review Details only when canonical surface update fails", async () => {
+  test("uses degraded fallback Review Details comment only when canonical visible surface update fails", async () => {
     const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
     const workspaceFixture = await createWorkspaceFixture();
     const { logger, entries } = createCaptureLogger();

--- a/src/handlers/review.test.ts
+++ b/src/handlers/review.test.ts
@@ -4,7 +4,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import type { Logger } from "pino";
-import { buildReviewPromptFingerprint, collectDiffContext, createReviewHandler, formatTimeoutErrorDetail, resolveAuthorTierFromSources } from "./review.ts";
+import { buildReviewPromptFingerprint, collectDiffContext, createReviewHandler, formatTimeoutErrorDetail, resolveAuthorTierFromSources, upsertCanonicalReviewSurface } from "./review.ts";
 import { createMentionHandler } from "./mention.ts";
 import { buildReviewOutputKey, buildReviewOutputMarker, extractReviewOutputKey } from "./review-idempotency.ts";
 import { createRetriever } from "../knowledge/retrieval.ts";
@@ -2053,6 +2053,69 @@ describe("createReviewHandler review_requested idempotency", () => {
     expect(approvalBody).toContain(marker);
   });
 
+  test("canonical surface upsert honors requested pull_review kind when issue comment and pull review surfaces both exist", async () => {
+    const reviewOutputKey = buildReviewOutputKey({
+      installationId: 42,
+      owner: "acme",
+      repo: "repo",
+      prNumber: 101,
+      action: "review_requested",
+      deliveryId: "delivery-123",
+      headSha: "abcdef1234567890",
+    });
+    const marker = buildReviewOutputMarker(reviewOutputKey);
+
+    let updatedIssueCommentId: number | undefined;
+    let updatedReviewId: number | undefined;
+
+    const octokit = {
+      rest: {
+        pulls: {
+          listReviews: async () => ({
+            data: [{ id: 902, body: `existing pull review\n\n${marker}` }],
+          }),
+        },
+        issues: {
+          listComments: async () => ({
+            data: [{ id: 901, body: `existing issue comment\n\n${marker}` }],
+          }),
+          updateComment: async ({ comment_id }: { comment_id: number; body: string }) => {
+            updatedIssueCommentId = comment_id;
+            return { data: {} };
+          },
+        },
+      },
+      request: async (
+        route: string,
+        params: { review_id: number; body: string },
+      ) => {
+        expect(route).toBe("PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}");
+        updatedReviewId = params.review_id;
+        return { data: {} };
+      },
+    };
+
+    const updatedSurface = await upsertCanonicalReviewSurface({
+      octokit: octokit as never,
+      owner: "acme",
+      repo: "repo",
+      prNumber: 101,
+      reviewOutputKey,
+      surfaceKind: "pull_review",
+      body: `updated canonical body\n\n${marker}`,
+      botHandles: ["kodiai", "claude"],
+      pullReviewEvent: "APPROVE",
+    });
+
+    expect(updatedSurface).toEqual({
+      kind: "pull_review",
+      reviewId: 902,
+      body: `updated canonical body\n\n${marker}`,
+    });
+    expect(updatedReviewId).toBe(902);
+    expect(updatedIssueCommentId).toBeUndefined();
+  });
+
   test("auto-approve includes dep-bump merge confidence inside the shared approval body", async () => {
     const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
     const workspaceFixture = await createWorkspaceFixture({ autoApprove: true });
@@ -2069,7 +2132,7 @@ describe("createReviewHandler review_requested idempotency", () => {
     await $`git -C ${workspaceFixture.dir} commit -m "add dependency bump fixture"`.quiet();
 
     let approveCount = 0;
-    const createdReviews: Array<{ body?: string }> = [];
+    const createdReviews: Array<{ id: number; body?: string }> = [];
     const previousFetch = globalThis.fetch;
     globalThis.fetch = mock(async () => new Response("Not Found", { status: 404 })) as unknown as typeof globalThis.fetch;
 
@@ -2099,12 +2162,15 @@ describe("createReviewHandler review_requested idempotency", () => {
       rest: {
         pulls: {
           listReviewComments: async () => ({ data: [] }),
-          listReviews: async () => ({ data: [] }),
+          listReviews: async () => ({
+            data: createdReviews.map((review) => ({ id: review.id, body: review.body ?? "" })),
+          }),
           listCommits: async () => ({ data: [] }),
           createReview: async ({ body }: { body?: string }) => {
             approveCount++;
-            createdReviews.push({ body });
-            return { data: {} };
+            const id = 700 + approveCount;
+            createdReviews.push({ id, body });
+            return { data: { id } };
           },
         },
         reactions: {

--- a/src/handlers/review.test.ts
+++ b/src/handlers/review.test.ts
@@ -10920,7 +10920,7 @@ describe("createReviewHandler timeout resilience", () => {
     await workspaceFixture.cleanup();
   });
 
-  test("suppresses retry Review Details refresh after the canonical summary merge loses publish rights", async () => {
+  test("retry merge updates the same canonical comment with merged Review Details in a single upsert", async () => {
     const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
     const workspaceFixture = await createWorkspaceFixture();
     const { logger, entries } = createCaptureLogger();
@@ -11248,10 +11248,8 @@ describe("createReviewHandler timeout resilience", () => {
     expect(updatedCommentBodies).toHaveLength(updateCountBeforeRetry + 1);
     expect(issueComments.get(900)).toBe(updatedCommentBodies.at(-1));
     expect(issueComments.get(900)).toContain("Retry complete -- analyzed 2 of 3 files total after a reduced-scope follow-up.");
-    expect(issueComments.get(900)).not.toContain("<summary>Review Details</summary>");
-    expect(
-      entries.some((entry) => entry.message === "Skipping retry Review Details merge because publish rights were superseded"),
-    ).toBeTrue();
+    expect(issueComments.get(900)).toContain("<summary>Review Details</summary>");
+    expect(issueComments.get(901)).toBeUndefined();
 
     await workspaceFixture.cleanup();
   });

--- a/src/handlers/review.test.ts
+++ b/src/handlers/review.test.ts
@@ -1880,7 +1880,7 @@ describe("createReviewHandler review_requested idempotency", () => {
     ).toBe(true);
   });
 
-  test("replaying a clean PR review_requested keeps the approval body as the only canonical visible surface", async () => {
+  test("clean approval uses the approval review body as the only canonical visible surface", async () => {
     const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
     const workspaceFixture = await createWorkspaceFixture({ autoApprove: true });
     const { logger } = createCaptureLogger();
@@ -2000,6 +2000,7 @@ describe("createReviewHandler review_requested idempotency", () => {
     expect(createdReviews[0]?.body ?? "").toContain("Issues: none");
     expect(createdReviews[0]?.body ?? "").toContain("Evidence:");
     expect(createdReviews[0]?.body ?? "").toContain("- Review prompt covered 1 changed file.");
+    expect(createdReviews[0]?.body ?? "").toContain("<summary>Review Details</summary>");
     expect(createdReviews[0]?.body ?? "").not.toContain("Merge Confidence:");
     expect(createdIssueComments).toHaveLength(0);
     expect(extractReviewOutputKey(createdReviews[0]?.body)).toBe(expectedReviewOutputKey);
@@ -13956,14 +13957,13 @@ describe("createReviewHandler phase timing logging", () => {
 });
 
 describe("createReviewHandler Review Details phase timing publication", () => {
-  test("keeps findings Review Details off a second visible comment when the canonical summary is not yet discoverable", async () => {
+  test("appends Review Details timings into the published summary comment", async () => {
     const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
     const workspaceFixture = await createWorkspaceFixture();
 
+    const createdCommentBodies: string[] = [];
     let updatedSummaryBody: string | undefined;
-    let standaloneDetailsBody: string | undefined;
-    let createCommentCalls = 0;
-    let updateCommentCalls = 0;
+    let updatedSummaryCommentId: number | undefined;
     let issueCommentListCalls = 0;
 
     const reviewOutputKey = buildReviewOutputKey({
@@ -14023,15 +14023,14 @@ describe("createReviewHandler Review Details phase timing publication", () => {
         issues: {
           listComments: async () => {
             issueCommentListCalls += 1;
-            return { data: [] };
+            return { data: [{ id: 77, body: summaryBody }] };
           },
           createComment: async (params: { body: string }) => {
-            createCommentCalls += 1;
-            standaloneDetailsBody = params.body;
+            createdCommentBodies.push(params.body);
             return { data: { id: 88 } };
           },
-          updateComment: async (params: { body: string }) => {
-            updateCommentCalls += 1;
+          updateComment: async (params: { comment_id: number; body: string }) => {
+            updatedSummaryCommentId = params.comment_id;
             updatedSummaryBody = params.body;
             return { data: {} };
           },
@@ -14081,20 +14080,23 @@ describe("createReviewHandler Review Details phase timing publication", () => {
     );
 
     expect(issueCommentListCalls).toBeGreaterThanOrEqual(1);
-    expect(createCommentCalls).toBe(0);
-    expect(updateCommentCalls).toBe(0);
-    expect(standaloneDetailsBody).toBeUndefined();
-    expect(updatedSummaryBody).toBeUndefined();
+    expect(updatedSummaryCommentId).toBe(77);
+    expect(updatedSummaryBody).toContain("<summary>Review Details</summary>");
+    expect(updatedSummaryBody).toContain("queue wait: 250ms");
+    expect(updatedSummaryBody).toContain("executor handoff: 50ms");
+    expect(updatedSummaryBody).toContain("remote runtime: 500ms");
+    expect(updatedSummaryBody).toContain(buildReviewOutputMarker(reviewOutputKey));
+    expect(createdCommentBodies).toHaveLength(0);
 
     await workspaceFixture.cleanup();
   });
 
-  test("uses standalone Review Details only after canonical summary update failure and logs gateResult='degraded-fallback'", async () => {
+  test("falls back to standalone Review Details only when canonical surface update fails", async () => {
     const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
     const workspaceFixture = await createWorkspaceFixture();
     const { logger, entries } = createCaptureLogger();
 
-    let standaloneDetailsBody: string | undefined;
+    const createdCommentBodies: string[] = [];
     let updateCommentCalls = 0;
 
     const reviewOutputKey = buildReviewOutputKey({
@@ -14153,10 +14155,10 @@ describe("createReviewHandler Review Details phase timing publication", () => {
         issues: {
           listComments: async () => ({ data: [{ id: 77, body: summaryBody }] }),
           createComment: async (params: { body: string }) => {
-            standaloneDetailsBody = params.body;
+            createdCommentBodies.push(params.body);
             return { data: { id: 188 } };
           },
-          updateComment: async (_params: { body: string }) => {
+          updateComment: async (_params: { comment_id: number; body: string }) => {
             updateCommentCalls += 1;
             throw new Error("canonical update failed");
           },
@@ -14205,14 +14207,12 @@ describe("createReviewHandler Review Details phase timing publication", () => {
       }),
     );
 
-    expect(standaloneDetailsBody).toBeDefined();
-    expect(standaloneDetailsBody).toContain("<summary>Review Details</summary>");
-    expect(standaloneDetailsBody).toContain("- Total wall-clock:");
-    expect(standaloneDetailsBody).toContain("- Phase timings:");
-    expect(standaloneDetailsBody).toContain("queue wait: 250ms");
-    expect(standaloneDetailsBody).toContain("executor handoff: 50ms");
-    expect(standaloneDetailsBody).toContain("remote runtime: 500ms");
-    expect(standaloneDetailsBody).toContain("publication:");
+    expect(updateCommentCalls).toBe(1);
+    expect(createdCommentBodies).toHaveLength(1);
+    expect(createdCommentBodies[0]).toContain("<summary>Review Details</summary>");
+    expect(createdCommentBodies[0]).toContain("queue wait: 250ms");
+    expect(createdCommentBodies[0]).toContain("executor handoff: 50ms");
+    expect(createdCommentBodies[0]).toContain("remote runtime: 500ms");
     expect(
       entries.some((entry) => entry.data?.gate === "review-details-output" && entry.data?.gateResult === "degraded-fallback"),
     ).toBeTrue();

--- a/src/handlers/review.test.ts
+++ b/src/handlers/review.test.ts
@@ -4,7 +4,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import type { Logger } from "pino";
-import { buildReviewPromptFingerprint, collectDiffContext, createReviewHandler, formatTimeoutErrorDetail, resolveAuthorTierFromSources, upsertCanonicalReviewSurface } from "./review.ts";
+import { buildReviewPromptFingerprint, collectDiffContext, createReviewHandler, formatTimeoutErrorDetail, resolveAuthorTierFromSources } from "./review.ts";
 import { createMentionHandler } from "./mention.ts";
 import { buildReviewOutputKey, buildReviewOutputMarker, extractReviewOutputKey } from "./review-idempotency.ts";
 import { createRetriever } from "../knowledge/retrieval.ts";
@@ -2053,7 +2053,15 @@ describe("createReviewHandler review_requested idempotency", () => {
     expect(approvalBody).toContain(marker);
   });
 
-  test("canonical surface upsert honors requested pull_review kind when issue comment and pull review surfaces both exist", async () => {
+  test("auto-approve finalization updates the canonical pull review when mixed surfaces exist after a review-surface idempotency accept", async () => {
+    const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
+    const workspaceFixture = await createWorkspaceFixture({ autoApprove: true });
+
+    let approveCount = 0;
+    let issueCommentUpdateCount = 0;
+    let updatedReviewId: number | undefined;
+    const createdReviews: Array<{ id: number; body?: string | null }> = [];
+
     const reviewOutputKey = buildReviewOutputKey({
       installationId: 42,
       owner: "acme",
@@ -2065,23 +2073,71 @@ describe("createReviewHandler review_requested idempotency", () => {
     });
     const marker = buildReviewOutputMarker(reviewOutputKey);
 
-    let updatedIssueCommentId: number | undefined;
-    let updatedReviewId: number | undefined;
+    const reviewBodiesByCall = [
+      [{ id: 902, body: `existing pull review\n\n${marker}` }],
+      [{ id: 902, body: `existing pull review\n\n${marker}` }],
+      [],
+      [{ id: 902, body: `existing pull review\n\n${marker}` }],
+    ] as const;
+    const issueCommentBodiesByCall = [
+      [],
+      [],
+    ] as const;
+    let listReviewsCallCount = 0;
+    let listCommentsCallCount = 0;
+
+    const eventRouter: EventRouter = {
+      register: (eventKey, handler) => {
+        handlers.set(eventKey, handler);
+      },
+      dispatch: async () => undefined,
+    };
+
+    const jobQueue: JobQueue = {
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
+      getQueueSize: () => 0,
+      getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
+    };
+
+    const workspaceManager: WorkspaceManager = {
+      create: async () => ({
+        dir: workspaceFixture.dir,
+        cleanup: async () => undefined,
+      }),
+      cleanupStale: async () => 0,
+    };
 
     const octokit = {
       rest: {
         pulls: {
-          listReviews: async () => ({
-            data: [{ id: 902, body: `existing pull review\n\n${marker}` }],
-          }),
+          listReviewComments: async () => ({ data: [] }),
+          listReviews: async () => {
+            const data = reviewBodiesByCall[listReviewsCallCount] ?? [];
+            listReviewsCallCount += 1;
+            return { data };
+          },
+          listCommits: async () => ({ data: [] }),
+          createReview: async ({ body }: { body?: string }) => {
+            approveCount += 1;
+            const review = { id: 950 + approveCount, body: body ?? null };
+            createdReviews.push(review);
+            return { data: { id: review.id } };
+          },
+        },
+        reactions: {
+          createForIssue: async () => ({ data: {} }),
         },
         issues: {
-          listComments: async () => ({
-            data: [{ id: 901, body: `existing issue comment\n\n${marker}` }],
-          }),
+          listComments: async () => {
+            const data = issueCommentBodiesByCall[listCommentsCallCount] ?? [];
+            listCommentsCallCount += 1;
+            return { data };
+          },
+          createComment: async (params: { body: string }) => ({ data: { id: 901, body: params.body } }),
           updateComment: async ({ comment_id }: { comment_id: number; body: string }) => {
-            updatedIssueCommentId = comment_id;
-            return { data: {} };
+            issueCommentUpdateCount += 1;
+            return { data: { id: comment_id } };
           },
         },
       },
@@ -2091,29 +2147,59 @@ describe("createReviewHandler review_requested idempotency", () => {
       ) => {
         expect(route).toBe("PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}");
         updatedReviewId = params.review_id;
+        const existingReview = createdReviews.find((review) => review.id === params.review_id);
+        if (existingReview) {
+          existingReview.body = params.body;
+        }
         return { data: {} };
       },
     };
 
-    const updatedSurface = await upsertCanonicalReviewSurface({
-      octokit: octokit as never,
-      owner: "acme",
-      repo: "repo",
-      prNumber: 101,
-      reviewOutputKey,
-      surfaceKind: "pull_review",
-      body: `updated canonical body\n\n${marker}`,
-      botHandles: ["kodiai", "claude"],
-      pullReviewEvent: "APPROVE",
+    createReviewHandler({
+      eventRouter,
+      jobQueue,
+      workspaceManager,
+      githubApp: {
+        getAppSlug: () => "kodiai",
+        getInstallationOctokit: async () => octokit as never,
+        initialize: async () => undefined,
+        checkConnectivity: async () => true,
+        getInstallationToken: async () => "token",
+      } as unknown as GitHubApp,
+      executor: {
+        execute: async () => ({
+          conclusion: "success",
+          costUsd: 0,
+          numTurns: 1,
+          durationMs: 1,
+          sessionId: "session-mixed-surface-finalization",
+          executorPhaseTimings: [
+            { name: "executor handoff", status: "completed", durationMs: 50 },
+            { name: "remote runtime", status: "completed", durationMs: 500 },
+          ],
+        }),
+      } as never,
+      telemetryStore: noopTelemetryStore,
+      logger: createNoopLogger(),
     });
 
-    expect(updatedSurface).toEqual({
-      kind: "pull_review",
-      reviewId: 902,
-      body: `updated canonical body\n\n${marker}`,
-    });
+    const handler = handlers.get("pull_request.review_requested");
+    expect(handler).toBeDefined();
+
+    await handler!(
+      buildReviewRequestedEvent({
+        requested_reviewer: { login: "kodiai[bot]" },
+      }),
+    );
+
+    await workspaceFixture.cleanup();
+
+    expect(approveCount).toBe(1);
     expect(updatedReviewId).toBe(902);
-    expect(updatedIssueCommentId).toBeUndefined();
+    expect(issueCommentUpdateCount).toBe(0);
+    expect(createdReviews).toHaveLength(1);
+    expect(createdReviews[0]?.body).toContain("Decision: APPROVE");
+    expect(createdReviews[0]?.body).toContain("<summary>Review Details</summary>");
   });
 
   test("auto-approve includes dep-bump merge confidence inside the shared approval body", async () => {

--- a/src/handlers/review.test.ts
+++ b/src/handlers/review.test.ts
@@ -5297,6 +5297,111 @@ describe("createReviewHandler finding extraction", () => {
     await workspaceFixture.cleanup();
   });
 
+  test("review-comment idempotency accept still publishes Review Details when no canonical issue comment exists yet", async () => {
+    const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
+    const workspaceFixture = await createWorkspaceFixture();
+
+    const reviewOutputKey = buildReviewOutputKey({
+      installationId: 42,
+      owner: "acme",
+      repo: "repo",
+      prNumber: 101,
+      action: "review_requested",
+      deliveryId: "delivery-123",
+      headSha: "abcdef1234567890",
+    });
+    const marker = buildReviewOutputMarker(reviewOutputKey);
+
+    let exposeInlineFinding = false;
+    let detailsCommentBody: string | undefined;
+
+    const eventRouter: EventRouter = {
+      register: (eventKey, handler) => {
+        handlers.set(eventKey, handler);
+      },
+      dispatch: async () => undefined,
+    };
+
+    const jobQueue: JobQueue = {
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) =>
+        fn(createQueueRunMetadata()),
+      getQueueSize: () => 0,
+      getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
+    };
+
+    const workspaceManager: WorkspaceManager = {
+      create: async () => ({
+        dir: workspaceFixture.dir,
+        cleanup: async () => undefined,
+      }),
+      cleanupStale: async () => 0,
+    };
+
+    const octokit = {
+      rest: {
+        pulls: {
+          listReviewComments: async () => ({
+            data: exposeInlineFinding
+              ? [{ id: 41, body: `**Inline finding**\n\n${marker}`, path: "src/a.ts", line: 1, start_line: 1 }]
+              : [],
+          }),
+          listReviews: async () => ({ data: [] }),
+          listCommits: async () => ({ data: [] }),
+        },
+        issues: {
+          listComments: async () => ({ data: [] }),
+          createComment: async (params: { body: string }) => {
+            detailsCommentBody = params.body;
+            return { data: { id: 901 } };
+          },
+          updateComment: async () => ({ data: {} }),
+        },
+        reactions: { createForIssue: async () => ({ data: {} }) },
+      },
+    };
+
+    createReviewHandler({
+      eventRouter,
+      jobQueue,
+      workspaceManager,
+      githubApp: {
+        getAppSlug: () => "kodiai",
+        getInstallationOctokit: async () => octokit as never,
+      } as unknown as GitHubApp,
+      executor: {
+        execute: async () => {
+          exposeInlineFinding = true;
+          return {
+            conclusion: "success",
+            published: false,
+            costUsd: 0,
+            numTurns: 1,
+            durationMs: 1,
+            sessionId: "session-review-comment-idempotency-accept",
+            model: "test-model",
+            inputTokens: 0,
+            outputTokens: 0,
+            cacheReadTokens: 0,
+            cacheCreationTokens: 0,
+            stopReason: "end_turn",
+          };
+        },
+      } as never,
+      telemetryStore: noopTelemetryStore,
+      logger: createNoopLogger(),
+    });
+
+    const handler = handlers.get("pull_request.review_requested");
+    expect(handler).toBeDefined();
+
+    await handler!(buildReviewRequestedEvent({ requested_reviewer: { login: "kodiai[bot]" } }));
+
+    expect(detailsCommentBody).toContain("<summary>Review Details</summary>");
+
+    await workspaceFixture.cleanup();
+  });
+
   test("publishes Review Details even when execution reports published false", async () => {
     const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
     const workspaceFixture = await createWorkspaceFixture();
@@ -11310,8 +11415,11 @@ describe("createReviewHandler timeout resilience", () => {
 
     let queuedRetryJob: ((metadata: JobQueueRunMetadata) => Promise<unknown>) | undefined;
     let nextCommentId = 900;
-    const issueComments = new Map<number, string>();
+    const issueComments = new Map<number, string>([
+      [899, `older marker match\n\n${buildReviewOutputMarker(reviewOutputKey)}`],
+    ]);
     const updatedCommentBodies: string[] = [];
+    const updatedCommentIds: number[] = [];
     let exposeContinuationReviewComments = false;
     let allowRetryPublish = true;
     let retryExecutionStarted = false;
@@ -11426,6 +11534,7 @@ describe("createReviewHandler timeout resilience", () => {
           },
           updateComment: async (params: { comment_id: number; body: string }) => {
             updatedCommentBodies.push(params.body);
+            updatedCommentIds.push(params.comment_id);
             issueComments.set(params.comment_id, params.body);
             if (retryExecutionStarted) {
               allowRetryPublish = false;
@@ -11598,9 +11707,11 @@ describe("createReviewHandler timeout resilience", () => {
     await queuedRetryJob!(queueMetadata);
 
     expect(updatedCommentBodies).toHaveLength(updateCountBeforeRetry + 1);
+    expect(updatedCommentIds.at(-1)).toBe(900);
     expect(issueComments.get(900)).toBe(updatedCommentBodies.at(-1));
     expect(issueComments.get(900)).toContain("Retry complete -- analyzed 2 of 3 files total after a reduced-scope follow-up.");
     expect(issueComments.get(900)).toContain("<summary>Review Details</summary>");
+    expect(issueComments.get(899)).toBe(`older marker match\n\n${buildReviewOutputMarker(reviewOutputKey)}`);
     expect(issueComments.get(901)).toBeUndefined();
 
     await workspaceFixture.cleanup();
@@ -14985,6 +15096,121 @@ describe("createReviewHandler phase timing logging", () => {
 });
 
 describe("createReviewHandler Review Details phase timing publication", () => {
+  test("merges Review Details before later unrelated details blocks in the canonical summary body", async () => {
+    const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
+    const workspaceFixture = await createWorkspaceFixture();
+
+    let updatedSummaryBody: string | undefined;
+
+    const reviewOutputKey = buildReviewOutputKey({
+      installationId: 42,
+      owner: "acme",
+      repo: "repo",
+      prNumber: 101,
+      action: "review_requested",
+      deliveryId: "delivery-123",
+      headSha: "abcdef1234567890",
+    });
+
+    const summaryBody = [
+      "<details>",
+      "<summary>Kodiai Review Summary</summary>",
+      "",
+      "## What Changed",
+      "- Found one correctness issue worth fixing before merge.",
+      "",
+      "</details>",
+      "",
+      "<details>",
+      "<summary>Unrelated downstream section</summary>",
+      "",
+      "This block should stay after Review Details.",
+      "",
+      "</details>",
+      "",
+      buildReviewOutputMarker(reviewOutputKey),
+    ].join("\n");
+
+    const eventRouter: EventRouter = {
+      register: (eventKey, handler) => {
+        handlers.set(eventKey, handler);
+      },
+      dispatch: async () => undefined,
+    };
+
+    const jobQueue: JobQueue = {
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
+      getQueueSize: () => 0,
+      getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
+    };
+
+    const workspaceManager: WorkspaceManager = {
+      create: async () => ({ dir: workspaceFixture.dir, cleanup: async () => undefined }),
+      cleanupStale: async () => 0,
+    };
+
+    const octokit = {
+      rest: {
+        pulls: {
+          listReviewComments: async () => ({ data: [] }),
+          listReviews: async () => ({ data: [] }),
+          listCommits: async () => ({ data: [] }),
+        },
+        issues: {
+          listComments: async () => ({ data: [{ id: 77, body: summaryBody }] }),
+          createComment: async () => ({ data: { id: 88 } }),
+          updateComment: async (params: { comment_id: number; body: string }) => {
+            updatedSummaryBody = params.body;
+            return { data: {} };
+          },
+        },
+        reactions: { createForIssue: async () => ({ data: {} }) },
+        search: { issuesAndPullRequests: async () => ({ data: { total_count: 4 } }) },
+      },
+    };
+
+    createReviewHandler({
+      eventRouter,
+      jobQueue,
+      workspaceManager,
+      githubApp: {
+        getAppSlug: () => "kodiai",
+        getInstallationOctokit: async () => octokit as never,
+      } as unknown as GitHubApp,
+      executor: {
+        execute: async () => ({
+          conclusion: "success",
+          published: true,
+          costUsd: 0,
+          numTurns: 1,
+          durationMs: 1,
+          sessionId: "session-multi-details-summary",
+          executorPhaseTimings: [
+            { name: "executor handoff", status: "completed", durationMs: 50 },
+            { name: "remote runtime", status: "completed", durationMs: 500 },
+          ],
+        }),
+      } as never,
+      telemetryStore: noopTelemetryStore,
+      logger: createNoopLogger(),
+    });
+
+    const handler = handlers.get("pull_request.review_requested");
+    expect(handler).toBeDefined();
+
+    await handler!(buildReviewRequestedEvent({ requested_reviewer: { login: "kodiai[bot]" } }));
+
+    const reviewDetailsIndex = updatedSummaryBody?.indexOf("<summary>Review Details</summary>") ?? -1;
+    const unrelatedIndex = updatedSummaryBody?.indexOf("<summary>Unrelated downstream section</summary>") ?? -1;
+
+    expect(reviewDetailsIndex).toBeGreaterThan(-1);
+    expect(unrelatedIndex).toBeGreaterThan(-1);
+    expect(reviewDetailsIndex).toBeLessThan(unrelatedIndex);
+
+    await workspaceFixture.cleanup();
+  });
+
   test("merges Review Details timings into the published canonical visible surface", async () => {
     const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
     const workspaceFixture = await createWorkspaceFixture();

--- a/src/handlers/review.test.ts
+++ b/src/handlers/review.test.ts
@@ -1948,7 +1948,7 @@ describe("createReviewHandler review_requested idempotency", () => {
           createReview: async ({ body }: { body?: string }) => {
             approveCount++;
             createdReviews.push({ body: body ?? null });
-            return { data: {} };
+            return { data: { id: createdReviews.length } };
           },
         },
         reactions: {
@@ -1962,6 +1962,16 @@ describe("createReviewHandler review_requested idempotency", () => {
           },
           updateComment: async () => ({ data: {} }),
         },
+      },
+      request: async (
+        _route: string,
+        params: { review_id: number; body: string },
+      ) => {
+        const review = createdReviews[params.review_id - 1];
+        if (review) {
+          review.body = params.body;
+        }
+        return { data: {} };
       },
     };
 

--- a/src/handlers/review.test.ts
+++ b/src/handlers/review.test.ts
@@ -2202,6 +2202,145 @@ describe("createReviewHandler review_requested idempotency", () => {
     expect(createdReviews[0]?.body).toContain("<summary>Review Details</summary>");
   });
 
+  test("published-output finalization updates only the canonical issue comment when mixed surfaces exist after an issue-comment idempotency accept", async () => {
+    const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
+    const workspaceFixture = await createWorkspaceFixture({ autoApprove: false });
+
+    let issueCommentUpdateCount = 0;
+    let issueCommentUpdateId: number | undefined;
+    let createReviewCount = 0;
+    let updateReviewCount = 0;
+
+    const reviewOutputKey = buildReviewOutputKey({
+      installationId: 42,
+      owner: "acme",
+      repo: "repo",
+      prNumber: 101,
+      action: "review_requested",
+      deliveryId: "delivery-123",
+      headSha: "abcdef1234567890",
+    });
+    const marker = buildReviewOutputMarker(reviewOutputKey);
+
+    const issueCommentBodiesByCall = [
+      [{ id: 901, body: `existing issue comment\n\n${marker}` }],
+      [{ id: 901, body: `existing issue comment\n\n${marker}` }],
+      [{ id: 901, body: `existing issue comment\n\n${marker}` }],
+    ] as const;
+    const reviewBodiesByCall = [
+      [{ id: 902, body: `existing pull review\n\n${marker}` }],
+    ] as const;
+    let listCommentsCallCount = 0;
+    let listReviewsCallCount = 0;
+
+    const eventRouter: EventRouter = {
+      register: (eventKey, handler) => {
+        handlers.set(eventKey, handler);
+      },
+      dispatch: async () => undefined,
+    };
+
+    const jobQueue: JobQueue = {
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
+      getQueueSize: () => 0,
+      getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
+    };
+
+    const workspaceManager: WorkspaceManager = {
+      create: async () => ({
+        dir: workspaceFixture.dir,
+        cleanup: async () => undefined,
+      }),
+      cleanupStale: async () => 0,
+    };
+
+    const octokit = {
+      rest: {
+        pulls: {
+          listReviewComments: async () => ({ data: [] }),
+          listReviews: async () => {
+            const data = reviewBodiesByCall[listReviewsCallCount] ?? [];
+            listReviewsCallCount += 1;
+            return { data };
+          },
+          listCommits: async () => ({ data: [] }),
+          createReview: async () => {
+            createReviewCount += 1;
+            return { data: { id: 950 } };
+          },
+        },
+        reactions: {
+          createForIssue: async () => ({ data: {} }),
+        },
+        issues: {
+          listComments: async () => {
+            const data = issueCommentBodiesByCall[listCommentsCallCount] ?? [];
+            listCommentsCallCount += 1;
+            return { data };
+          },
+          createComment: async (params: { body: string }) => ({ data: { id: 901, body: params.body } }),
+          updateComment: async ({ comment_id, body }: { comment_id: number; body: string }) => {
+            issueCommentUpdateCount += 1;
+            issueCommentUpdateId = comment_id;
+            expect(body).toContain("<summary>Review Details</summary>");
+            return { data: { id: comment_id, body } };
+          },
+        },
+      },
+      request: async () => {
+        updateReviewCount += 1;
+        return { data: {} };
+      },
+    };
+
+    createReviewHandler({
+      eventRouter,
+      jobQueue,
+      workspaceManager,
+      githubApp: {
+        getAppSlug: () => "kodiai",
+        getInstallationOctokit: async () => octokit as never,
+        initialize: async () => undefined,
+        checkConnectivity: async () => true,
+        getInstallationToken: async () => "token",
+      } as unknown as GitHubApp,
+      executor: {
+        execute: async () => ({
+          conclusion: "success",
+          published: true,
+          costUsd: 0,
+          numTurns: 1,
+          durationMs: 1,
+          sessionId: "session-issue-comment-mixed-surface-finalization",
+          executorPhaseTimings: [
+            { name: "executor handoff", status: "completed", durationMs: 50 },
+            { name: "remote runtime", status: "completed", durationMs: 500 },
+          ],
+        }),
+      } as never,
+      telemetryStore: noopTelemetryStore,
+      logger: createNoopLogger(),
+    });
+
+    const handler = handlers.get("pull_request.review_requested");
+    expect(handler).toBeDefined();
+
+    await handler!(
+      buildReviewRequestedEvent({
+        requested_reviewer: { login: "kodiai[bot]" },
+      }),
+    );
+
+    await workspaceFixture.cleanup();
+
+    expect(issueCommentUpdateId).toBe(901);
+    expect(issueCommentUpdateCount).toBe(1);
+    expect(createReviewCount).toBe(0);
+    expect(updateReviewCount).toBe(0);
+    expect(listReviewsCallCount).toBe(0);
+  });
+
   test("auto-approve includes dep-bump merge confidence inside the shared approval body", async () => {
     const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
     const workspaceFixture = await createWorkspaceFixture({ autoApprove: true });

--- a/src/handlers/review.ts
+++ b/src/handlers/review.ts
@@ -690,7 +690,7 @@ function getCanonicalReviewSurfaceId(surface: CanonicalReviewSurface): number {
   return surface.kind === "issue_comment" ? surface.commentId : surface.reviewId;
 }
 
-export async function findCanonicalReviewSurface(params: {
+async function findCanonicalReviewSurface(params: {
   octokit: Octokit;
   owner: string;
   repo: string;
@@ -851,7 +851,7 @@ async function createCanonicalReviewSurface(params: {
   throw new Error("Created canonical pull review could not be reloaded");
 }
 
-export async function upsertCanonicalReviewSurface(params: {
+async function upsertCanonicalReviewSurface(params: {
   octokit: Octokit;
   owner: string;
   repo: string;

--- a/src/handlers/review.ts
+++ b/src/handlers/review.ts
@@ -680,13 +680,15 @@ async function fetchCommitMessages(
 
 
 
-export type CanonicalSurfaceKind = "issue_comment" | "pull_review";
+export type CanonicalReviewSurface =
+  | { kind: "issue_comment"; commentId: number; body: string }
+  | { kind: "pull_review"; reviewId: number; body: string };
 
-export type CanonicalReviewSurface = {
-  kind: CanonicalSurfaceKind;
-  id: number;
-  body: string;
-};
+export type CanonicalSurfaceKind = CanonicalReviewSurface["kind"];
+
+function getCanonicalReviewSurfaceId(surface: CanonicalReviewSurface): number {
+  return surface.kind === "issue_comment" ? surface.commentId : surface.reviewId;
+}
 
 async function findCanonicalReviewSurface(params: {
   octokit: Octokit;
@@ -715,7 +717,7 @@ async function findCanonicalReviewSurface(params: {
   if (issueComment) {
     return {
       kind: "issue_comment",
-      id: issueComment.id,
+      commentId: issueComment.id,
       body: issueComment.body,
     };
   }
@@ -739,7 +741,7 @@ async function findCanonicalReviewSurface(params: {
 
   return {
     kind: "pull_review",
-    id: pullReview.id,
+    reviewId: pullReview.id,
     body: pullReview.body,
   };
 }
@@ -759,24 +761,31 @@ async function updateCanonicalReviewSurface(params: {
     await params.octokit.rest.issues.updateComment({
       owner: params.owner,
       repo: params.repo,
-      comment_id: params.surface.id,
+      comment_id: params.surface.commentId,
       body: sanitizedBody,
     });
-  } else {
-    await params.octokit.request(
-      "PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}",
-      {
-        owner: params.owner,
-        repo: params.repo,
-        pull_number: params.prNumber,
-        review_id: params.surface.id,
-        body: sanitizedBody,
-      },
-    );
+
+    return {
+      kind: "issue_comment",
+      commentId: params.surface.commentId,
+      body: sanitizedBody,
+    };
   }
 
+  await params.octokit.request(
+    "PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}",
+    {
+      owner: params.owner,
+      repo: params.repo,
+      pull_number: params.prNumber,
+      review_id: params.surface.reviewId,
+      body: sanitizedBody,
+    },
+  );
+
   return {
-    ...params.surface,
+    kind: "pull_review",
+    reviewId: params.surface.reviewId,
     body: sanitizedBody,
   };
 }
@@ -786,6 +795,7 @@ async function createCanonicalReviewSurface(params: {
   owner: string;
   repo: string;
   prNumber: number;
+  reviewOutputKey: string;
   surfaceKind: CanonicalSurfaceKind;
   body: string;
   botHandles: string[];
@@ -803,7 +813,7 @@ async function createCanonicalReviewSurface(params: {
 
     return {
       kind: "issue_comment",
-      id: response.data.id,
+      commentId: response.data.id,
       body: sanitizedBody,
     };
   }
@@ -819,7 +829,7 @@ async function createCanonicalReviewSurface(params: {
   if (typeof response.data.id === "number") {
     return {
       kind: "pull_review",
-      id: response.data.id,
+      reviewId: response.data.id,
       body: sanitizedBody,
     };
   }
@@ -829,7 +839,7 @@ async function createCanonicalReviewSurface(params: {
     owner: params.owner,
     repo: params.repo,
     prNumber: params.prNumber,
-    reviewOutputKey: extractReviewOutputKey(sanitizedBody) ?? "",
+    reviewOutputKey: params.reviewOutputKey,
   });
 
   if (createdSurface?.kind === "pull_review") {
@@ -880,6 +890,7 @@ async function upsertCanonicalReviewSurface(params: {
     owner: params.owner,
     repo: params.repo,
     prNumber: params.prNumber,
+    reviewOutputKey: params.reviewOutputKey,
     surfaceKind: params.surfaceKind,
     body: params.body,
     botHandles: params.botHandles,
@@ -1028,7 +1039,7 @@ async function appendReviewDetailsToSummary(params: {
     body: updatedBody,
     botHandles,
   });
-  return updatedSurface.id;
+  return getCanonicalReviewSurfaceId(updatedSurface);
 }
 
 async function resolveAuthorTier(params: {

--- a/src/handlers/review.ts
+++ b/src/handlers/review.ts
@@ -715,14 +715,17 @@ async function findCanonicalReviewSurface(params: {
       && typeof comment.body === "string"
       && comment.body.includes(marker)
     );
+    const issueCommentBody = typeof issueComment?.body === "string" ? issueComment.body : undefined;
 
-    return issueComment
-      ? {
+    if (typeof issueComment?.id === "number" && issueCommentBody !== undefined) {
+      return {
         kind: "issue_comment",
         commentId: issueComment.id,
-        body: issueComment.body,
-      }
-      : null;
+        body: issueCommentBody,
+      };
+    }
+
+    return null;
   }
 
   const reviewsResponse = await params.octokit.rest.pulls.listReviews({
@@ -737,14 +740,17 @@ async function findCanonicalReviewSurface(params: {
     && typeof review.body === "string"
     && review.body.includes(marker)
   );
+  const pullReviewBody = typeof pullReview?.body === "string" ? pullReview.body : undefined;
 
-  return pullReview
-    ? {
+  if (typeof pullReview?.id === "number" && pullReviewBody !== undefined) {
+    return {
       kind: "pull_review",
       reviewId: pullReview.id,
-      body: pullReview.body,
-    }
-    : null;
+      body: pullReviewBody,
+    };
+  }
+
+  return null;
 }
 
 async function updateCanonicalReviewSurface(params: {
@@ -812,6 +818,10 @@ async function createCanonicalReviewSurface(params: {
       body: sanitizedBody,
     });
 
+    if (typeof response.data.id !== "number") {
+      throw new Error("Created canonical issue comment did not return an id");
+    }
+
     return {
       kind: "issue_comment",
       commentId: response.data.id,
@@ -857,7 +867,7 @@ async function upsertCanonicalReviewSurface(params: {
   repo: string;
   prNumber: number;
   reviewOutputKey: string;
-  surfaceKind: CanonicalSurfaceKind;
+  preferredKind: CanonicalSurfaceKind;
   body: string;
   botHandles: string[];
   pullReviewEvent?: "APPROVE" | "COMMENT" | "REQUEST_CHANGES";
@@ -869,7 +879,7 @@ async function upsertCanonicalReviewSurface(params: {
     repo: params.repo,
     prNumber: params.prNumber,
     reviewOutputKey: params.reviewOutputKey,
-    surfaceKind: params.surfaceKind,
+    surfaceKind: params.preferredKind,
   });
 
   if (params.recheckCanPublish && !params.recheckCanPublish()) {
@@ -894,10 +904,76 @@ async function upsertCanonicalReviewSurface(params: {
     repo: params.repo,
     prNumber: params.prNumber,
     reviewOutputKey: params.reviewOutputKey,
-    surfaceKind: params.surfaceKind,
+    surfaceKind: params.preferredKind,
     body: params.body,
     botHandles: params.botHandles,
     pullReviewEvent: params.pullReviewEvent,
+  });
+}
+
+async function rebuildCanonicalReviewSurfaceWithDetails(params: {
+  octokit: Octokit;
+  owner: string;
+  repo: string;
+  prNumber: number;
+  reviewOutputKey: string;
+  preferredKind: CanonicalSurfaceKind;
+  reviewDetailsBlock: string;
+  botHandles: string[];
+  summaryBody?: string;
+  pullReviewEvent?: "APPROVE" | "COMMENT" | "REQUEST_CHANGES";
+  requireDegradationDisclosure: boolean;
+  reviewBoundedness?: ReviewBoundednessContract | null;
+  recheckCanPublish?: () => boolean;
+}): Promise<CanonicalReviewSurface | undefined> {
+  const existingSurface = await findCanonicalReviewSurface({
+    octokit: params.octokit,
+    owner: params.owner,
+    repo: params.repo,
+    prNumber: params.prNumber,
+    reviewOutputKey: params.reviewOutputKey,
+    surfaceKind: params.preferredKind,
+  });
+
+  const summaryBody = params.summaryBody ?? existingSurface?.body;
+  if (!summaryBody) {
+    throw new Error(`Canonical ${params.preferredKind} surface not found for review output marker`);
+  }
+
+  const rebuiltBody = mergeReviewDetailsIntoSummaryBody({
+    summaryBody,
+    reviewDetailsBlock: params.reviewDetailsBlock,
+    requireDegradationDisclosure: params.requireDegradationDisclosure,
+    reviewBoundedness: params.reviewBoundedness,
+  });
+
+  if (params.recheckCanPublish && !params.recheckCanPublish()) {
+    return undefined;
+  }
+
+  if (existingSurface) {
+    return await updateCanonicalReviewSurface({
+      octokit: params.octokit,
+      owner: params.owner,
+      repo: params.repo,
+      prNumber: params.prNumber,
+      surface: existingSurface,
+      body: rebuiltBody,
+      botHandles: params.botHandles,
+    });
+  }
+
+  return await upsertCanonicalReviewSurface({
+    octokit: params.octokit,
+    owner: params.owner,
+    repo: params.repo,
+    prNumber: params.prNumber,
+    reviewOutputKey: params.reviewOutputKey,
+    preferredKind: params.preferredKind,
+    body: rebuiltBody,
+    botHandles: params.botHandles,
+    pullReviewEvent: params.pullReviewEvent,
+    recheckCanPublish: params.recheckCanPublish,
   });
 }
 
@@ -996,57 +1072,7 @@ function mergeReviewDetailsIntoSummaryBody(params: {
   return `${beforeWithoutExistingDetails}\n\n${updatedReviewDetails}\n${after}`;
 }
 
-async function appendReviewDetailsToSummary(params: {
-  octokit: Awaited<ReturnType<GitHubApp["getInstallationOctokit"]>>;
-  owner: string;
-  repo: string;
-  prNumber: number;
-  reviewOutputKey: string;
-  reviewDetailsBlock: string;
-  botHandles: string[];
-  requireDegradationDisclosure: boolean;
-  reviewBoundedness?: ReviewBoundednessContract | null;
-  recheckCanPublish?: () => boolean;
-}): Promise<number | undefined> {
-  const { octokit, owner, repo, prNumber, reviewOutputKey, botHandles } = params;
-
-  const canonicalSurface = await findCanonicalReviewSurface({
-    octokit,
-    owner,
-    repo,
-    prNumber,
-    reviewOutputKey,
-    surfaceKind: "issue_comment",
-  });
-
-  if (!canonicalSurface || canonicalSurface.kind !== "issue_comment") {
-    throw new Error("Summary comment not found for review output marker");
-  }
-
-  const updatedBody = mergeReviewDetailsIntoSummaryBody({
-    summaryBody: canonicalSurface.body,
-    reviewDetailsBlock: params.reviewDetailsBlock,
-    requireDegradationDisclosure: params.requireDegradationDisclosure,
-    reviewBoundedness: params.reviewBoundedness,
-  });
-
-  if (params.recheckCanPublish && !params.recheckCanPublish()) {
-    return undefined;
-  }
-
-  const updatedSurface = await updateCanonicalReviewSurface({
-    octokit,
-    owner,
-    repo,
-    prNumber,
-    surface: canonicalSurface,
-    body: updatedBody,
-    botHandles,
-  });
-  return getCanonicalReviewSurfaceId(updatedSurface);
-}
-
-async function resolveAuthorTier(params: {
+function resolveAuthorTier(params: {
   authorLogin: string;
   authorAssociation: string;
   repo: string;
@@ -4596,17 +4622,17 @@ export function createReviewHandler(deps: {
             canonicalReviewDetailsBody = fullDetailsBody;
 
             if (result.published) {
-              // Summary comment was posted -- append Review Details to it
               if (canPublishVisibleOutput("deterministic Review Details append")) {
-                let appendedToSummary = false;
+                let canonicalIssueComment: CanonicalReviewSurface | undefined;
                 try {
                   setReviewWorkPhase("publish");
-                  const appendedCommentId = await appendReviewDetailsToSummary({
+                  canonicalIssueComment = await rebuildCanonicalReviewSurfaceWithDetails({
                     octokit: extractionOctokit,
                     owner: apiOwner,
                     repo: apiRepo,
                     prNumber: pr.number,
                     reviewOutputKey,
+                    preferredKind: "issue_comment",
                     reviewDetailsBlock: fullDetailsBody,
                     botHandles: [githubApp.getAppSlug(), "claude"],
                     requireDegradationDisclosure: authorClassification.searchEnrichment.degraded,
@@ -4614,12 +4640,10 @@ export function createReviewHandler(deps: {
                     recheckCanPublish: () =>
                       canPublishVisibleOutput("deterministic Review Details append"),
                   });
-                  appendedToSummary = appendedCommentId !== undefined;
                 } catch (appendErr) {
-                  // Fallback: post standalone if the initial append fails (e.g., summary comment not found yet)
                   logger.warn(
                     { ...baseLog, gate: "review-details-output", gateResult: "degraded-fallback", err: appendErr },
-                    "Failed to append Review Details to summary comment; posting standalone",
+                    "Failed to rebuild canonical issue comment with Review Details; posting standalone",
                   );
                   if (canPublishVisibleOutput("deterministic Review Details standalone comment")) {
                     setReviewWorkPhase("publish");
@@ -4637,17 +4661,19 @@ export function createReviewHandler(deps: {
                   }
                 }
 
-                if (appendedToSummary) {
+                if (canonicalIssueComment?.kind === "issue_comment") {
                   finalizePublicationPhaseTiming();
                   try {
-                    await appendReviewDetailsToSummary({
+                    await rebuildCanonicalReviewSurfaceWithDetails({
                       octokit: extractionOctokit,
                       owner: apiOwner,
                       repo: apiRepo,
                       prNumber: pr.number,
                       reviewOutputKey,
+                      preferredKind: "issue_comment",
                       reviewDetailsBlock: buildReviewDetailsBody(),
                       botHandles: [githubApp.getAppSlug(), "claude"],
+                      summaryBody: canonicalIssueComment.body,
                       requireDegradationDisclosure: authorClassification.searchEnrichment.degraded,
                       reviewBoundedness,
                       recheckCanPublish: () =>
@@ -4661,7 +4687,7 @@ export function createReviewHandler(deps: {
                         gateResult: "finalized-append-failed",
                         err: appendErr,
                       },
-                      "Failed to refresh finalized Review Details timing in summary comment",
+                      "Failed to refresh finalized Review Details timing in canonical issue comment",
                     );
                   }
                 }
@@ -5325,7 +5351,13 @@ export function createReviewHandler(deps: {
 
               try {
                 if (canPublishVisibleOutput("timeout Review Details comment")) {
-                  const mergedPartialBody = mergeReviewDetailsIntoSummaryBody({
+                  await rebuildCanonicalReviewSurfaceWithDetails({
+                    octokit,
+                    owner: apiOwner,
+                    repo: apiRepo,
+                    prNumber: pr.number,
+                    reviewOutputKey,
+                    preferredKind: "issue_comment",
                     summaryBody: partialBody,
                     reviewDetailsBlock: buildReviewDetailsBody({
                       timeoutProgress: timeoutReviewDetails,
@@ -5338,18 +5370,11 @@ export function createReviewHandler(deps: {
                           }
                         : null,
                     }),
+                    botHandles: [githubApp.getAppSlug(), "claude"],
                     requireDegradationDisclosure: authorClassification.searchEnrichment.degraded,
                     reviewBoundedness,
+                    recheckCanPublish: () => canPublishVisibleOutput("timeout Review Details comment"),
                   });
-
-                  if (canPublishVisibleOutput("timeout Review Details comment")) {
-                    await octokit.rest.issues.updateComment({
-                      owner: apiOwner,
-                      repo: apiRepo,
-                      comment_id: partialCommentId,
-                      body: sanitizeOutgoingMentions(mergedPartialBody, [githubApp.getAppSlug(), "claude"]),
-                    });
-                  }
                 }
               } catch (reviewDetailsErr) {
                 logger.warn(
@@ -5456,12 +5481,6 @@ export function createReviewHandler(deps: {
                 } catch (err) {
                   logger.warn({ err }, "Resilience telemetry write failed (non-blocking)");
                   continuationProjectionDegraded = true;
-                  await persistDegradedContinuationFamilyState({
-                    authoritativeAttemptId: retryReviewWorkAttempt.attemptId,
-                    authoritativeOutcome: "continuation-pending",
-                    finalStopReason: "awaiting-continuation",
-                    reviewOutputKey: retryReviewOutputKey,
-                  });
                 }
               }
 
@@ -5870,36 +5889,39 @@ export function createReviewHandler(deps: {
                           retryDeliveryId,
                         )) {
                           setReviewWorkPhaseForAttempt(retryReviewWorkAttempt.attemptId, "publish");
-                          await retryOctokit.rest.issues.updateComment({
-                            owner: apiOwner,
-                            repo: apiRepo,
-                            comment_id: commentIdToUpdate,
-                            body: sanitizeOutgoingMentions(mergedBody, [githubApp.getAppSlug(), "claude"]),
-                          });
 
                           try {
-                            const mergedBodyWithDetails = mergeReviewDetailsIntoSummaryBody({
+                            const mergedBodyWithDetails = await rebuildCanonicalReviewSurfaceWithDetails({
+                              octokit: retryOctokit,
+                              owner: apiOwner,
+                              repo: apiRepo,
+                              prNumber: pr.number,
+                              reviewOutputKey,
+                              preferredKind: "issue_comment",
                               summaryBody: mergedBody,
                               reviewDetailsBlock: buildReviewDetailsBody({
                                 reviewFirstPass: mergedFirstPass,
                               }),
+                              botHandles: [githubApp.getAppSlug(), "claude"],
                               requireDegradationDisclosure: authorClassification.searchEnrichment.degraded,
                               reviewBoundedness,
+                              recheckCanPublish: () =>
+                                canPublishReviewWorkOutput(
+                                  retryReviewWorkAttempt.attemptId,
+                                  "retry Review Details merge",
+                                  retryDeliveryId,
+                                ),
                             });
 
-                            if (
-                              canPublishReviewWorkOutput(
-                                retryReviewWorkAttempt.attemptId,
-                                "retry Review Details merge",
-                                retryDeliveryId,
-                              )
-                            ) {
-                              await retryOctokit.rest.issues.updateComment({
-                                owner: apiOwner,
-                                repo: apiRepo,
-                                comment_id: commentIdToUpdate,
-                                body: sanitizeOutgoingMentions(mergedBodyWithDetails, [githubApp.getAppSlug(), "claude"]),
+                            if (!mergedBodyWithDetails) {
+                              await settleRetryWithoutCanonicalUpdate({
+                                attemptId: retryReviewWorkAttempt.attemptId,
+                                reviewOutputKey: retryReviewOutputKey,
+                                deliveryId: retryDeliveryId,
+                                reason: "publish-superseded",
+                                logMessage: "Retry settlement skipped because publish rights were superseded",
                               });
+                              return;
                             }
                           } catch (reviewDetailsErr) {
                             logger.warn(
@@ -6192,12 +6214,14 @@ export function createReviewHandler(deps: {
 
             if (exhaustedTurnBudget && failureFirstPass?.state === "bounded-first-pass") {
               try {
-                await appendReviewDetailsToSummary({
+                await rebuildCanonicalReviewSurfaceWithDetails({
                   octokit,
                   owner: apiOwner,
                   repo: apiRepo,
                   prNumber: pr.number,
                   reviewOutputKey,
+                  preferredKind: "issue_comment",
+                  summaryBody: failureBody,
                   reviewDetailsBlock: buildReviewDetailsBody({
                     reviewFirstPass: failureFirstPass,
                   }),
@@ -6314,7 +6338,7 @@ export function createReviewHandler(deps: {
                 repo: apiRepo,
                 prNumber: pr.number,
                 reviewOutputKey,
-                surfaceKind: "pull_review",
+                preferredKind: "pull_review",
                 pullReviewEvent: "APPROVE",
                 body: mergeReviewDetailsIntoSummaryBody({
                   summaryBody: buildApprovedReviewBody({

--- a/src/handlers/review.ts
+++ b/src/handlers/review.ts
@@ -5924,6 +5924,9 @@ export function createReviewHandler(deps: {
                         )) {
                           setReviewWorkPhaseForAttempt(retryReviewWorkAttempt.attemptId, "publish");
 
+                          let retryMergeProjectionStatus: ContinuationFamilyProjectionStatus = "canonical";
+                          let retryMergeLogMessage = "Retry complete -- updated partial review comment with merged results";
+
                           try {
                             const mergedBodyWithDetails = await rebuildCanonicalReviewSurfaceWithDetails({
                               octokit: retryOctokit,
@@ -5968,6 +5971,9 @@ export function createReviewHandler(deps: {
                               },
                               "Failed to rebuild retry canonical issue comment with Review Details; posting standalone",
                             );
+
+                            retryMergeProjectionStatus = "degraded";
+                            retryMergeLogMessage = "Retry complete -- updated partial review comment with merged results; Review Details published via standalone fallback";
 
                             if (
                               canPublishReviewWorkOutput(
@@ -6017,15 +6023,16 @@ export function createReviewHandler(deps: {
                               retryFilesReviewed,
                               partialCommentId,
                               settlementReason: settlementDecision.reason,
+                              projectionStatus: retryMergeProjectionStatus,
                             },
-                            "Retry complete -- updated partial review comment with merged results",
+                            retryMergeLogMessage,
                           );
 
                           await persistContinuationFamilyState({
                             authoritativeAttemptId: retryReviewWorkAttempt.attemptId,
                             authoritativeOutcome: "merged",
                             finalStopReason: "merged-continuation-results",
-                            projectionStatus: "canonical",
+                            projectionStatus: retryMergeProjectionStatus,
                             reviewOutputKey: retryReviewOutputKey,
                           });
 

--- a/src/handlers/review.ts
+++ b/src/handlers/review.ts
@@ -1026,14 +1026,15 @@ function mergeReviewDetailsIntoSummaryBody(params: {
   }
 
   const closingTag = '</details>';
-  const lastCloseIdx = summaryBody.lastIndexOf(closingTag);
-  if (lastCloseIdx === -1) {
+  const firstCloseIdx = summaryBody.indexOf(closingTag);
+  if (firstCloseIdx === -1) {
     return `${summaryBody}\n\n${updatedReviewDetails}`;
   }
 
-  const before = summaryBody.slice(0, lastCloseIdx).trimEnd();
-  const after = summaryBody.slice(lastCloseIdx);
-  return `${before}\n\n${updatedReviewDetails}\n${after}`;
+  const insertionIdx = firstCloseIdx + closingTag.length;
+  const before = summaryBody.slice(0, insertionIdx).trimEnd();
+  const after = summaryBody.slice(insertionIdx).trimStart();
+  return after ? `${before}\n\n${updatedReviewDetails}\n\n${after}` : `${before}\n\n${updatedReviewDetails}`;
 }
 
 function resolveAuthorTier(params: {
@@ -5908,6 +5909,11 @@ export function createReviewHandler(deps: {
                               prNumber: pr.number,
                               reviewOutputKey,
                               preferredKind: "issue_comment",
+                              canonicalSurface: {
+                                kind: "issue_comment",
+                                commentId: commentIdToUpdate,
+                                body: mergedBody,
+                              },
                               summaryBody: mergedBody,
                               reviewDetailsBlock: buildReviewDetailsBody({
                                 reviewFirstPass: mergedFirstPass,

--- a/src/handlers/review.ts
+++ b/src/handlers/review.ts
@@ -735,7 +735,7 @@ async function findCanonicalReviewSurface(params: {
     per_page: 100,
   });
 
-  const pullReview = reviewsResponse.data.find((review) =>
+  const pullReview = [...reviewsResponse.data].reverse().find((review) =>
     typeof review.id === "number"
     && typeof review.body === "string"
     && review.body.includes(marker)

--- a/src/handlers/review.ts
+++ b/src/handlers/review.ts
@@ -1,3 +1,4 @@
+import type { Octokit } from "@octokit/rest";
 import type {
   PullRequestOpenedEvent,
   PullRequestReadyForReviewEvent,
@@ -679,6 +680,213 @@ async function fetchCommitMessages(
 
 
 
+export type CanonicalSurfaceKind = "issue_comment" | "pull_review";
+
+export type CanonicalReviewSurface = {
+  kind: CanonicalSurfaceKind;
+  id: number;
+  body: string;
+};
+
+async function findCanonicalReviewSurface(params: {
+  octokit: Octokit;
+  owner: string;
+  repo: string;
+  prNumber: number;
+  reviewOutputKey: string;
+}): Promise<CanonicalReviewSurface | null> {
+  const marker = buildReviewOutputMarker(params.reviewOutputKey);
+
+  const commentsResponse = await params.octokit.rest.issues.listComments({
+    owner: params.owner,
+    repo: params.repo,
+    issue_number: params.prNumber,
+    per_page: 100,
+    sort: "created",
+    direction: "desc",
+  });
+
+  const issueComment = commentsResponse.data.find((comment) =>
+    typeof comment.id === "number"
+    && typeof comment.body === "string"
+    && comment.body.includes(marker)
+  );
+
+  if (issueComment) {
+    return {
+      kind: "issue_comment",
+      id: issueComment.id,
+      body: issueComment.body,
+    };
+  }
+
+  const reviewsResponse = await params.octokit.rest.pulls.listReviews({
+    owner: params.owner,
+    repo: params.repo,
+    pull_number: params.prNumber,
+    per_page: 100,
+  });
+
+  const pullReview = reviewsResponse.data.find((review) =>
+    typeof review.id === "number"
+    && typeof review.body === "string"
+    && review.body.includes(marker)
+  );
+
+  if (!pullReview) {
+    return null;
+  }
+
+  return {
+    kind: "pull_review",
+    id: pullReview.id,
+    body: pullReview.body,
+  };
+}
+
+async function updateCanonicalReviewSurface(params: {
+  octokit: Octokit;
+  owner: string;
+  repo: string;
+  prNumber: number;
+  surface: CanonicalReviewSurface;
+  body: string;
+  botHandles: string[];
+}): Promise<CanonicalReviewSurface> {
+  const sanitizedBody = sanitizeOutgoingMentions(params.body, params.botHandles);
+
+  if (params.surface.kind === "issue_comment") {
+    await params.octokit.rest.issues.updateComment({
+      owner: params.owner,
+      repo: params.repo,
+      comment_id: params.surface.id,
+      body: sanitizedBody,
+    });
+  } else {
+    await params.octokit.request(
+      "PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}",
+      {
+        owner: params.owner,
+        repo: params.repo,
+        pull_number: params.prNumber,
+        review_id: params.surface.id,
+        body: sanitizedBody,
+      },
+    );
+  }
+
+  return {
+    ...params.surface,
+    body: sanitizedBody,
+  };
+}
+
+async function createCanonicalReviewSurface(params: {
+  octokit: Octokit;
+  owner: string;
+  repo: string;
+  prNumber: number;
+  surfaceKind: CanonicalSurfaceKind;
+  body: string;
+  botHandles: string[];
+  pullReviewEvent?: "APPROVE" | "COMMENT" | "REQUEST_CHANGES";
+}): Promise<CanonicalReviewSurface> {
+  const sanitizedBody = sanitizeOutgoingMentions(params.body, params.botHandles);
+
+  if (params.surfaceKind === "issue_comment") {
+    const response = await params.octokit.rest.issues.createComment({
+      owner: params.owner,
+      repo: params.repo,
+      issue_number: params.prNumber,
+      body: sanitizedBody,
+    });
+
+    return {
+      kind: "issue_comment",
+      id: response.data.id,
+      body: sanitizedBody,
+    };
+  }
+
+  const response = await params.octokit.rest.pulls.createReview({
+    owner: params.owner,
+    repo: params.repo,
+    pull_number: params.prNumber,
+    event: params.pullReviewEvent ?? "COMMENT",
+    body: sanitizedBody,
+  });
+
+  if (typeof response.data.id === "number") {
+    return {
+      kind: "pull_review",
+      id: response.data.id,
+      body: sanitizedBody,
+    };
+  }
+
+  const createdSurface = await findCanonicalReviewSurface({
+    octokit: params.octokit,
+    owner: params.owner,
+    repo: params.repo,
+    prNumber: params.prNumber,
+    reviewOutputKey: extractReviewOutputKey(sanitizedBody) ?? "",
+  });
+
+  if (createdSurface?.kind === "pull_review") {
+    return createdSurface;
+  }
+
+  throw new Error("Created canonical pull review could not be reloaded");
+}
+
+async function upsertCanonicalReviewSurface(params: {
+  octokit: Octokit;
+  owner: string;
+  repo: string;
+  prNumber: number;
+  reviewOutputKey: string;
+  surfaceKind: CanonicalSurfaceKind;
+  body: string;
+  botHandles: string[];
+  pullReviewEvent?: "APPROVE" | "COMMENT" | "REQUEST_CHANGES";
+  recheckCanPublish?: () => boolean;
+}): Promise<CanonicalReviewSurface | undefined> {
+  const existingSurface = await findCanonicalReviewSurface({
+    octokit: params.octokit,
+    owner: params.owner,
+    repo: params.repo,
+    prNumber: params.prNumber,
+    reviewOutputKey: params.reviewOutputKey,
+  });
+
+  if (params.recheckCanPublish && !params.recheckCanPublish()) {
+    return undefined;
+  }
+
+  if (existingSurface) {
+    return await updateCanonicalReviewSurface({
+      octokit: params.octokit,
+      owner: params.owner,
+      repo: params.repo,
+      prNumber: params.prNumber,
+      surface: existingSurface,
+      body: params.body,
+      botHandles: params.botHandles,
+    });
+  }
+
+  return await createCanonicalReviewSurface({
+    octokit: params.octokit,
+    owner: params.owner,
+    repo: params.repo,
+    prNumber: params.prNumber,
+    surfaceKind: params.surfaceKind,
+    body: params.body,
+    botHandles: params.botHandles,
+    pullReviewEvent: params.pullReviewEvent,
+  });
+}
+
 async function upsertReviewDetailsComment(params: {
   octokit: Awaited<ReturnType<GitHubApp["getInstallationOctokit"]>>;
   owner: string;
@@ -787,30 +995,22 @@ async function appendReviewDetailsToSummary(params: {
   recheckCanPublish?: () => boolean;
 }): Promise<number | undefined> {
   const { octokit, owner, repo, prNumber, reviewOutputKey, botHandles } = params;
-  let updatedReviewDetails = params.reviewDetailsBlock;
-  const marker = buildReviewOutputMarker(reviewOutputKey);
 
-  const commentsResponse = await octokit.rest.issues.listComments({
+  const canonicalSurface = await findCanonicalReviewSurface({
+    octokit,
     owner,
     repo,
-    issue_number: prNumber,
-    per_page: 100,
-    sort: "created",
-    direction: "desc",
+    prNumber,
+    reviewOutputKey,
   });
 
-  const summaryComment = commentsResponse.data.find((comment) =>
-    typeof comment.body === "string" && comment.body.includes(marker)
-  );
-
-  if (!summaryComment) {
+  if (!canonicalSurface || canonicalSurface.kind !== "issue_comment") {
     throw new Error("Summary comment not found for review output marker");
   }
 
-  let summaryBody = summaryComment.body!;
   const updatedBody = mergeReviewDetailsIntoSummaryBody({
-    summaryBody,
-    reviewDetailsBlock: updatedReviewDetails,
+    summaryBody: canonicalSurface.body,
+    reviewDetailsBlock: params.reviewDetailsBlock,
     requireDegradationDisclosure: params.requireDegradationDisclosure,
     reviewBoundedness: params.reviewBoundedness,
   });
@@ -819,13 +1019,16 @@ async function appendReviewDetailsToSummary(params: {
     return undefined;
   }
 
-  await octokit.rest.issues.updateComment({
+  const updatedSurface = await updateCanonicalReviewSurface({
+    octokit,
     owner,
     repo,
-    comment_id: summaryComment.id,
-    body: sanitizeOutgoingMentions(updatedBody, botHandles),
+    prNumber,
+    surface: canonicalSurface,
+    body: updatedBody,
+    botHandles,
   });
-  return summaryComment.id;
+  return updatedSurface.id;
 }
 
 async function resolveAuthorTier(params: {
@@ -2260,18 +2463,42 @@ export function createReviewHandler(deps: {
         });
 
         if (!idempotencyCheck.shouldPublish) {
-          logger.info(
-            {
-              ...baseLog,
-              gate: "review-output-idempotency",
-              gateResult: "skipped",
-              skipReason: "already-published",
-              reviewOutputKey,
-              existingLocation: idempotencyCheck.existingLocation,
-            },
-            "Skipping review execution because output already published for key",
-          );
-          return;
+          const canonicalSurface = await findCanonicalReviewSurface({
+            octokit: idempotencyOctokit,
+            owner: apiOwner,
+            repo: apiRepo,
+            prNumber: pr.number,
+            reviewOutputKey,
+          });
+          const canonicalSurfaceHasReviewDetails = canonicalSurface?.body.includes("<summary>Review Details</summary>") ?? false;
+
+          if (canonicalSurface && !canonicalSurfaceHasReviewDetails) {
+            logger.info(
+              {
+                ...baseLog,
+                gate: "review-output-idempotency",
+                gateResult: "accepted",
+                reason: "canonical-surface-missing-review-details",
+                reviewOutputKey,
+                existingLocation: idempotencyCheck.existingLocation,
+                canonicalSurfaceKind: canonicalSurface.kind,
+              },
+              "Review output idempotency check accepted incomplete canonical surface for Review Details finalization",
+            );
+          } else {
+            logger.info(
+              {
+                ...baseLog,
+                gate: "review-output-idempotency",
+                gateResult: "skipped",
+                skipReason: "already-published",
+                reviewOutputKey,
+                existingLocation: idempotencyCheck.existingLocation,
+              },
+              "Skipping review execution because output already published for key",
+            );
+            return;
+          }
         }
 
         logger.info(
@@ -4268,6 +4495,7 @@ export function createReviewHandler(deps: {
           (diffAnalysis?.metrics.totalLinesRemoved ?? 0);
 
         const reviewCompletedAt = new Date().toISOString();
+        let canonicalReviewDetailsBody: string | null = null;
         const buildReviewDetailsBody = (params?: {
           timeoutProgress?: TimeoutReviewDetailsProgress;
           reviewFirstPass?: ReviewFirstPassPayload | null;
@@ -4342,6 +4570,7 @@ export function createReviewHandler(deps: {
 
           try {
             const fullDetailsBody = buildReviewDetailsBody();
+            canonicalReviewDetailsBody = fullDetailsBody;
 
             if (result.published) {
               // Summary comment was posted -- append Review Details to it
@@ -4366,12 +4595,12 @@ export function createReviewHandler(deps: {
                 } catch (appendErr) {
                   // Fallback: post standalone if the initial append fails (e.g., summary comment not found yet)
                   logger.warn(
-                    { ...baseLog, gate: "review-details-output", gateResult: "append-fallback", err: appendErr },
+                    { ...baseLog, gate: "review-details-output", gateResult: "degraded-fallback", err: appendErr },
                     "Failed to append Review Details to summary comment; posting standalone",
                   );
                   if (canPublishVisibleOutput("deterministic Review Details standalone comment")) {
                     setReviewWorkPhase("publish");
-                    const reviewDetailsCommentId = await upsertReviewDetailsComment({
+                    await upsertReviewDetailsComment({
                       octokit: extractionOctokit,
                       owner: apiOwner,
                       repo: apiRepo,
@@ -4382,22 +4611,6 @@ export function createReviewHandler(deps: {
                       recheckCanPublish: () =>
                         canPublishVisibleOutput("deterministic Review Details standalone comment"),
                     });
-
-                    finalizePublicationPhaseTiming();
-                    if (
-                      reviewDetailsCommentId !== undefined &&
-                      canPublishVisibleOutput("finalized Review Details standalone comment")
-                    ) {
-                      await extractionOctokit.rest.issues.updateComment({
-                        owner: apiOwner,
-                        repo: apiRepo,
-                        comment_id: reviewDetailsCommentId,
-                        body: sanitizeOutgoingMentions(
-                          buildReviewDetailsBody(),
-                          [githubApp.getAppSlug(), "claude"],
-                        ),
-                      });
-                    }
                   }
                 }
 
@@ -4431,9 +4644,12 @@ export function createReviewHandler(deps: {
                 }
               }
             } else {
-              // No summary comment (clean review) -- post standalone Review Details
-              // FORMAT-11 exemption: no summary exists to embed into; standalone preserves metrics visibility
-              if (canPublishVisibleOutput("deterministic Review Details standalone comment")) {
+              const approvalWillOwnCanonicalSurface = config.review.autoApprove && result.conclusion === "success";
+
+              if (approvalWillOwnCanonicalSurface) {
+                // Clean approvals now own the canonical visible surface. The approval review body
+                // gets the Review Details block after the approval is created and can be edited.
+              } else if (canPublishVisibleOutput("deterministic Review Details standalone comment")) {
                 setReviewWorkPhase("publish");
                 const reviewDetailsCommentId = await upsertReviewDetailsComment({
                   octokit: extractionOctokit,
@@ -6041,20 +6257,56 @@ export function createReviewHandler(deps: {
               ? renderApprovalConfidence(depBumpContext.mergeConfidence)
               : null;
 
+            let approvalBody = buildApprovedReviewBody({
+              reviewOutputKey,
+              evidence: approvalEvidence,
+              approvalConfidence,
+            });
+
+            if (canonicalReviewDetailsBody) {
+              approvalBody = mergeReviewDetailsIntoSummaryBody({
+                summaryBody: approvalBody,
+                reviewDetailsBlock: canonicalReviewDetailsBody,
+                requireDegradationDisclosure: authorClassification.searchEnrichment.degraded,
+                reviewBoundedness,
+              });
+            }
+
             await octokit.rest.pulls.createReview({
               owner: apiOwner,
               repo: apiRepo,
               pull_number: pr.number,
               event: "APPROVE",
               body: sanitizeOutgoingMentions(
-                buildApprovedReviewBody({
-                  reviewOutputKey,
-                  evidence: approvalEvidence,
-                  approvalConfidence,
-                }),
+                approvalBody,
                 [appSlug, "claude"],
               ),
             });
+
+            if (canonicalReviewDetailsBody) {
+              finalizePublicationPhaseTiming();
+              await upsertCanonicalReviewSurface({
+                octokit,
+                owner: apiOwner,
+                repo: apiRepo,
+                prNumber: pr.number,
+                reviewOutputKey,
+                surfaceKind: "pull_review",
+                pullReviewEvent: "APPROVE",
+                body: mergeReviewDetailsIntoSummaryBody({
+                  summaryBody: buildApprovedReviewBody({
+                    reviewOutputKey,
+                    evidence: approvalEvidence,
+                    approvalConfidence,
+                  }),
+                  reviewDetailsBlock: buildReviewDetailsBody(),
+                  requireDegradationDisclosure: authorClassification.searchEnrichment.degraded,
+                  reviewBoundedness,
+                }),
+                botHandles: [appSlug, "claude"],
+                recheckCanPublish: () => canPublishVisibleOutput("finalized approval review"),
+              });
+            }
 
             logger.info(
               {

--- a/src/handlers/review.ts
+++ b/src/handlers/review.ts
@@ -1059,17 +1059,20 @@ function mergeReviewDetailsIntoSummaryBody(params: {
     );
   }
 
+  const existingReviewDetailsPattern = /\n?<details>\s*\n?<summary>Review Details<\/summary>[\s\S]*?<\/details>\n?/;
+  if (existingReviewDetailsPattern.test(summaryBody)) {
+    return summaryBody.replace(existingReviewDetailsPattern, `\n\n${updatedReviewDetails}\n\n`).trim();
+  }
+
   const closingTag = '</details>';
   const lastCloseIdx = summaryBody.lastIndexOf(closingTag);
   if (lastCloseIdx === -1) {
     return `${summaryBody}\n\n${updatedReviewDetails}`;
   }
 
-  const before = summaryBody.slice(0, lastCloseIdx);
+  const before = summaryBody.slice(0, lastCloseIdx).trimEnd();
   const after = summaryBody.slice(lastCloseIdx);
-  const existingReviewDetailsPattern = /\n?<details>\s*\n?<summary>Review Details<\/summary>[\s\S]*?<\/details>\n?/;
-  const beforeWithoutExistingDetails = before.replace(existingReviewDetailsPattern, "\n").trimEnd();
-  return `${beforeWithoutExistingDetails}\n\n${updatedReviewDetails}\n${after}`;
+  return `${before}\n\n${updatedReviewDetails}\n${after}`;
 }
 
 function resolveAuthorTier(params: {

--- a/src/handlers/review.ts
+++ b/src/handlers/review.ts
@@ -921,19 +921,22 @@ async function rebuildCanonicalReviewSurfaceWithDetails(params: {
   reviewDetailsBlock: string;
   botHandles: string[];
   summaryBody?: string;
+  canonicalSurface?: CanonicalReviewSurface;
   pullReviewEvent?: "APPROVE" | "COMMENT" | "REQUEST_CHANGES";
   requireDegradationDisclosure: boolean;
   reviewBoundedness?: ReviewBoundednessContract | null;
   recheckCanPublish?: () => boolean;
 }): Promise<CanonicalReviewSurface | undefined> {
-  const existingSurface = await findCanonicalReviewSurface({
-    octokit: params.octokit,
-    owner: params.owner,
-    repo: params.repo,
-    prNumber: params.prNumber,
-    reviewOutputKey: params.reviewOutputKey,
-    surfaceKind: params.preferredKind,
-  });
+  const existingSurface = params.canonicalSurface?.kind === params.preferredKind
+    ? params.canonicalSurface
+    : await findCanonicalReviewSurface({
+      octokit: params.octokit,
+      owner: params.owner,
+      repo: params.repo,
+      prNumber: params.prNumber,
+      reviewOutputKey: params.reviewOutputKey,
+      surfaceKind: params.preferredKind,
+    });
 
   const summaryBody = params.summaryBody ?? existingSurface?.body;
   if (!summaryBody) {
@@ -1059,7 +1062,7 @@ function mergeReviewDetailsIntoSummaryBody(params: {
     );
   }
 
-  const existingReviewDetailsPattern = /\n?<details>\s*\n?<summary>Review Details<\/summary>[\s\S]*?<\/details>\n?/;
+  const existingReviewDetailsPattern = /\n?<details>\s*\n?<summary>Review Details<\/summary>[\s\S]*?<\/details>(?:\n?\s*<!--\s*kodiai:review-details:[^>]+-->)?\n?/;
   if (existingReviewDetailsPattern.test(summaryBody)) {
     return summaryBody.replace(existingReviewDetailsPattern, `\n\n${updatedReviewDetails}\n\n`).trim();
   }
@@ -6453,6 +6456,7 @@ export function createReviewHandler(deps: {
                 reviewDetailsBlock: buildReviewDetailsBody(),
                 botHandles: [appSlug, "claude"],
                 summaryBody: canonicalApprovalReview.body,
+                canonicalSurface: canonicalApprovalReview,
                 requireDegradationDisclosure: authorClassification.searchEnrichment.degraded,
                 reviewBoundedness,
                 pullReviewEvent: "APPROVE",

--- a/src/handlers/review.ts
+++ b/src/handlers/review.ts
@@ -868,63 +868,14 @@ async function upsertCanonicalReviewSurface(params: {
   prNumber: number;
   reviewOutputKey: string;
   preferredKind: CanonicalSurfaceKind;
-  body: string;
-  botHandles: string[];
-  pullReviewEvent?: "APPROVE" | "COMMENT" | "REQUEST_CHANGES";
-  recheckCanPublish?: () => boolean;
-}): Promise<CanonicalReviewSurface | undefined> {
-  const existingSurface = await findCanonicalReviewSurface({
-    octokit: params.octokit,
-    owner: params.owner,
-    repo: params.repo,
-    prNumber: params.prNumber,
-    reviewOutputKey: params.reviewOutputKey,
-    surfaceKind: params.preferredKind,
-  });
-
-  if (params.recheckCanPublish && !params.recheckCanPublish()) {
-    return undefined;
-  }
-
-  if (existingSurface) {
-    return await updateCanonicalReviewSurface({
-      octokit: params.octokit,
-      owner: params.owner,
-      repo: params.repo,
-      prNumber: params.prNumber,
-      surface: existingSurface,
-      body: params.body,
-      botHandles: params.botHandles,
-    });
-  }
-
-  return await createCanonicalReviewSurface({
-    octokit: params.octokit,
-    owner: params.owner,
-    repo: params.repo,
-    prNumber: params.prNumber,
-    reviewOutputKey: params.reviewOutputKey,
-    surfaceKind: params.preferredKind,
-    body: params.body,
-    botHandles: params.botHandles,
-    pullReviewEvent: params.pullReviewEvent,
-  });
-}
-
-async function rebuildCanonicalReviewSurfaceWithDetails(params: {
-  octokit: Octokit;
-  owner: string;
-  repo: string;
-  prNumber: number;
-  reviewOutputKey: string;
-  preferredKind: CanonicalSurfaceKind;
-  reviewDetailsBlock: string;
-  botHandles: string[];
+  body?: string;
+  reviewDetailsBlock?: string;
   summaryBody?: string;
   canonicalSurface?: CanonicalReviewSurface;
-  pullReviewEvent?: "APPROVE" | "COMMENT" | "REQUEST_CHANGES";
-  requireDegradationDisclosure: boolean;
+  requireDegradationDisclosure?: boolean;
   reviewBoundedness?: ReviewBoundednessContract | null;
+  botHandles: string[];
+  pullReviewEvent?: "APPROVE" | "COMMENT" | "REQUEST_CHANGES";
   recheckCanPublish?: () => boolean;
 }): Promise<CanonicalReviewSurface | undefined> {
   const existingSurface = params.canonicalSurface?.kind === params.preferredKind
@@ -938,17 +889,25 @@ async function rebuildCanonicalReviewSurfaceWithDetails(params: {
       surfaceKind: params.preferredKind,
     });
 
-  const summaryBody = params.summaryBody ?? existingSurface?.body;
-  if (!summaryBody) {
-    throw new Error(`Canonical ${params.preferredKind} surface not found for review output marker`);
-  }
+  const body = params.reviewDetailsBlock
+    ? (() => {
+      const summaryBody = params.summaryBody ?? existingSurface?.body;
+      if (!summaryBody) {
+        throw new Error(`Canonical ${params.preferredKind} surface not found for review output marker`);
+      }
 
-  const rebuiltBody = mergeReviewDetailsIntoSummaryBody({
-    summaryBody,
-    reviewDetailsBlock: params.reviewDetailsBlock,
-    requireDegradationDisclosure: params.requireDegradationDisclosure,
-    reviewBoundedness: params.reviewBoundedness,
-  });
+      return mergeReviewDetailsIntoSummaryBody({
+        summaryBody,
+        reviewDetailsBlock: params.reviewDetailsBlock,
+        requireDegradationDisclosure: params.requireDegradationDisclosure ?? false,
+        reviewBoundedness: params.reviewBoundedness,
+      });
+    })()
+    : params.body;
+
+  if (!body) {
+    throw new Error("Canonical review surface upsert requires body content");
+  }
 
   if (params.recheckCanPublish && !params.recheckCanPublish()) {
     return undefined;
@@ -961,26 +920,25 @@ async function rebuildCanonicalReviewSurfaceWithDetails(params: {
       repo: params.repo,
       prNumber: params.prNumber,
       surface: existingSurface,
-      body: rebuiltBody,
+      body,
       botHandles: params.botHandles,
     });
   }
 
-  return await upsertCanonicalReviewSurface({
+  return await createCanonicalReviewSurface({
     octokit: params.octokit,
     owner: params.owner,
     repo: params.repo,
     prNumber: params.prNumber,
     reviewOutputKey: params.reviewOutputKey,
-    preferredKind: params.preferredKind,
-    body: rebuiltBody,
+    surfaceKind: params.preferredKind,
+    body,
     botHandles: params.botHandles,
     pullReviewEvent: params.pullReviewEvent,
-    recheckCanPublish: params.recheckCanPublish,
   });
 }
 
-async function upsertReviewDetailsComment(params: {
+async function upsertDegradedReviewDetailsFallbackComment(params: {
   octokit: Awaited<ReturnType<GitHubApp["getInstallationOctokit"]>>;
   owner: string;
   repo: string;
@@ -4620,7 +4578,7 @@ export function createReviewHandler(deps: {
               deltaStillOpen: deltaClassification?.counts.stillOpen ?? null,
               provenanceCount: retrievalCtx?.findings.length ?? null,
             },
-            "Attempting deterministic Review Details publication",
+            "Attempting canonical Review Details publication",
           );
 
           try {
@@ -4628,11 +4586,11 @@ export function createReviewHandler(deps: {
             canonicalReviewDetailsBody = fullDetailsBody;
 
             if (result.published) {
-              if (canPublishVisibleOutput("deterministic Review Details append")) {
+              if (canPublishVisibleOutput("canonical Review Details merge")) {
                 let canonicalIssueComment: CanonicalReviewSurface | undefined;
                 try {
                   setReviewWorkPhase("publish");
-                  canonicalIssueComment = await rebuildCanonicalReviewSurfaceWithDetails({
+                  canonicalIssueComment = await upsertCanonicalReviewSurface({
                     octokit: extractionOctokit,
                     owner: apiOwner,
                     repo: apiRepo,
@@ -4644,16 +4602,16 @@ export function createReviewHandler(deps: {
                     requireDegradationDisclosure: authorClassification.searchEnrichment.degraded,
                     reviewBoundedness,
                     recheckCanPublish: () =>
-                      canPublishVisibleOutput("deterministic Review Details append"),
+                      canPublishVisibleOutput("canonical Review Details merge"),
                   });
                 } catch (appendErr) {
                   logger.warn(
                     { ...baseLog, gate: "review-details-output", gateResult: "degraded-fallback", err: appendErr },
-                    "Failed to rebuild canonical issue comment with Review Details; posting standalone",
+                    "Failed to update canonical review surface with Review Details; using degraded fallback comment",
                   );
-                  if (canPublishVisibleOutput("deterministic Review Details standalone comment")) {
+                  if (canPublishVisibleOutput("degraded Review Details fallback comment")) {
                     setReviewWorkPhase("publish");
-                    await upsertReviewDetailsComment({
+                    await upsertDegradedReviewDetailsFallbackComment({
                       octokit: extractionOctokit,
                       owner: apiOwner,
                       repo: apiRepo,
@@ -4662,7 +4620,7 @@ export function createReviewHandler(deps: {
                       body: fullDetailsBody,
                       botHandles: [githubApp.getAppSlug(), "claude"],
                       recheckCanPublish: () =>
-                        canPublishVisibleOutput("deterministic Review Details standalone comment"),
+                        canPublishVisibleOutput("degraded Review Details fallback comment"),
                     });
                   }
                 }
@@ -4670,7 +4628,7 @@ export function createReviewHandler(deps: {
                 if (canonicalIssueComment?.kind === "issue_comment") {
                   finalizePublicationPhaseTiming();
                   try {
-                    await rebuildCanonicalReviewSurfaceWithDetails({
+                    await upsertCanonicalReviewSurface({
                       octokit: extractionOctokit,
                       owner: apiOwner,
                       repo: apiRepo,
@@ -4683,7 +4641,7 @@ export function createReviewHandler(deps: {
                       requireDegradationDisclosure: authorClassification.searchEnrichment.degraded,
                       reviewBoundedness,
                       recheckCanPublish: () =>
-                        canPublishVisibleOutput("finalized Review Details append"),
+                        canPublishVisibleOutput("finalized canonical Review Details merge"),
                     });
                   } catch (appendErr) {
                     logger.warn(
@@ -4701,9 +4659,9 @@ export function createReviewHandler(deps: {
             } else {
               const approvalWillOwnCanonicalSurface = config.review.autoApprove && result.conclusion === "success";
 
-              if (!approvalWillOwnCanonicalSurface && canPublishVisibleOutput("deterministic Review Details standalone comment")) {
+              if (!approvalWillOwnCanonicalSurface && canPublishVisibleOutput("degraded Review Details fallback comment")) {
                 setReviewWorkPhase("publish");
-                const reviewDetailsCommentId = await upsertReviewDetailsComment({
+                const reviewDetailsCommentId = await upsertDegradedReviewDetailsFallbackComment({
                   octokit: extractionOctokit,
                   owner: apiOwner,
                   repo: apiRepo,
@@ -4712,7 +4670,7 @@ export function createReviewHandler(deps: {
                   body: fullDetailsBody,
                   botHandles: [githubApp.getAppSlug(), "claude"],
                   recheckCanPublish: () =>
-                    canPublishVisibleOutput("deterministic Review Details standalone comment"),
+                    canPublishVisibleOutput("degraded Review Details fallback comment"),
                 });
 
                 finalizePublicationPhaseTiming();
@@ -4741,7 +4699,7 @@ export function createReviewHandler(deps: {
                 reviewOutputKey,
                 err,
               },
-              "Failed to publish deterministic Review Details summary",
+              "Failed to publish canonical-or-degraded Review Details output",
             );
           }
         }
@@ -5353,8 +5311,8 @@ export function createReviewHandler(deps: {
               );
 
               try {
-                if (canPublishVisibleOutput("timeout Review Details comment")) {
-                  await rebuildCanonicalReviewSurfaceWithDetails({
+                if (canPublishVisibleOutput("timeout canonical Review Details merge")) {
+                  await upsertCanonicalReviewSurface({
                     octokit,
                     owner: apiOwner,
                     repo: apiRepo,
@@ -5376,7 +5334,7 @@ export function createReviewHandler(deps: {
                     botHandles: [githubApp.getAppSlug(), "claude"],
                     requireDegradationDisclosure: authorClassification.searchEnrichment.degraded,
                     reviewBoundedness,
-                    recheckCanPublish: () => canPublishVisibleOutput("timeout Review Details comment"),
+                    recheckCanPublish: () => canPublishVisibleOutput("timeout canonical Review Details merge"),
                   });
                 }
               } catch (reviewDetailsErr) {
@@ -5388,12 +5346,12 @@ export function createReviewHandler(deps: {
                     reviewOutputKey,
                     err: reviewDetailsErr,
                   },
-                  "Failed to rebuild timeout canonical issue comment with Review Details; posting standalone",
+                  "Failed to update timeout canonical review surface with Review Details; using degraded fallback comment",
                 );
 
-                if (canPublishVisibleOutput("timeout Review Details standalone comment")) {
+                if (canPublishVisibleOutput("timeout degraded Review Details fallback comment")) {
                   try {
-                    await upsertReviewDetailsComment({
+                    await upsertDegradedReviewDetailsFallbackComment({
                       octokit,
                       owner: apiOwner,
                       repo: apiRepo,
@@ -5412,7 +5370,7 @@ export function createReviewHandler(deps: {
                       }),
                       botHandles: [githubApp.getAppSlug(), "claude"],
                       recheckCanPublish: () =>
-                        canPublishVisibleOutput("timeout Review Details standalone comment"),
+                        canPublishVisibleOutput("timeout degraded Review Details fallback comment"),
                     });
                   } catch (fallbackErr) {
                     logger.warn(
@@ -5423,7 +5381,7 @@ export function createReviewHandler(deps: {
                         reviewOutputKey,
                         err: fallbackErr,
                       },
-                      "Failed to publish standalone Review Details for timeout partial output",
+                      "Failed to publish degraded Review Details fallback comment for timeout partial output",
                     );
                   }
                 }
@@ -5934,7 +5892,7 @@ export function createReviewHandler(deps: {
                           let retryMergeLogMessage = "Retry complete -- updated partial review comment with merged results";
 
                           try {
-                            const mergedBodyWithDetails = await rebuildCanonicalReviewSurfaceWithDetails({
+                            const mergedBodyWithDetails = await upsertCanonicalReviewSurface({
                               octokit: retryOctokit,
                               owner: apiOwner,
                               repo: apiRepo,
@@ -5951,7 +5909,7 @@ export function createReviewHandler(deps: {
                               recheckCanPublish: () =>
                                 canPublishReviewWorkOutput(
                                   retryReviewWorkAttempt.attemptId,
-                                  "retry Review Details merge",
+                                  "retry canonical Review Details merge",
                                   retryDeliveryId,
                                 ),
                             });
@@ -5975,21 +5933,21 @@ export function createReviewHandler(deps: {
                                 reviewOutputKey,
                                 err: reviewDetailsErr,
                               },
-                              "Failed to rebuild retry canonical issue comment with Review Details; posting standalone",
+                              "Failed to update retry canonical review surface with Review Details; using degraded fallback comment",
                             );
 
                             retryMergeProjectionStatus = "degraded";
-                            retryMergeLogMessage = "Retry complete -- updated partial review comment with merged results; Review Details published via standalone fallback";
+                            retryMergeLogMessage = "Retry complete -- updated partial review comment with merged results; Review Details published via degraded fallback comment";
 
                             if (
                               canPublishReviewWorkOutput(
                                 retryReviewWorkAttempt.attemptId,
-                                "retry Review Details standalone comment",
+                                "retry degraded Review Details fallback comment",
                                 retryDeliveryId,
                               )
                             ) {
                               try {
-                                await upsertReviewDetailsComment({
+                                await upsertDegradedReviewDetailsFallbackComment({
                                   octokit: retryOctokit,
                                   owner: apiOwner,
                                   repo: apiRepo,
@@ -6002,7 +5960,7 @@ export function createReviewHandler(deps: {
                                   recheckCanPublish: () =>
                                     canPublishReviewWorkOutput(
                                       retryReviewWorkAttempt.attemptId,
-                                      "retry Review Details standalone comment",
+                                      "retry degraded Review Details fallback comment",
                                       retryDeliveryId,
                                     ),
                                 });
@@ -6015,7 +5973,7 @@ export function createReviewHandler(deps: {
                                     reviewOutputKey,
                                     err: fallbackErr,
                                   },
-                                  "Failed to publish standalone Review Details after retry merge",
+                                  "Failed to publish degraded Review Details fallback comment after retry merge",
                                 );
                               }
                             }
@@ -6300,7 +6258,7 @@ export function createReviewHandler(deps: {
 
             if (exhaustedTurnBudget && failureFirstPass?.state === "bounded-first-pass") {
               try {
-                await rebuildCanonicalReviewSurfaceWithDetails({
+                await upsertCanonicalReviewSurface({
                   octokit,
                   owner: apiOwner,
                   repo: apiRepo,
@@ -6314,7 +6272,7 @@ export function createReviewHandler(deps: {
                   botHandles: [githubApp.getAppSlug(), "claude"],
                   requireDegradationDisclosure: authorClassification.searchEnrichment.degraded,
                   reviewBoundedness,
-                  recheckCanPublish: () => canPublishVisibleOutput("max-turns Review Details comment"),
+                  recheckCanPublish: () => canPublishVisibleOutput("max-turns canonical Review Details merge"),
                 });
               } catch (reviewDetailsErr) {
                 logger.warn(
@@ -6325,12 +6283,12 @@ export function createReviewHandler(deps: {
                     reviewOutputKey,
                     err: reviewDetailsErr,
                   },
-                  "Failed to rebuild max-turns canonical issue comment with Review Details; posting standalone",
+                  "Failed to update max-turns canonical review surface with Review Details; using degraded fallback comment",
                 );
 
-                if (canPublishVisibleOutput("max-turns Review Details standalone comment")) {
+                if (canPublishVisibleOutput("max-turns degraded Review Details fallback comment")) {
                   try {
-                    await upsertReviewDetailsComment({
+                    await upsertDegradedReviewDetailsFallbackComment({
                       octokit,
                       owner: apiOwner,
                       repo: apiRepo,
@@ -6341,7 +6299,7 @@ export function createReviewHandler(deps: {
                       }),
                       botHandles: [githubApp.getAppSlug(), "claude"],
                       recheckCanPublish: () =>
-                        canPublishVisibleOutput("max-turns Review Details standalone comment"),
+                        canPublishVisibleOutput("max-turns degraded Review Details fallback comment"),
                     });
                   } catch (fallbackErr) {
                     logger.warn(
@@ -6352,7 +6310,7 @@ export function createReviewHandler(deps: {
                         reviewOutputKey,
                         err: fallbackErr,
                       },
-                      "Failed to publish standalone Review Details for max-turns fallback",
+                      "Failed to publish degraded Review Details fallback comment for max-turns fallback",
                     );
                   }
                 }
@@ -6444,9 +6402,9 @@ export function createReviewHandler(deps: {
             if (
               canonicalApprovalReview?.kind === "pull_review"
               && canonicalReviewDetailsBody
-              && canPublishVisibleOutput("finalized approval Review Details append")
+              && canPublishVisibleOutput("finalized approval canonical Review Details merge")
             ) {
-              await rebuildCanonicalReviewSurfaceWithDetails({
+              await upsertCanonicalReviewSurface({
                 octokit,
                 owner: apiOwner,
                 repo: apiRepo,
@@ -6461,7 +6419,7 @@ export function createReviewHandler(deps: {
                 reviewBoundedness,
                 pullReviewEvent: "APPROVE",
                 recheckCanPublish: () =>
-                  canPublishVisibleOutput("finalized approval Review Details append"),
+                  canPublishVisibleOutput("finalized approval canonical Review Details merge"),
               });
             }
 

--- a/src/handlers/review.ts
+++ b/src/handlers/review.ts
@@ -4648,10 +4648,10 @@ export function createReviewHandler(deps: {
                       {
                         ...baseLog,
                         gate: "review-details-output",
-                        gateResult: "finalized-append-failed",
+                        gateResult: "finalized-canonical-merge-failed",
                         err: appendErr,
                       },
-                      "Failed to refresh finalized Review Details timing in canonical issue comment",
+                      "Failed to refresh finalized canonical Review Details surface",
                     );
                   }
                 }

--- a/src/handlers/review.ts
+++ b/src/handlers/review.ts
@@ -690,36 +690,39 @@ function getCanonicalReviewSurfaceId(surface: CanonicalReviewSurface): number {
   return surface.kind === "issue_comment" ? surface.commentId : surface.reviewId;
 }
 
-async function findCanonicalReviewSurface(params: {
+export async function findCanonicalReviewSurface(params: {
   octokit: Octokit;
   owner: string;
   repo: string;
   prNumber: number;
   reviewOutputKey: string;
+  surfaceKind: CanonicalSurfaceKind;
 }): Promise<CanonicalReviewSurface | null> {
   const marker = buildReviewOutputMarker(params.reviewOutputKey);
 
-  const commentsResponse = await params.octokit.rest.issues.listComments({
-    owner: params.owner,
-    repo: params.repo,
-    issue_number: params.prNumber,
-    per_page: 100,
-    sort: "created",
-    direction: "desc",
-  });
+  if (params.surfaceKind === "issue_comment") {
+    const commentsResponse = await params.octokit.rest.issues.listComments({
+      owner: params.owner,
+      repo: params.repo,
+      issue_number: params.prNumber,
+      per_page: 100,
+      sort: "created",
+      direction: "desc",
+    });
 
-  const issueComment = commentsResponse.data.find((comment) =>
-    typeof comment.id === "number"
-    && typeof comment.body === "string"
-    && comment.body.includes(marker)
-  );
+    const issueComment = commentsResponse.data.find((comment) =>
+      typeof comment.id === "number"
+      && typeof comment.body === "string"
+      && comment.body.includes(marker)
+    );
 
-  if (issueComment) {
-    return {
-      kind: "issue_comment",
-      commentId: issueComment.id,
-      body: issueComment.body,
-    };
+    return issueComment
+      ? {
+        kind: "issue_comment",
+        commentId: issueComment.id,
+        body: issueComment.body,
+      }
+      : null;
   }
 
   const reviewsResponse = await params.octokit.rest.pulls.listReviews({
@@ -735,15 +738,13 @@ async function findCanonicalReviewSurface(params: {
     && review.body.includes(marker)
   );
 
-  if (!pullReview) {
-    return null;
-  }
-
-  return {
-    kind: "pull_review",
-    reviewId: pullReview.id,
-    body: pullReview.body,
-  };
+  return pullReview
+    ? {
+      kind: "pull_review",
+      reviewId: pullReview.id,
+      body: pullReview.body,
+    }
+    : null;
 }
 
 async function updateCanonicalReviewSurface(params: {
@@ -840,6 +841,7 @@ async function createCanonicalReviewSurface(params: {
     repo: params.repo,
     prNumber: params.prNumber,
     reviewOutputKey: params.reviewOutputKey,
+    surfaceKind: "pull_review",
   });
 
   if (createdSurface?.kind === "pull_review") {
@@ -849,7 +851,7 @@ async function createCanonicalReviewSurface(params: {
   throw new Error("Created canonical pull review could not be reloaded");
 }
 
-async function upsertCanonicalReviewSurface(params: {
+export async function upsertCanonicalReviewSurface(params: {
   octokit: Octokit;
   owner: string;
   repo: string;
@@ -867,6 +869,7 @@ async function upsertCanonicalReviewSurface(params: {
     repo: params.repo,
     prNumber: params.prNumber,
     reviewOutputKey: params.reviewOutputKey,
+    surfaceKind: params.surfaceKind,
   });
 
   if (params.recheckCanPublish && !params.recheckCanPublish()) {
@@ -1013,6 +1016,7 @@ async function appendReviewDetailsToSummary(params: {
     repo,
     prNumber,
     reviewOutputKey,
+    surfaceKind: "issue_comment",
   });
 
   if (!canonicalSurface || canonicalSurface.kind !== "issue_comment") {
@@ -2474,13 +2478,21 @@ export function createReviewHandler(deps: {
         });
 
         if (!idempotencyCheck.shouldPublish) {
-          const canonicalSurface = await findCanonicalReviewSurface({
-            octokit: idempotencyOctokit,
-            owner: apiOwner,
-            repo: apiRepo,
-            prNumber: pr.number,
-            reviewOutputKey,
-          });
+          const canonicalSurfaceKind = idempotencyCheck.existingLocation === "review"
+            ? "pull_review"
+            : idempotencyCheck.existingLocation === "issue-comment"
+              ? "issue_comment"
+              : null;
+          const canonicalSurface = canonicalSurfaceKind
+            ? await findCanonicalReviewSurface({
+              octokit: idempotencyOctokit,
+              owner: apiOwner,
+              repo: apiRepo,
+              prNumber: pr.number,
+              reviewOutputKey,
+              surfaceKind: canonicalSurfaceKind,
+            })
+            : null;
           const canonicalSurfaceHasReviewDetails = canonicalSurface?.body.includes("<summary>Review Details</summary>") ?? false;
 
           if (canonicalSurface && !canonicalSurfaceHasReviewDetails) {

--- a/src/handlers/review.ts
+++ b/src/handlers/review.ts
@@ -680,11 +680,11 @@ async function fetchCommitMessages(
 
 
 
-export type CanonicalReviewSurface =
+type CanonicalReviewSurface =
   | { kind: "issue_comment"; commentId: number; body: string }
   | { kind: "pull_review"; reviewId: number; body: string };
 
-export type CanonicalSurfaceKind = CanonicalReviewSurface["kind"];
+type CanonicalSurfaceKind = CanonicalReviewSurface["kind"];
 
 function getCanonicalReviewSurfaceId(surface: CanonicalReviewSurface): number {
   return surface.kind === "issue_comment" ? surface.commentId : surface.reviewId;

--- a/src/handlers/review.ts
+++ b/src/handlers/review.ts
@@ -4695,10 +4695,7 @@ export function createReviewHandler(deps: {
             } else {
               const approvalWillOwnCanonicalSurface = config.review.autoApprove && result.conclusion === "success";
 
-              if (approvalWillOwnCanonicalSurface) {
-                // Clean approvals now own the canonical visible surface. The approval review body
-                // gets the Review Details block after the approval is created and can be edited.
-              } else if (canPublishVisibleOutput("deterministic Review Details standalone comment")) {
+              if (!approvalWillOwnCanonicalSurface && canPublishVisibleOutput("deterministic Review Details standalone comment")) {
                 setReviewWorkPhase("publish");
                 const reviewDetailsCommentId = await upsertReviewDetailsComment({
                   octokit: extractionOctokit,
@@ -5381,12 +5378,49 @@ export function createReviewHandler(deps: {
                   {
                     ...baseLog,
                     gate: "review-details-output",
-                    gateResult: "timeout-failed",
+                    gateResult: "degraded-fallback",
                     reviewOutputKey,
                     err: reviewDetailsErr,
                   },
-                  "Failed to publish Review Details for timeout partial output",
+                  "Failed to rebuild timeout canonical issue comment with Review Details; posting standalone",
                 );
+
+                if (canPublishVisibleOutput("timeout Review Details standalone comment")) {
+                  try {
+                    await upsertReviewDetailsComment({
+                      octokit,
+                      owner: apiOwner,
+                      repo: apiRepo,
+                      prNumber: pr.number,
+                      reviewOutputKey,
+                      body: buildReviewDetailsBody({
+                        timeoutProgress: timeoutReviewDetails,
+                        reviewFirstPass: timeoutFirstPass,
+                        timeoutBudget: appliedTimeoutBudget
+                          ? {
+                              remoteRuntimeBudgetSeconds: appliedTimeoutBudget.remoteRuntimeBudgetSeconds,
+                              infraOverheadBudgetSeconds: appliedTimeoutBudget.infraOverheadBudgetSeconds,
+                              totalTimeoutSeconds: appliedTimeoutBudget.totalTimeoutSeconds,
+                            }
+                          : null,
+                      }),
+                      botHandles: [githubApp.getAppSlug(), "claude"],
+                      recheckCanPublish: () =>
+                        canPublishVisibleOutput("timeout Review Details standalone comment"),
+                    });
+                  } catch (fallbackErr) {
+                    logger.warn(
+                      {
+                        ...baseLog,
+                        gate: "review-details-output",
+                        gateResult: "failed",
+                        reviewOutputKey,
+                        err: fallbackErr,
+                      },
+                      "Failed to publish standalone Review Details for timeout partial output",
+                    );
+                  }
+                }
               }
 
               // Structured resilience telemetry (best-effort)
@@ -5928,12 +5962,51 @@ export function createReviewHandler(deps: {
                               {
                                 ...baseLog,
                                 gate: "review-details-output",
-                                gateResult: "retry-merge-failed",
+                                gateResult: "degraded-fallback",
                                 reviewOutputKey,
                                 err: reviewDetailsErr,
                               },
-                              "Failed to refresh Review Details after retry merge",
+                              "Failed to rebuild retry canonical issue comment with Review Details; posting standalone",
                             );
+
+                            if (
+                              canPublishReviewWorkOutput(
+                                retryReviewWorkAttempt.attemptId,
+                                "retry Review Details standalone comment",
+                                retryDeliveryId,
+                              )
+                            ) {
+                              try {
+                                await upsertReviewDetailsComment({
+                                  octokit: retryOctokit,
+                                  owner: apiOwner,
+                                  repo: apiRepo,
+                                  prNumber: pr.number,
+                                  reviewOutputKey,
+                                  body: buildReviewDetailsBody({
+                                    reviewFirstPass: mergedFirstPass,
+                                  }),
+                                  botHandles: [githubApp.getAppSlug(), "claude"],
+                                  recheckCanPublish: () =>
+                                    canPublishReviewWorkOutput(
+                                      retryReviewWorkAttempt.attemptId,
+                                      "retry Review Details standalone comment",
+                                      retryDeliveryId,
+                                    ),
+                                });
+                              } catch (fallbackErr) {
+                                logger.warn(
+                                  {
+                                    ...baseLog,
+                                    gate: "review-details-output",
+                                    gateResult: "failed",
+                                    reviewOutputKey,
+                                    err: fallbackErr,
+                                  },
+                                  "Failed to publish standalone Review Details after retry merge",
+                                );
+                              }
+                            }
                           }
 
                           logger.info(
@@ -6235,12 +6308,41 @@ export function createReviewHandler(deps: {
                   {
                     ...baseLog,
                     gate: "review-details-output",
-                    gateResult: "failure-fallback-failed",
+                    gateResult: "degraded-fallback",
                     reviewOutputKey,
                     err: reviewDetailsErr,
                   },
-                  "Failed to merge Review Details into max-turns bounded fallback comment",
+                  "Failed to rebuild max-turns canonical issue comment with Review Details; posting standalone",
                 );
+
+                if (canPublishVisibleOutput("max-turns Review Details standalone comment")) {
+                  try {
+                    await upsertReviewDetailsComment({
+                      octokit,
+                      owner: apiOwner,
+                      repo: apiRepo,
+                      prNumber: pr.number,
+                      reviewOutputKey,
+                      body: buildReviewDetailsBody({
+                        reviewFirstPass: failureFirstPass,
+                      }),
+                      botHandles: [githubApp.getAppSlug(), "claude"],
+                      recheckCanPublish: () =>
+                        canPublishVisibleOutput("max-turns Review Details standalone comment"),
+                    });
+                  } catch (fallbackErr) {
+                    logger.warn(
+                      {
+                        ...baseLog,
+                        gate: "review-details-output",
+                        gateResult: "failed",
+                        reviewOutputKey,
+                        err: fallbackErr,
+                      },
+                      "Failed to publish standalone Review Details for max-turns fallback",
+                    );
+                  }
+                }
               }
             }
           }
@@ -6304,20 +6406,11 @@ export function createReviewHandler(deps: {
               ? renderApprovalConfidence(depBumpContext.mergeConfidence)
               : null;
 
-            let approvalBody = buildApprovedReviewBody({
+            const approvalBody = buildApprovedReviewBody({
               reviewOutputKey,
               evidence: approvalEvidence,
               approvalConfidence,
             });
-
-            if (canonicalReviewDetailsBody) {
-              approvalBody = mergeReviewDetailsIntoSummaryBody({
-                summaryBody: approvalBody,
-                reviewDetailsBlock: canonicalReviewDetailsBody,
-                requireDegradationDisclosure: authorClassification.searchEnrichment.degraded,
-                reviewBoundedness,
-              });
-            }
 
             await octokit.rest.pulls.createReview({
               owner: apiOwner,
@@ -6330,29 +6423,35 @@ export function createReviewHandler(deps: {
               ),
             });
 
-            if (canonicalReviewDetailsBody) {
-              finalizePublicationPhaseTiming();
-              await upsertCanonicalReviewSurface({
+            if (canonicalReviewDetailsBody && canPublishVisibleOutput("approval Review Details standalone comment")) {
+              setReviewWorkPhase("publish");
+              const reviewDetailsCommentId = await upsertReviewDetailsComment({
                 octokit,
                 owner: apiOwner,
                 repo: apiRepo,
                 prNumber: pr.number,
                 reviewOutputKey,
-                preferredKind: "pull_review",
-                pullReviewEvent: "APPROVE",
-                body: mergeReviewDetailsIntoSummaryBody({
-                  summaryBody: buildApprovedReviewBody({
-                    reviewOutputKey,
-                    evidence: approvalEvidence,
-                    approvalConfidence,
-                  }),
-                  reviewDetailsBlock: buildReviewDetailsBody(),
-                  requireDegradationDisclosure: authorClassification.searchEnrichment.degraded,
-                  reviewBoundedness,
-                }),
+                body: canonicalReviewDetailsBody,
                 botHandles: [appSlug, "claude"],
-                recheckCanPublish: () => canPublishVisibleOutput("finalized approval review"),
+                recheckCanPublish: () =>
+                  canPublishVisibleOutput("approval Review Details standalone comment"),
               });
+
+              finalizePublicationPhaseTiming();
+              if (
+                reviewDetailsCommentId !== undefined &&
+                canPublishVisibleOutput("finalized approval Review Details standalone comment")
+              ) {
+                await octokit.rest.issues.updateComment({
+                  owner: apiOwner,
+                  repo: apiRepo,
+                  comment_id: reviewDetailsCommentId,
+                  body: sanitizeOutgoingMentions(
+                    buildReviewDetailsBody(),
+                    [appSlug, "claude"],
+                  ),
+                });
+              }
             }
 
             logger.info(

--- a/src/handlers/review.ts
+++ b/src/handlers/review.ts
@@ -2459,6 +2459,7 @@ export function createReviewHandler(deps: {
         }
 
         const idempotencyOctokit = await githubApp.getInstallationOctokit(event.installationId);
+        let acceptedCanonicalSurface: CanonicalReviewSurface | null = null;
         const idempotencyCheck = await ensureReviewOutputNotPublished({
           octokit: idempotencyOctokit,
           owner: apiOwner,
@@ -2486,6 +2487,7 @@ export function createReviewHandler(deps: {
           const canonicalSurfaceHasReviewDetails = canonicalSurface?.body.includes("<summary>Review Details</summary>") ?? false;
 
           if (canonicalSurface && !canonicalSurfaceHasReviewDetails) {
+            acceptedCanonicalSurface = canonicalSurface;
             logger.info(
               {
                 ...baseLog,
@@ -4597,6 +4599,9 @@ export function createReviewHandler(deps: {
                     prNumber: pr.number,
                     reviewOutputKey,
                     preferredKind: "issue_comment",
+                    canonicalSurface: acceptedCanonicalSurface?.kind === "issue_comment"
+                      ? acceptedCanonicalSurface
+                      : undefined,
                     reviewDetailsBlock: fullDetailsBody,
                     botHandles: [githubApp.getAppSlug(), "claude"],
                     requireDegradationDisclosure: authorClassification.searchEnrichment.degraded,
@@ -4635,6 +4640,7 @@ export function createReviewHandler(deps: {
                       prNumber: pr.number,
                       reviewOutputKey,
                       preferredKind: "issue_comment",
+                      canonicalSurface: canonicalIssueComment,
                       reviewDetailsBlock: buildReviewDetailsBody(),
                       botHandles: [githubApp.getAppSlug(), "claude"],
                       summaryBody: canonicalIssueComment.body,
@@ -5319,6 +5325,9 @@ export function createReviewHandler(deps: {
                     prNumber: pr.number,
                     reviewOutputKey,
                     preferredKind: "issue_comment",
+                    canonicalSurface: partialCommentId
+                      ? { kind: "issue_comment", commentId: partialCommentId, body: partialBody }
+                      : undefined,
                     summaryBody: partialBody,
                     reviewDetailsBlock: buildReviewDetailsBody({
                       timeoutProgress: timeoutReviewDetails,

--- a/src/handlers/review.ts
+++ b/src/handlers/review.ts
@@ -6417,48 +6417,45 @@ export function createReviewHandler(deps: {
               reviewOutputKey,
               evidence: approvalEvidence,
               approvalConfidence,
+              reviewDetailsBlock: canonicalReviewDetailsBody,
             });
 
-            await octokit.rest.pulls.createReview({
+            const canonicalApprovalReview = await upsertCanonicalReviewSurface({
+              octokit,
               owner: apiOwner,
               repo: apiRepo,
-              pull_number: pr.number,
-              event: "APPROVE",
-              body: sanitizeOutgoingMentions(
-                approvalBody,
-                [appSlug, "claude"],
-              ),
+              prNumber: pr.number,
+              reviewOutputKey,
+              preferredKind: "pull_review",
+              body: approvalBody,
+              botHandles: [appSlug, "claude"],
+              pullReviewEvent: "APPROVE",
+              recheckCanPublish: () => canPublishVisibleOutput("auto-approval"),
             });
 
-            if (canonicalReviewDetailsBody && canPublishVisibleOutput("approval Review Details standalone comment")) {
-              setReviewWorkPhase("publish");
-              const reviewDetailsCommentId = await upsertReviewDetailsComment({
+            finalizePublicationPhaseTiming();
+
+            if (
+              canonicalApprovalReview?.kind === "pull_review"
+              && canonicalReviewDetailsBody
+              && canPublishVisibleOutput("finalized approval Review Details append")
+            ) {
+              await rebuildCanonicalReviewSurfaceWithDetails({
                 octokit,
                 owner: apiOwner,
                 repo: apiRepo,
                 prNumber: pr.number,
                 reviewOutputKey,
-                body: canonicalReviewDetailsBody,
+                preferredKind: "pull_review",
+                reviewDetailsBlock: buildReviewDetailsBody(),
                 botHandles: [appSlug, "claude"],
+                summaryBody: canonicalApprovalReview.body,
+                requireDegradationDisclosure: authorClassification.searchEnrichment.degraded,
+                reviewBoundedness,
+                pullReviewEvent: "APPROVE",
                 recheckCanPublish: () =>
-                  canPublishVisibleOutput("approval Review Details standalone comment"),
+                  canPublishVisibleOutput("finalized approval Review Details append"),
               });
-
-              finalizePublicationPhaseTiming();
-              if (
-                reviewDetailsCommentId !== undefined &&
-                canPublishVisibleOutput("finalized approval Review Details standalone comment")
-              ) {
-                await octokit.rest.issues.updateComment({
-                  owner: apiOwner,
-                  repo: apiRepo,
-                  comment_id: reviewDetailsCommentId,
-                  body: sanitizeOutgoingMentions(
-                    buildReviewDetailsBody(),
-                    [appSlug, "claude"],
-                  ),
-                });
-              }
             }
 
             logger.info(


### PR DESCRIPTION
## Summary
- unify Review Details publication onto one canonical visible surface per review cycle
- use the canonical issue comment for findings/timeout/max-turns/retry flows
- use the canonical approval review body for clean approval flows
- keep standalone Review Details only as explicit degraded fallback
- tighten idempotency and mixed-surface regression coverage so canonical surface selection stays truthful

## What changed
- added internal canonical review surface helpers in `src/handlers/review.ts`
- migrated issue-comment-backed Review Details refreshes onto canonical issue-comment rebuild/upsert
- migrated clean approvals so inline Review Details live in the approval review body
- fixed approval refresh to target the exact canonical review id and keep a single Review Details block/marker
- quarantined legacy standalone helper behavior behind degraded fallback only
- renamed remaining append-era terminology to canonical/degraded language

## Verification
- `bun test ./src/handlers/review.test.ts`
- `bun test ./src/handlers/review-idempotency.test.ts`
- `bun test --max-concurrency=2 src/handlers src/lib`
  - result: `1156 pass, 0 fail`

## Issue
- closes #102
