### PR TITLE
Clarify bounded review exhaustiveness

### DIFF
--- a/scripts/backfill-issues.ts
+++ b/scripts/backfill-issues.ts
@@ -140,6 +140,7 @@ async function main() {
       port: 0,
       logLevel: "info",
       botAllowList: [],
+      slackWebhookRelaySources: [],
       slackWikiChannelId: "",
       wikiStalenessThresholdDays: 30,
       wikiGithubOwner: "",

--- a/scripts/backfill-review-comments.ts
+++ b/scripts/backfill-review-comments.ts
@@ -151,6 +151,7 @@ async function main() {
       port: 0,
       logLevel: "info",
       botAllowList: [],
+      slackWebhookRelaySources: [],
       slackWikiChannelId: "",
       wikiStalenessThresholdDays: 30,
       wikiGithubOwner: "",

--- a/scripts/cleanup-wiki-issue.ts
+++ b/scripts/cleanup-wiki-issue.ts
@@ -177,6 +177,7 @@ async function main() {
     port: 3000,
     logLevel: "info",
     botAllowList: [],
+    slackWebhookRelaySources: [],
     slackWikiChannelId: "",
     wikiStalenessThresholdDays: 30,
     wikiGithubOwner: "",

--- a/scripts/publish-wiki-updates.ts
+++ b/scripts/publish-wiki-updates.ts
@@ -157,6 +157,7 @@ async function main() {
       port: 0,
       logLevel: process.env.LOG_LEVEL ?? "info",
       botAllowList: [],
+      slackWebhookRelaySources: [],
       slackWikiChannelId: "",
       wikiStalenessThresholdDays: 30,
       wikiGithubOwner: values.owner!,

--- a/scripts/sync-triage-reactions.ts
+++ b/scripts/sync-triage-reactions.ts
@@ -138,6 +138,7 @@ async function main(): Promise<void> {
         port: 0,
         logLevel: "info",
         botAllowList: [],
+      slackWebhookRelaySources: [],
       slackWikiChannelId: "",
       wikiStalenessThresholdDays: 30,
       wikiGithubOwner: "",

--- a/scripts/verify-m029-s04.test.ts
+++ b/scripts/verify-m029-s04.test.ts
@@ -45,7 +45,7 @@ function makeSequentialSqlStub(responses: Array<unknown[] | Error>): unknown {
 }
 
 /** Build a minimal octokit stub that returns paginated comment pages. */
-type IssueCleanCommentStub = { id: number; body: string; user?: { login: string; type?: string } };
+type IssueCleanCommentStub = { id: number; body: string; user?: { login: string; type?: string } | null };
 
 function makeOctokitStub(pages: Array<Array<IssueCleanCommentStub>>) {
   return {

--- a/scripts/verify-m029-s04.ts
+++ b/scripts/verify-m029-s04.ts
@@ -492,6 +492,7 @@ export async function buildM029S04ProofHarness(opts?: {
           port: 3000,
           logLevel: "silent",
           botAllowList: [],
+          slackWebhookRelaySources: [],
           slackWikiChannelId: "",
           wikiStalenessThresholdDays: 30,
           wikiGithubOwner: "",
@@ -505,7 +506,7 @@ export async function buildM029S04ProofHarness(opts?: {
           acaJobName: "caj-kodiai-agent",
         };
 
-        const githubApp = createGitHubApp(appConfig as Parameters<typeof createGitHubApp>[0], logger);
+        const githubApp = createGitHubApp(appConfig, logger);
         await githubApp.initialize();
         const context = await githubApp.getRepoInstallationContext(REPO_OWNER, REPO_NAME);
         if (!context) {

--- a/scripts/verify-m064-s03.ts
+++ b/scripts/verify-m064-s03.ts
@@ -123,7 +123,7 @@ function makeCanonicalState(
 
 function createStore(
   stateByBaseReviewOutputKey: Map<string, ContinuationFamilyStateRecord>,
-): Pick<KnowledgeStore, "getContinuationFamilyState"> {
+): OperatorLookupStore {
   return {
     async getContinuationFamilyState(key: ContinuationFamilyStateKey): Promise<ContinuationFamilyStateRecord | null> {
       const state = stateByBaseReviewOutputKey.get(key.baseReviewOutputKey);

--- a/scripts/verify-m065-s02.test.ts
+++ b/scripts/verify-m065-s02.test.ts
@@ -442,6 +442,43 @@ describe("verify-m065-s02", () => {
     });
   });
 
+  test("evaluate rejects nested report fields with non-string scalar shapes", async () => {
+    const { evaluateM065S02 } = await loadModule();
+
+    const report = await evaluateM065S02({
+      reviewOutputKey: makeReviewKey(),
+      generatedAt: "2026-04-24T09:45:00.000Z",
+      runtimeTimingEvaluator: async () => ({
+        ...makeRuntimeReport(),
+        review_output_key: 123,
+        delivery_id: { value: "delivery-101" },
+      }),
+      visibleReviewEvaluator: async () => ({
+        ...makeVisibleReport(),
+        repo: ["xbmc", "kodiai"],
+        review_output_key: 123,
+        delivery_id: { value: "delivery-101" },
+      }),
+      operatorEvidenceEvaluator: async () => makeOperatorReport(),
+    });
+
+    expect(report.success).toBe(false);
+    expect(report.status_code).toBe("m065_s02_nested_contract_failed");
+    expect(report.failing_check_id).not.toBeNull();
+    expect([
+      "M065-S02-RUNTIME-TIMING-EVIDENCE",
+      "M065-S02-VISIBLE-REVIEW-PROOF",
+    ]).toContain(report.failing_check_id!);
+    expect(report.checks.find((check) => check.id === "M065-S02-RUNTIME-TIMING-EVIDENCE")).toMatchObject({
+      passed: false,
+      status_code: "nested_report_malformed",
+    });
+    expect(report.checks.find((check) => check.id === "M065-S02-VISIBLE-REVIEW-PROOF")).toMatchObject({
+      passed: false,
+      status_code: "nested_report_malformed",
+    });
+  });
+
   test("representative live bundle fails when nested proofs disagree on delivery, repo, or PR identity", async () => {
     const { evaluateM065S02 } = await loadModule();
 

--- a/scripts/verify-m065-s02.test.ts
+++ b/scripts/verify-m065-s02.test.ts
@@ -423,7 +423,7 @@ describe("verify-m065-s02", () => {
         generated_at: "2026-04-24T09:45:00.000Z",
         success: true,
         issues: [],
-      }) as never,
+      }),
       visibleReviewEvaluator: async () => makeVisibleReport(),
       operatorEvidenceEvaluator: async () => makeOperatorReport(),
     });

--- a/scripts/verify-m065-s02.test.ts
+++ b/scripts/verify-m065-s02.test.ts
@@ -423,7 +423,7 @@ describe("verify-m065-s02", () => {
         generated_at: "2026-04-24T09:45:00.000Z",
         success: true,
         issues: [],
-      }),
+      }) as never,
       visibleReviewEvaluator: async () => makeVisibleReport(),
       operatorEvidenceEvaluator: async () => makeOperatorReport(),
     });

--- a/scripts/verify-m065-s02.ts
+++ b/scripts/verify-m065-s02.ts
@@ -298,17 +298,29 @@ function isBaseNestedReportContract(value: unknown, command: NestedCommand): val
     && record.issues.every((item) => typeof item === "string");
 }
 
+function isStringOrNull(value: unknown): value is string | null {
+  return typeof value === "string" || value === null;
+}
+
 function isRuntimeTimingReport(value: unknown): value is RuntimeTimingNestedReport {
-  return isBaseNestedReportContract(value, "verify:m048:s01")
-    && typeof (value as Record<string, unknown>).review_output_key !== "undefined"
-    && typeof (value as Record<string, unknown>).delivery_id !== "undefined";
+  if (!isBaseNestedReportContract(value, "verify:m048:s01")) {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  return isStringOrNull(record.review_output_key)
+    && isStringOrNull(record.delivery_id);
 }
 
 function isVisibleReviewReport(value: unknown): value is VisibleReviewNestedReport {
-  return isBaseNestedReportContract(value, "verify:m049:s02")
-    && typeof (value as Record<string, unknown>).repo === "string"
-    && typeof (value as Record<string, unknown>).review_output_key !== "undefined"
-    && typeof (value as Record<string, unknown>).delivery_id !== "undefined";
+  if (!isBaseNestedReportContract(value, "verify:m049:s02")) {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  return isStringOrNull(record.repo)
+    && isStringOrNull(record.review_output_key)
+    && isStringOrNull(record.delivery_id);
 }
 
 function isOperatorEvidenceReport(value: unknown): value is OperatorEvidenceNestedReport {

--- a/scripts/verify-m065-s02.ts
+++ b/scripts/verify-m065-s02.ts
@@ -122,9 +122,9 @@ type VerifyM065S02Args = {
   invalidArg: string | null;
 };
 
-type EvaluateRuntimeTiming = (params: { reviewOutputKey: string; deliveryId: string }) => Promise<RuntimeTimingNestedReport>;
-type EvaluateVisibleReview = (params: { repo: string; reviewOutputKey: string }) => Promise<VisibleReviewNestedReport>;
-type EvaluateOperatorEvidence = (params: { reviewOutputKey: string }) => Promise<OperatorEvidenceNestedReport>;
+type EvaluateRuntimeTiming = (params: { reviewOutputKey: string; deliveryId: string }) => Promise<unknown>;
+type EvaluateVisibleReview = (params: { repo: string; reviewOutputKey: string }) => Promise<unknown>;
+type EvaluateOperatorEvidence = (params: { reviewOutputKey: string }) => Promise<unknown>;
 
 type EvaluateParams = {
   reviewOutputKey: string;

--- a/scripts/verify-m065-s02.ts
+++ b/scripts/verify-m065-s02.ts
@@ -1,7 +1,7 @@
 import { parseReviewOutputKey } from "../src/handlers/review-idempotency.ts";
-import { evaluateM048S01, type M048S01Report } from "./verify-m048-s01.ts";
-import { evaluateM049S02, type M049S02Report } from "./verify-m049-s02.ts";
-import { evaluateM064S03, type M064S03Report } from "./verify-m064-s03.ts";
+import { evaluateM048S01 } from "./verify-m048-s01.ts";
+import { evaluateM049S02 } from "./verify-m049-s02.ts";
+import { evaluateM064S03 } from "./verify-m064-s03.ts";
 
 export const M065_S02_CHECK_IDS = [
   "M065-S02-IDENTITY-CORRELATION",
@@ -40,6 +40,39 @@ type NestedReportContract = {
   [key: string]: unknown;
 };
 
+type RuntimeTimingNestedReport = NestedReportContract & {
+  review_output_key?: string | null;
+  delivery_id?: string | null;
+  evidence?: {
+    conclusion?: string | null;
+    published?: boolean | null;
+  } | null;
+};
+
+type VisibleReviewNestedReport = NestedReportContract & {
+  repo?: string | null;
+  review_output_key?: string | null;
+  delivery_id?: string | null;
+  artifact?: {
+    source?: string | null;
+    reviewState?: string | null;
+    prNumber?: number | null;
+  } | null;
+  bodyContract?: {
+    valid?: boolean | null;
+  } | null;
+};
+
+type OperatorEvidenceNestedReport = NestedReportContract & {
+  record_count?: number;
+  records?: Array<{
+    baseReviewOutputKey?: string | null;
+    repoFullName?: string | null;
+    prNumber?: number | null;
+    statusCode?: string | null;
+  }>;
+};
+
 export type M065S02Check = {
   id: M065S02CheckId;
   passed: boolean;
@@ -72,9 +105,9 @@ export type M065S02Report = {
   check_ids: M065S02CheckId[];
   checks: M065S02Check[];
   nested_reports: {
-    runtimeTiming: M048S01Report | null;
-    visibleReview: M049S02Report | null;
-    operatorEvidence: M064S03Report | null;
+    runtimeTiming: RuntimeTimingNestedReport | null;
+    visibleReview: VisibleReviewNestedReport | null;
+    operatorEvidence: OperatorEvidenceNestedReport | null;
   };
   failing_check_id: M065S02CheckId | null;
   issues: string[];
@@ -89,9 +122,9 @@ type VerifyM065S02Args = {
   invalidArg: string | null;
 };
 
-type EvaluateRuntimeTiming = (params: { reviewOutputKey: string; deliveryId: string }) => Promise<M048S01Report>;
-type EvaluateVisibleReview = (params: { repo: string; reviewOutputKey: string }) => Promise<M049S02Report>;
-type EvaluateOperatorEvidence = (params: { reviewOutputKey: string }) => Promise<M064S03Report>;
+type EvaluateRuntimeTiming = (params: { reviewOutputKey: string; deliveryId: string }) => Promise<RuntimeTimingNestedReport>;
+type EvaluateVisibleReview = (params: { repo: string; reviewOutputKey: string }) => Promise<VisibleReviewNestedReport>;
+type EvaluateOperatorEvidence = (params: { reviewOutputKey: string }) => Promise<OperatorEvidenceNestedReport>;
 
 type EvaluateParams = {
   reviewOutputKey: string;
@@ -265,20 +298,20 @@ function isBaseNestedReportContract(value: unknown, command: NestedCommand): val
     && record.issues.every((item) => typeof item === "string");
 }
 
-function isRuntimeTimingReport(value: unknown): value is M048S01Report {
+function isRuntimeTimingReport(value: unknown): value is RuntimeTimingNestedReport {
   return isBaseNestedReportContract(value, "verify:m048:s01")
     && typeof (value as Record<string, unknown>).review_output_key !== "undefined"
     && typeof (value as Record<string, unknown>).delivery_id !== "undefined";
 }
 
-function isVisibleReviewReport(value: unknown): value is M049S02Report {
+function isVisibleReviewReport(value: unknown): value is VisibleReviewNestedReport {
   return isBaseNestedReportContract(value, "verify:m049:s02")
     && typeof (value as Record<string, unknown>).repo === "string"
     && typeof (value as Record<string, unknown>).review_output_key !== "undefined"
     && typeof (value as Record<string, unknown>).delivery_id !== "undefined";
 }
 
-function isOperatorEvidenceReport(value: unknown): value is M064S03Report {
+function isOperatorEvidenceReport(value: unknown): value is OperatorEvidenceNestedReport {
   return isBaseNestedReportContract(value, "verify:m064:s03")
     && typeof (value as Record<string, unknown>).record_count === "number"
     && Array.isArray((value as Record<string, unknown>).records);
@@ -318,7 +351,7 @@ function buildNestedCheck(params: {
   reportKey: NestedReportKey;
   command: NestedCommand;
   report: unknown;
-  validator: (value: unknown) => boolean;
+  validator: (value: unknown) => value is NestedReportContract;
 }): { check: M065S02Check; issue: string | null; malformed: boolean; failed: boolean } {
   const drillDownCommand = `bun run ${params.command} -- --json`;
 
@@ -467,9 +500,9 @@ function collectIdentityIssues(params: {
   expectedDeliveryId: string;
   expectedRepo: string;
   expectedPrNumber: number;
-  runtimeReport: M048S01Report | null;
-  visibleReport: M049S02Report | null;
-  operatorReport: M064S03Report | null;
+  runtimeReport: RuntimeTimingNestedReport | null;
+  visibleReport: VisibleReviewNestedReport | null;
+  operatorReport: OperatorEvidenceNestedReport | null;
 }): string[] {
   const issues: string[] = [];
 
@@ -523,9 +556,9 @@ function collectIdentityIssues(params: {
 }
 
 function collectRepresentativeBundleIssues(params: {
-  runtimeReport: M048S01Report | null;
-  visibleReport: M049S02Report | null;
-  operatorReport: M064S03Report | null;
+  runtimeReport: RuntimeTimingNestedReport | null;
+  visibleReport: VisibleReviewNestedReport | null;
+  operatorReport: OperatorEvidenceNestedReport | null;
 }): string[] {
   const issues: string[] = [];
 

--- a/scripts/verify-m065-s03.test.ts
+++ b/scripts/verify-m065-s03.test.ts
@@ -255,7 +255,7 @@ describe("verify-m065-s03", () => {
       json: true,
       stdout: { write: (chunk: string) => void stdout.push(chunk) },
       stderr: { write: (chunk: string) => void stderr.push(chunk) },
-      evaluateRegressionGate: () => ({ checks: [] }),
+      evaluateRegressionGate: () => ({ checks: [] }) as never,
       readTextFile: async (filePath: string) => {
         if (normalize(filePath) === "docs/runbooks/m065-rollout-proof.md") {
           return PASSING_RUNBOOK

--- a/scripts/verify-m065-s03.test.ts
+++ b/scripts/verify-m065-s03.test.ts
@@ -255,7 +255,7 @@ describe("verify-m065-s03", () => {
       json: true,
       stdout: { write: (chunk: string) => void stdout.push(chunk) },
       stderr: { write: (chunk: string) => void stderr.push(chunk) },
-      evaluateRegressionGate: () => ({ checks: [] }) as never,
+      evaluateRegressionGate: () => ({ checks: [] }),
       readTextFile: async (filePath: string) => {
         if (normalize(filePath) === "docs/runbooks/m065-rollout-proof.md") {
           return PASSING_RUNBOOK

--- a/scripts/verify-m065-s03.ts
+++ b/scripts/verify-m065-s03.ts
@@ -94,7 +94,7 @@ type StdWriter = {
 
 type EvaluateOptions = {
   generatedAt?: string;
-  evaluateRegressionGate?: () => RegressionGateReport;
+  evaluateRegressionGate?: () => unknown;
   readTextFile?: (filePath: string) => Promise<string>;
   fileExists?: (filePath: string) => Promise<boolean>;
 };

--- a/scripts/verify-m065.test.ts
+++ b/scripts/verify-m065.test.ts
@@ -98,7 +98,7 @@ type JsonReport = {
       drill_down_command: string;
     };
     freshRegressionProof: {
-      state: "pending" | "satisfied";
+      state: "failed" | "pending" | "satisfied";
       source: string | null;
       detail: string;
       drill_down_command: string;

--- a/src/contributor/xbmc-fixture-refresh.ts
+++ b/src/contributor/xbmc-fixture-refresh.ts
@@ -1017,6 +1017,7 @@ function buildGitHubAppConfig(repository: string, privateKey: string) {
     port: 0,
     logLevel: "info",
     botAllowList: [],
+    slackWebhookRelaySources: [],
     slackWikiChannelId: "",
     wikiStalenessThresholdDays: 30,
     wikiGithubOwner: "",

--- a/src/execution/executor.test.ts
+++ b/src/execution/executor.test.ts
@@ -100,6 +100,7 @@ function makeConfig(overrides?: Partial<AppConfig>): AppConfig {
     port: 3000,
     logLevel: "info",
     botAllowList: [],
+    slackWebhookRelaySources: [],
     slackWikiChannelId: "",
     wikiStalenessThresholdDays: 30,
     wikiGithubOwner: "xbmc",

--- a/src/execution/executor.ts
+++ b/src/execution/executor.ts
@@ -24,6 +24,7 @@ import {
   pollUntilComplete,
   cancelAcaJob,
   readJobResult,
+  readJobDiagnostics,
 } from "../jobs/aca-launcher.ts";
 import {
   buildAuthFetchUrl,

--- a/src/execution/review-prompt.test.ts
+++ b/src/execution/review-prompt.test.ts
@@ -771,6 +771,30 @@ test("buildReviewPrompt remains backward compatible without new fields", () => {
   expect(prompt).not.toContain("## Path-Specific Review Instructions");
 });
 
+test("buildReviewPrompt instructs risk-ranked first-pass triage before deep inspection", () => {
+  const prompt = buildReviewPrompt(baseContext({
+    changedFiles: [
+      "src/auth/token.ts",
+      "src/ui/button.tsx",
+      "docs/readme.md",
+    ],
+  }));
+
+  expect(prompt).toContain("## First-pass changed-file triage");
+  expect(prompt).toContain("Before deep inspection, rank the changed files by review risk and intended impact.");
+  expect(prompt).toContain("Inspect the highest-risk files first so a bounded run preserves the most important coverage.");
+  expect(prompt).toContain("Start with files touching security, correctness, data persistence, public API, concurrency, or error handling.");
+});
+
+test("buildReviewPrompt requires an early checkpoint after planning review order", () => {
+  const prompt = buildReviewPrompt(baseContext({ checkpointEnabled: true }));
+
+  expect(prompt).toContain("Before deep inspection, call the save_review_checkpoint tool once after you choose the initial review order.");
+  expect(prompt).toContain("Use findingCount: 0 for this planning checkpoint.");
+  expect(prompt).toContain("summaryDraft should describe the planned first-pass focus and the highest-risk files selected first.");
+  expect(prompt).toContain("Then continue updating the checkpoint after reviewing every 3-5 files.");
+});
+
 test("buildReviewPrompt includes Focus Hints section when focusHints provided", () => {
   const prompt = buildReviewPrompt(
     baseContext({ focusHints: ["auth", "ios"] }),

--- a/src/execution/review-prompt.test.ts
+++ b/src/execution/review-prompt.test.ts
@@ -483,6 +483,13 @@ test("maxComments overrides default", () => {
   expect(prompt).toContain("at most 3 inline comments");
 });
 
+test("comment cap is a publication cap, not an analysis stopping point", () => {
+  const prompt = buildReviewPrompt(baseContext({ maxComments: 3 }));
+  expect(prompt).toContain("The comment limit is a publication cap, not an analysis stopping point.");
+  expect(prompt).toContain("Continue analyzing after you identify the first 3 candidate findings");
+  expect(prompt).toContain("publish the strongest 3 after completing the full review pass");
+});
+
 test("buildSuppressionRulesSection formats string and object suppressions", () => {
   const section = buildSuppressionRulesSection([
     "missing JSDoc",
@@ -2785,6 +2792,8 @@ describe("buildReviewPrompt graph context integration", () => {
     expect(prompt).toContain(`\"${disclosureSentence}\"`);
     expect(prompt).toContain("Do not paraphrase it.");
     expect(prompt).toContain("Do not repeat it elsewhere in the summary.");
+    expect(prompt).toContain("Do not claim the review found all relevant issues when bounded files or severity filters excluded scope.");
+    expect(prompt).toContain("If the review is bounded, frame the verdict as the result for the inspected scope.");
   });
 
   test("keeps small unbounded standard prompts silent and omits bounded-review instructions in enhanced mode", () => {

--- a/src/execution/review-prompt.ts
+++ b/src/execution/review-prompt.ts
@@ -1897,6 +1897,13 @@ export function buildReviewPromptDetails(context: {
     `To see changed files with stats: Bash(git log origin/${context.baseBranch}..HEAD --stat)`,
     "Read the diff carefully before posting any comments.",
     "",
+    "## First-pass changed-file triage",
+    "",
+    "Before deep inspection, rank the changed files by review risk and intended impact.",
+    "Inspect the highest-risk files first so a bounded run preserves the most important coverage.",
+    "Start with files touching security, correctness, data persistence, public API, concurrency, or error handling.",
+    "Use the remaining files as lower-priority follow-up scope if the run becomes bounded by timeout or max turns.",
+    "",
     "## What to look for",
     "",
     "Review the changes for:",
@@ -1931,12 +1938,20 @@ export function buildReviewPromptDetails(context: {
   if (context.checkpointEnabled === true) {
     instructionLines.push(
       "",
-      "IMPORTANT: This review may time out. Call the save_review_checkpoint tool after reviewing every 3-5 files. Include:",
+      "IMPORTANT: This review may time out or run out of turns. Preserve progress with the save_review_checkpoint tool.",
+      "Before deep inspection, call the save_review_checkpoint tool once after you choose the initial review order. Include:",
+      "- filesReviewed: []",
+      "- findingCount: 0",
+      "- summaryDraft: describe the planned first-pass focus and the highest-risk files selected first",
+      "",
+      "Use findingCount: 0 for this planning checkpoint.",
+      "summaryDraft should describe the planned first-pass focus and the highest-risk files selected first.",
+      "Then continue updating the checkpoint after reviewing every 3-5 files. Include:",
       "- filesReviewed: list of file paths you have fully analyzed",
       "- findingCount: total findings generated so far",
       "- summaryDraft: a brief summary of findings so far",
       "",
-      "This ensures your work is preserved if the session times out.",
+      "This ensures your work is preserved if the session times out or exhausts max turns.",
     );
   }
 

--- a/src/execution/review-prompt.ts
+++ b/src/execution/review-prompt.ts
@@ -398,6 +398,8 @@ function buildCommentCapInstructions(maxComments: number): string {
     "## Comment Limit",
     "",
     `Post at most ${maxComments} inline comments for this PR review.`,
+    "The comment limit is a publication cap, not an analysis stopping point.",
+    `Continue analyzing after you identify the first ${maxComments} candidate findings; publish the strongest ${maxComments} after completing the full review pass.`,
     "Prioritize by severity: CRITICAL first, then MAJOR, MEDIUM, MINOR.",
     "If more issues exist than the limit allows, add a note at the end of your final inline comment:",
     `"Note: Additional lower-severity issues were found but omitted. Increase review.maxComments in .kodiai.yml to see more."`,
@@ -1801,6 +1803,8 @@ export function buildReviewPromptDetails(context: {
       `\"${context.reviewBoundedness.disclosureSentence}\"`,
       "Do not paraphrase it.",
       "Do not repeat it elsewhere in the summary.",
+      "Do not claim the review found all relevant issues when bounded files or severity filters excluded scope.",
+      "If the review is bounded, frame the verdict as the result for the inspected scope.",
     );
   }
   pushBudgetedSection("review-size-context", sizeContextLines, REVIEW_SECTION_BUDGETS.sizeContext);

--- a/src/handlers/review.test.ts
+++ b/src/handlers/review.test.ts
@@ -8822,6 +8822,7 @@ describe("createReviewHandler finding prioritization", () => {
       ],
     });
 
+    expect(result.detailsCommentBody).toContain("Comment cap saturated: published 1/2 prioritized findings; 1 lower-priority finding(s) omitted from inline publication");
     expect(result.detailsCommentBody).toContain("Prioritization: scored 2 findings");
     expect(result.detailsCommentBody).toContain("top score");
     expect(result.detailsCommentBody).toContain("threshold score");

--- a/src/handlers/review.test.ts
+++ b/src/handlers/review.test.ts
@@ -16720,6 +16720,7 @@ describe("createReviewHandler failure fallback publication", () => {
 
     expect(queuedRetryJob).toBeDefined();
     expect(createdCommentBodies.join("\n")).not.toContain("Try requesting another review");
+    expect(createdCommentBodies.join("\n")).not.toContain("Try requesting another review after narrowing the scope or improving the available review context.");
 
     await workspaceFixture.cleanup();
   });

--- a/src/handlers/review.test.ts
+++ b/src/handlers/review.test.ts
@@ -2062,6 +2062,128 @@ describe("createReviewHandler review_requested idempotency", () => {
     expect(createdIssueComments).toHaveLength(0);
   });
 
+  test("published approval review receives Review Details instead of creating a separate issue comment", async () => {
+    const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
+    const workspaceFixture = await createWorkspaceFixture({ autoApprove: true });
+
+    let issueCommentCreateCount = 0;
+    let updatedReviewId: number | undefined;
+    const reviewOutputKey = buildReviewOutputKey({
+      installationId: 42,
+      owner: "acme",
+      repo: "repo",
+      prNumber: 101,
+      action: "review_requested",
+      deliveryId: "delivery-123",
+      headSha: "abcdef1234567890",
+    });
+    const marker = buildReviewOutputMarker(reviewOutputKey);
+    const existingApprovalReview = {
+      id: 777,
+      body: `<details>\n<summary>kodiai response</summary>\n\nDecision: APPROVE\nIssues: none\n\nEvidence:\n- Agent-published clean approval.\n\n</details>\n\n${marker}`,
+    };
+
+    const eventRouter: EventRouter = {
+      register: (eventKey, handler) => {
+        handlers.set(eventKey, handler);
+      },
+      dispatch: async () => undefined,
+    };
+
+    const jobQueue: JobQueue = {
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
+      getQueueSize: () => 0,
+      getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
+    };
+
+    const workspaceManager: WorkspaceManager = {
+      create: async () => ({
+        dir: workspaceFixture.dir,
+        cleanup: async () => undefined,
+      }),
+      cleanupStale: async () => 0,
+    };
+
+    const octokit = {
+      rest: {
+        pulls: {
+          listReviewComments: async () => ({ data: [] }),
+          listReviews: async () => ({ data: [existingApprovalReview] }),
+          createReview: async () => {
+            throw new Error("auto-approval should skip when the executor already published output");
+          },
+        },
+        reactions: {
+          createForIssue: async () => ({ data: {} }),
+        },
+        issues: {
+          listComments: async () => ({ data: [] }),
+          createComment: async () => {
+            issueCommentCreateCount += 1;
+            return { data: { id: 1 } };
+          },
+          updateComment: async () => ({ data: {} }),
+        },
+      },
+      request: async (
+        route: string,
+        params: { review_id: number; body: string },
+      ) => {
+        expect(route).toBe("PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}");
+        updatedReviewId = params.review_id;
+        existingApprovalReview.body = params.body;
+        return { data: {} };
+      },
+    };
+
+    createReviewHandler({
+      eventRouter,
+      jobQueue,
+      workspaceManager,
+      githubApp: {
+        getAppSlug: () => "kodiai",
+        getInstallationOctokit: async () => octokit as never,
+        initialize: async () => undefined,
+        checkConnectivity: async () => true,
+        getInstallationToken: async () => "token",
+      } as unknown as GitHubApp,
+      executor: {
+        execute: async () => ({
+          conclusion: "success",
+          published: true,
+          costUsd: 0,
+          numTurns: 1,
+          durationMs: 1,
+          sessionId: "session-published-approval-details",
+          executorPhaseTimings: [
+            { name: "executor handoff", status: "completed", durationMs: 50 },
+            { name: "remote runtime", status: "completed", durationMs: 500 },
+          ],
+        }),
+      } as never,
+      telemetryStore: noopTelemetryStore,
+      logger: createNoopLogger(),
+    });
+
+    const handler = handlers.get("pull_request.review_requested");
+    expect(handler).toBeDefined();
+
+    await handler!(
+      buildReviewRequestedEvent({
+        requested_reviewer: { login: "kodiai[bot]" },
+      }),
+    );
+
+    await workspaceFixture.cleanup();
+
+    expect(updatedReviewId).toBe(777);
+    expect(issueCommentCreateCount).toBe(0);
+    expect(existingApprovalReview.body).toContain("Decision: APPROVE");
+    expect(existingApprovalReview.body).toContain("<summary>Review Details</summary>");
+    expect(existingApprovalReview.body).toContain("publication:");
+  });
+
   test("auto-approval finalization refreshes the same canonical approval review id when older marker-matching reviews exist", async () => {
     const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
     const workspaceFixture = await createWorkspaceFixture({ autoApprove: true });
@@ -8822,7 +8944,7 @@ describe("createReviewHandler finding prioritization", () => {
       ],
     });
 
-    expect(result.detailsCommentBody).toContain("Comment cap saturated: published 1/2 prioritized findings; 1 lower-priority finding(s) omitted from inline publication");
+    expect(result.detailsCommentBody).toContain("Comment cap saturated: published 1/2 prioritized findings; 1 lower-priority finding omitted from inline publication");
     expect(result.detailsCommentBody).toContain("Prioritization: scored 2 findings");
     expect(result.detailsCommentBody).toContain("top score");
     expect(result.detailsCommentBody).toContain("threshold score");

--- a/src/handlers/review.ts
+++ b/src/handlers/review.ts
@@ -4404,6 +4404,9 @@ export function createReviewHandler(deps: {
           findingsScored: number;
           topScore: number | null;
           thresholdScore: number | null;
+          maxComments?: number;
+          selectedFindings?: number;
+          omittedFindings?: number;
         } | undefined;
 
         if (visibleFindings.length > resolvedMaxComments) {
@@ -4420,7 +4423,12 @@ export function createReviewHandler(deps: {
             weights: config.review.prioritization,
           });
 
-          prioritizationStats = prioritized.stats;
+          prioritizationStats = {
+            ...prioritized.stats,
+            maxComments: resolvedMaxComments,
+            selectedFindings: prioritized.selectedFindings.length,
+            omittedFindings: Math.max(0, visibleFindings.length - prioritized.selectedFindings.length),
+          };
 
           const selectedOriginalIndexes = new Set(
             prioritized.selectedFindings.map((finding) => finding.originalIndex),

--- a/src/handlers/review.ts
+++ b/src/handlers/review.ts
@@ -878,7 +878,7 @@ async function upsertCanonicalReviewSurface(params: {
   pullReviewEvent?: "APPROVE" | "COMMENT" | "REQUEST_CHANGES";
   recheckCanPublish?: () => boolean;
 }): Promise<CanonicalReviewSurface | undefined> {
-  const existingSurface = params.canonicalSurface?.kind === params.preferredKind
+  let existingSurface = params.canonicalSurface?.kind === params.preferredKind
     ? params.canonicalSurface
     : await findCanonicalReviewSurface({
       octokit: params.octokit,
@@ -888,6 +888,18 @@ async function upsertCanonicalReviewSurface(params: {
       reviewOutputKey: params.reviewOutputKey,
       surfaceKind: params.preferredKind,
     });
+
+  if (!existingSurface && params.reviewDetailsBlock) {
+    const alternateKind: CanonicalSurfaceKind = params.preferredKind === "issue_comment" ? "pull_review" : "issue_comment";
+    existingSurface = await findCanonicalReviewSurface({
+      octokit: params.octokit,
+      owner: params.owner,
+      repo: params.repo,
+      prNumber: params.prNumber,
+      reviewOutputKey: params.reviewOutputKey,
+      surfaceKind: alternateKind,
+    });
+  }
 
   const body = params.reviewDetailsBlock
     ? (() => {

--- a/src/knowledge/continuation-operator-evidence.test.ts
+++ b/src/knowledge/continuation-operator-evidence.test.ts
@@ -68,7 +68,7 @@ describe("resolveContinuationOperatorEvidence", () => {
     });
 
     expect(observedKey).not.toBeNull();
-    expect(observedKey as unknown as ContinuationFamilyStateKey).toEqual({
+    expect(observedKey!).toEqual({
       familyKey: "acme/repo#101",
       baseReviewOutputKey: makeReviewOutputKey(),
     });

--- a/src/knowledge/continuation-operator-evidence.test.ts
+++ b/src/knowledge/continuation-operator-evidence.test.ts
@@ -67,7 +67,8 @@ describe("resolveContinuationOperatorEvidence", () => {
       }),
     });
 
-    expect(observedKey).toEqual({
+    expect(observedKey).not.toBeNull();
+    expect(observedKey as unknown as ContinuationFamilyStateKey).toEqual({
       familyKey: "acme/repo#101",
       baseReviewOutputKey: makeReviewOutputKey(),
     });
@@ -121,9 +122,6 @@ describe("buildContinuationOperatorEvidenceReport", () => {
       baseReviewOutputKey: makeReviewOutputKey(),
       familyKey: "acme/repo#101",
       parsedReviewOutputKey: {
-        reviewOutputKey: makeReviewOutputKey(),
-        baseReviewOutputKey: makeReviewOutputKey(),
-        retryAttempt: null,
         installationId: 42,
         owner: "acme",
         repo: "repo",
@@ -133,6 +131,7 @@ describe("buildContinuationOperatorEvidenceReport", () => {
         deliveryId: "delivery-123",
         effectiveDeliveryId: "delivery-123",
         headSha: "abcdef1234567890",
+        retryAttempt: null,
       },
       canonicalState: makeCanonicalState(),
       detail: "resolved",

--- a/src/knowledge/continuation-operator-evidence.ts
+++ b/src/knowledge/continuation-operator-evidence.ts
@@ -105,8 +105,9 @@ export function buildContinuationOperatorEvidenceReport(
   const parsed = lookup.parsedReviewOutputKey;
 
   if (!canonicalState) {
+    const status = lookup.status === "resolved" ? "lookup-unavailable" : lookup.status;
     return {
-      status: lookup.status,
+      status,
       detail: lookup.detail,
       reviewOutputKey: lookup.reviewOutputKey,
       baseReviewOutputKey: lookup.baseReviewOutputKey,

--- a/src/lib/review-utils.test.ts
+++ b/src/lib/review-utils.test.ts
@@ -363,6 +363,23 @@ describe("formatReviewDetailsSummary", () => {
     expect(result).toContain("publication: 120ms (degraded: captured before publication completed)");
   });
 
+  it("renders saturated comment-cap diagnostics when prioritization omitted findings", () => {
+    const result = formatReviewDetailsSummary({
+      ...BASE_PARAMS,
+      prioritization: {
+        findingsScored: 9,
+        topScore: 182,
+        thresholdScore: 97,
+        maxComments: 3,
+        selectedFindings: 3,
+        omittedFindings: 6,
+      },
+    });
+
+    expect(result).toContain("- Comment cap saturated: published 3/9 prioritized findings; 6 lower-priority finding(s) omitted from inline publication");
+    expect(result).toContain("- Prioritization: scored 9 findings | top score 182 | threshold score 97");
+  });
+
   it("renders requested versus effective bounded-review lines without duplicating the old profile line", () => {
     const result = formatReviewDetailsSummary({
       ...BASE_PARAMS,

--- a/src/lib/review-utils.test.ts
+++ b/src/lib/review-utils.test.ts
@@ -376,8 +376,24 @@ describe("formatReviewDetailsSummary", () => {
       },
     });
 
-    expect(result).toContain("- Comment cap saturated: published 3/9 prioritized findings; 6 lower-priority finding(s) omitted from inline publication");
+    expect(result).toContain("- Comment cap saturated: published 3/9 prioritized findings; 6 lower-priority findings omitted from inline publication");
     expect(result).toContain("- Prioritization: scored 9 findings | top score 182 | threshold score 97");
+  });
+
+  it("renders singular saturated comment-cap diagnostics when one finding is omitted", () => {
+    const result = formatReviewDetailsSummary({
+      ...BASE_PARAMS,
+      prioritization: {
+        findingsScored: 4,
+        topScore: 182,
+        thresholdScore: 97,
+        maxComments: 3,
+        selectedFindings: 3,
+        omittedFindings: 1,
+      },
+    });
+
+    expect(result).toContain("- Comment cap saturated: published 3/4 prioritized findings; 1 lower-priority finding omitted from inline publication");
   });
 
   it("renders requested versus effective bounded-review lines without duplicating the old profile line", () => {

--- a/src/lib/review-utils.ts
+++ b/src/lib/review-utils.ts
@@ -544,6 +544,9 @@ export function formatReviewDetailsSummary(params: {
     findingsScored: number;
     topScore: number | null;
     thresholdScore: number | null;
+    maxComments?: number;
+    selectedFindings?: number;
+    omittedFindings?: number;
   };
   usageLimit?: {
     utilization: number | undefined;
@@ -720,6 +723,18 @@ export function formatReviewDetailsSummary(params: {
   }
 
   if (prioritization) {
+    const hasSaturatedCommentCap =
+      typeof prioritization.maxComments === "number" &&
+      typeof prioritization.selectedFindings === "number" &&
+      typeof prioritization.omittedFindings === "number" &&
+      prioritization.omittedFindings > 0;
+
+    if (hasSaturatedCommentCap) {
+      sections.push(
+        `- Comment cap saturated: published ${prioritization.selectedFindings}/${prioritization.findingsScored} prioritized findings; ${prioritization.omittedFindings} lower-priority finding(s) omitted from inline publication`,
+      );
+    }
+
     sections.push(
       `- Prioritization: scored ${prioritization.findingsScored} findings | top score ${prioritization.topScore ?? "n/a"} | threshold score ${prioritization.thresholdScore ?? "n/a"}`,
     );

--- a/src/lib/review-utils.ts
+++ b/src/lib/review-utils.ts
@@ -730,8 +730,9 @@ export function formatReviewDetailsSummary(params: {
       prioritization.omittedFindings > 0;
 
     if (hasSaturatedCommentCap) {
+      const omittedFindingLabel = prioritization.omittedFindings === 1 ? "finding" : "findings";
       sections.push(
-        `- Comment cap saturated: published ${prioritization.selectedFindings}/${prioritization.findingsScored} prioritized findings; ${prioritization.omittedFindings} lower-priority finding(s) omitted from inline publication`,
+        `- Comment cap saturated: published ${prioritization.selectedFindings}/${prioritization.findingsScored} prioritized findings; ${prioritization.omittedFindings} lower-priority ${omittedFindingLabel} omitted from inline publication`,
       );
     }
 

--- a/src/routes/slack-commands.test.ts
+++ b/src/routes/slack-commands.test.ts
@@ -41,6 +41,7 @@ function createTestConfig(): AppConfig {
     port: 3000,
     logLevel: "info",
     botAllowList: [],
+    slackWebhookRelaySources: [],
     slackWikiChannelId: "",
     wikiStalenessThresholdDays: 30,
     wikiGithubOwner: "xbmc",

--- a/src/routes/slack-events.test.ts
+++ b/src/routes/slack-events.test.ts
@@ -34,6 +34,7 @@ function createTestConfig(): AppConfig {
     port: 3000,
     logLevel: "info",
     botAllowList: [],
+    slackWebhookRelaySources: [],
     slackWikiChannelId: "",
     wikiStalenessThresholdDays: 30,
     wikiGithubOwner: "xbmc",

--- a/src/routes/webhooks.test.ts
+++ b/src/routes/webhooks.test.ts
@@ -37,6 +37,7 @@ function createTestConfig(): AppConfig {
     port: 3000,
     logLevel: "info",
     botAllowList: [],
+    slackWebhookRelaySources: [],
     slackWikiChannelId: "",
     wikiStalenessThresholdDays: 30,
     wikiGithubOwner: "xbmc",


### PR DESCRIPTION
## Summary

Fixes #115.

This PR tightens the first-pass review contract so large or bounded reviews do not look exhaustive when scope was intentionally constrained:

- treats `review.maxComments` as an inline publication cap, not an analysis stopping point
- instructs the reviewer to continue analysis after the first N candidate findings and publish the strongest N after the full pass
- warns bounded review summaries not to claim all relevant issues were found when files or severity filters excluded scope
- surfaces saturated comment caps in Review Details, including how many prioritized findings were published and how many lower-priority findings were omitted
- clears repo-wide TypeScript drift that was blocking `bun run tsc --noEmit`

## Verification

Freshly run before opening this PR:

- `bun run tsc --noEmit` — pass
- `bun test --max-concurrency=2 scripts src` — 4288 pass, 144 skip, 0 fail
- `git diff --check` — pass
