### PR TITLE
Fix Slack queued replay safety rails

### DIFF
--- a/src/execution/mcp/comment-server.test.ts
+++ b/src/execution/mcp/comment-server.test.ts
@@ -185,6 +185,9 @@ describe("createCommentServer", () => {
     expect(createReviewParams!.body).toContain("<details>");
     expect(createReviewParams!.body).toContain("<summary>kodiai response</summary>");
     expect(createReviewParams!.body).toContain("Decision: APPROVE");
+    expect(String(createReviewParams!.body).indexOf("Decision: APPROVE")).toBeLessThan(
+      String(createReviewParams!.body).indexOf("<details>"),
+    );
     expect(createReviewParams!.body).toContain("Issues: none");
     expect(createReviewParams!.body).toContain("Evidence:");
     expect(extractReviewOutputKey(String(createReviewParams!.body))).toBe(reviewOutputKey);
@@ -243,6 +246,9 @@ describe("createCommentServer", () => {
     expect(createReviewBody).toContain("<details>");
     expect(createReviewBody).toContain("<summary>kodiai response</summary>");
     expect(createReviewBody).toContain("Decision: APPROVE");
+    expect(createReviewBody!.indexOf("Decision: APPROVE")).toBeLessThan(
+      createReviewBody!.indexOf("<details>"),
+    );
     expect(createReviewBody).toContain("Issues: none");
     expect(createReviewBody).toContain("Evidence:");
   });

--- a/src/execution/mcp/comment-server.ts
+++ b/src/execution/mcp/comment-server.ts
@@ -121,7 +121,7 @@ export function createCommentServer(
         throw new Error("Invalid kodiai response: APPROVE must include 1-3 evidence bullets");
       }
 
-      return wrapInDetails(
+      const collapsedBody = wrapInDetails(
         [
           "Decision: APPROVE",
           "Issues: none",
@@ -131,6 +131,8 @@ export function createCommentServer(
         ].join("\n"),
         "kodiai response",
       );
+
+      return `Decision: APPROVE\n\n${collapsedBody}`;
     }
 
     // NOT APPROVED: require Issues: header and issue lines.

--- a/src/execution/mention-prompt.test.ts
+++ b/src/execution/mention-prompt.test.ts
@@ -128,6 +128,9 @@ describe("buildMentionPrompt", () => {
     expect(prompt).toContain("Do NOT claim any edits were made");
 
     expect(approvalSection).toContain("Decision: APPROVE");
+    expect(approvalSection.indexOf("Decision: APPROVE")).toBeLessThan(
+      approvalSection.indexOf("<details>"),
+    );
     expect(approvalSection).toContain("Issues: none");
     expect(approvalSection).toContain("Evidence:");
     expect(approvalSection).toContain("- <factual evidence>");

--- a/src/execution/mention-prompt.ts
+++ b/src/execution/mention-prompt.ts
@@ -289,9 +289,12 @@ export function buildMentionPromptDetails(params: {
 
   lines.push("- If (and only if) the user is asking for a PR review / approval decision:");
   lines.push(
-    "  - Keep APPROVE responses wrapped in `<details>` so the review stays collapsed in GitHub.",
+    "  - Put `Decision: APPROVE` on the first line so the approval is visible without expanding the collapsed response.",
+    "  - Keep the detailed APPROVE response wrapped in `<details>` below that visible decision line.",
     "  - Use this exact APPROVE body:",
     "    ```",
+    "    Decision: APPROVE",
+    "    ",
     "    <details>",
     '    <summary>kodiai response</summary>',
     "    ",

--- a/src/handlers/review-idempotency.test.ts
+++ b/src/handlers/review-idempotency.test.ts
@@ -202,6 +202,7 @@ describe("review idempotency helpers", () => {
     expect(result).toContain("<details>");
     expect(result).toContain("<summary>kodiai response</summary>");
     expect(result).toContain("Decision: APPROVE");
+    expect(result.indexOf("Decision: APPROVE")).toBeLessThan(result.indexOf("<details>"));
     expect(result).toContain("Issues: none");
     expect(result).toContain("Evidence:");
     expect(result).toContain(marker);

--- a/src/handlers/review-idempotency.ts
+++ b/src/handlers/review-idempotency.ts
@@ -302,9 +302,10 @@ export function buildApprovedReviewBody(params: {
 }): string {
   const marker = buildReviewOutputMarker(params.reviewOutputKey);
   const evidence = buildApprovedReviewEvidence(params);
+  const visibleDecisionLine = "Decision: APPROVE";
   const collapsedBody = wrapInDetails(
     [
-      "Decision: APPROVE",
+      visibleDecisionLine,
       "Issues: none",
       "",
       "Evidence:",
@@ -312,11 +313,12 @@ export function buildApprovedReviewBody(params: {
     ].join("\n"),
     "kodiai response",
   );
+  const approvalBody = `${visibleDecisionLine}\n\n${collapsedBody}`;
   const reviewDetailsBlock = params.reviewDetailsBlock?.trim();
 
   return reviewDetailsBlock
-    ? [collapsedBody, "", reviewDetailsBlock, "", marker].join("\n")
-    : [collapsedBody, "", marker].join("\n");
+    ? [approvalBody, "", reviewDetailsBlock, "", marker].join("\n")
+    : [approvalBody, "", marker].join("\n");
 }
 
 export async function ensureReviewOutputNotPublished(deps: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -629,26 +629,30 @@ try {
   const replaySlackThreadSessionStore = createSlackThreadSessionStore();
 
   for (const entry of pendingWebhooks) {
+    const entryId = entry.id;
+    if (typeof entryId !== "number") {
+      logger.error({ entry }, "Dequeued webhook entry missing ID; skipping startup replay because completion state cannot be recorded");
+      queuedWebhooksFailed++;
+      continue;
+    }
+
     try {
       const result = await replayQueuedWebhook({
         entry,
         config,
         logger,
         dispatchGitHubEvent: (event) => eventRouter.dispatch(event),
-        handleSlackBootstrap: async (payload) => {
+        handleSlackAllowedEvent: async (payload) => {
           await slackAssistantHandler.handle(payload);
         },
         slackThreadSessionStore: replaySlackThreadSessionStore,
       });
 
-      await webhookQueueStore.markCompleted(entry.id!);
+      await webhookQueueStore.markCompleted(entryId);
       queuedWebhooksProcessed++;
-      if (result.status === "ignored") {
-        logger.info({ id: entry.id, source: entry.source, reason: result.reason }, "Queued webhook replay marked complete after ignore decision");
-      }
     } catch (err) {
-      logger.warn({ err, id: entry.id, source: entry.source }, "Failed to replay queued webhook");
-      await webhookQueueStore.markFailed(entry.id!);
+      logger.warn({ err, id: entryId, source: entry.source }, "Failed to replay queued webhook");
+      await webhookQueueStore.markFailed(entryId);
       queuedWebhooksFailed++;
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,11 +45,13 @@ import { createContributorProfileStore } from "./contributor/index.ts";
 import { createSlackCommandRoutes } from "./routes/slack-commands.ts";
 import { createSlackClient } from "./slack/client.ts";
 import { createSlackAssistantHandler } from "./slack/assistant-handler.ts";
+import { createSlackThreadSessionStore } from "./slack/thread-session-store.ts";
 import { createSlackWriteRunner } from "./slack/write-runner.ts";
 import { deliverWebhookRelayEvent } from "./slack/webhook-relay-delivery.ts";
 import { createRequestTracker } from "./lifecycle/request-tracker.ts";
 import { createShutdownManager } from "./lifecycle/shutdown-manager.ts";
 import { createWebhookQueueStore } from "./lifecycle/webhook-queue-store.ts";
+import { replayQueuedWebhook } from "./lifecycle/webhook-replay.ts";
 
 // Global error handlers — log and keep running instead of silently crashing
 process.on("uncaughtException", (err) => {
@@ -624,40 +626,26 @@ let queuedWebhooksFailed = 0;
 
 try {
   const pendingWebhooks = await webhookQueueStore.dequeuePending();
+  const replaySlackThreadSessionStore = createSlackThreadSessionStore();
 
   for (const entry of pendingWebhooks) {
     try {
-      if (entry.source === "github") {
-        // Reconstruct WebhookEvent from queued data
-        const payload = JSON.parse(entry.body) as Record<string, unknown>;
-        const installation = payload.installation as { id: number } | undefined;
-        const event = {
-          id: entry.deliveryId ?? `replay-${entry.id}`,
-          name: entry.eventName ?? "unknown",
-          payload,
-          installationId: installation?.id ?? 0,
-        };
-        await eventRouter.dispatch(event);
-      } else if (entry.source === "slack") {
-        // Reconstruct Slack bootstrap payload and dispatch
-        const slackPayload = JSON.parse(entry.body) as Record<string, unknown>;
-        const slackEvent = slackPayload.event as Record<string, unknown> | undefined;
-
-        if (slackEvent) {
-          const bootstrapPayload = {
-            channel: (slackEvent.channel as string) ?? "",
-            threadTs: (slackEvent.thread_ts as string) ?? (slackEvent.ts as string) ?? "",
-            messageTs: (slackEvent.ts as string) ?? "",
-            user: (slackEvent.user as string) ?? "",
-            text: (slackEvent.text as string) ?? "",
-            replyTarget: "thread-only" as const,
-          };
-          await slackAssistantHandler.handle(bootstrapPayload);
-        }
-      }
+      const result = await replayQueuedWebhook({
+        entry,
+        config,
+        logger,
+        dispatchGitHubEvent: (event) => eventRouter.dispatch(event),
+        handleSlackBootstrap: async (payload) => {
+          await slackAssistantHandler.handle(payload);
+        },
+        slackThreadSessionStore: replaySlackThreadSessionStore,
+      });
 
       await webhookQueueStore.markCompleted(entry.id!);
       queuedWebhooksProcessed++;
+      if (result.status === "ignored") {
+        logger.info({ id: entry.id, source: entry.source, reason: result.reason }, "Queued webhook replay marked complete after ignore decision");
+      }
     } catch (err) {
       logger.warn({ err, id: entry.id, source: entry.source }, "Failed to replay queued webhook");
       await webhookQueueStore.markFailed(entry.id!);

--- a/src/index.ts
+++ b/src/index.ts
@@ -637,7 +637,7 @@ try {
     }
 
     try {
-      const result = await replayQueuedWebhook({
+      await replayQueuedWebhook({
         entry,
         config,
         logger,

--- a/src/lifecycle/webhook-replay.test.ts
+++ b/src/lifecycle/webhook-replay.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from "bun:test";
+import type { Logger } from "pino";
+import type { AppConfig } from "../config.ts";
+import type { SlackV1BootstrapPayload } from "../slack/safety-rails.ts";
+import type { WebhookEvent } from "../webhook/types.ts";
+import { replayQueuedWebhook } from "./webhook-replay.ts";
+
+function createTestLogger(): Logger {
+  return {
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+    debug: () => undefined,
+    trace: () => undefined,
+    fatal: () => undefined,
+    child: () => createTestLogger(),
+  } as unknown as Logger;
+}
+
+function createTestConfig(): AppConfig {
+  return {
+    githubAppId: "12345",
+    githubPrivateKey: "-----BEGIN PRIVATE KEY-----\nTEST\n-----END PRIVATE KEY-----",
+    webhookSecret: "webhook-secret",
+    slackSigningSecret: "slack-secret",
+    slackBotToken: "xoxb-test-token",
+    slackBotUserId: "U123BOT",
+    slackKodiaiChannelId: "C123KODIAI",
+    slackDefaultRepo: "xbmc/xbmc",
+    slackAssistantModel: "claude-3-5-haiku-latest",
+    slackWebhookRelaySources: [],
+    port: 3000,
+    logLevel: "info",
+    botAllowList: [],
+    slackWikiChannelId: "",
+    wikiStalenessThresholdDays: 30,
+    wikiGithubOwner: "xbmc",
+    wikiGithubRepo: "xbmc",
+    botUserPat: "",
+    botUserLogin: "",
+    addonRepos: [],
+    mcpInternalBaseUrl: "",
+    acaJobImage: "",
+    acaResourceGroup: "rg-kodiai",
+    acaJobName: "caj-kodiai-agent",
+  };
+}
+
+describe("replayQueuedWebhook", () => {
+  test("replays queued GitHub webhook through the event router", async () => {
+    const dispatched: WebhookEvent[] = [];
+
+    await replayQueuedWebhook({
+      entry: {
+        id: 1,
+        source: "github",
+        deliveryId: "delivery-1",
+        eventName: "issues",
+        headers: {},
+        body: JSON.stringify({ installation: { id: 123 }, action: "opened" }),
+      },
+      config: createTestConfig(),
+      logger: createTestLogger(),
+      dispatchGitHubEvent: async (event) => {
+        dispatched.push(event);
+      },
+      handleSlackBootstrap: async () => undefined,
+    });
+
+    expect(dispatched).toEqual([
+      {
+        id: "delivery-1",
+        name: "issues",
+        payload: { installation: { id: 123 }, action: "opened" },
+        installationId: 123,
+      },
+    ]);
+  });
+
+  test("replays queued Slack event through the same channel and mention safety rails", async () => {
+    const processed: SlackV1BootstrapPayload[] = [];
+
+    await replayQueuedWebhook({
+      entry: {
+        id: 2,
+        source: "slack",
+        headers: {},
+        body: JSON.stringify({
+          type: "event_callback",
+          event: {
+            type: "message",
+            channel: "C999OTHER",
+            channel_type: "channel",
+            ts: "1700000000.000001",
+            user: "U123USER",
+            text: "<@U123BOT> should not run",
+          },
+        }),
+      },
+      config: createTestConfig(),
+      logger: createTestLogger(),
+      dispatchGitHubEvent: async () => undefined,
+      handleSlackBootstrap: async (payload) => {
+        processed.push(payload);
+      },
+    });
+
+    expect(processed).toHaveLength(0);
+  });
+
+  test("replays queued Slack mention when it passes safety rails", async () => {
+    const processed: SlackV1BootstrapPayload[] = [];
+
+    await replayQueuedWebhook({
+      entry: {
+        id: 3,
+        source: "slack",
+        headers: {},
+        body: JSON.stringify({
+          type: "event_callback",
+          event: {
+            type: "app_mention",
+            channel: "C123KODIAI",
+            channel_type: "channel",
+            ts: "1700000000.000777",
+            user: "U777USER",
+            text: "<@U123BOT> run this",
+          },
+        }),
+      },
+      config: createTestConfig(),
+      logger: createTestLogger(),
+      dispatchGitHubEvent: async () => undefined,
+      handleSlackBootstrap: async (payload) => {
+        processed.push(payload);
+      },
+    });
+
+    expect(processed).toEqual([
+      {
+        channel: "C123KODIAI",
+        threadTs: "1700000000.000777",
+        messageTs: "1700000000.000777",
+        user: "U777USER",
+        text: "<@U123BOT> run this",
+        replyTarget: "thread-only",
+      },
+    ]);
+  });
+});

--- a/src/lifecycle/webhook-replay.test.ts
+++ b/src/lifecycle/webhook-replay.test.ts
@@ -189,6 +189,25 @@ describe("replayQueuedWebhook", () => {
     expect(processed).toHaveLength(0);
   });
 
+  test("normalizes malformed GitHub installation id to the legacy sentinel", async () => {
+    const dispatched: WebhookEvent[] = [];
+
+    await replayQueuedWebhook({
+      entry: {
+        id: 6,
+        source: "github",
+        deliveryId: "delivery-malformed-installation",
+        eventName: "issues",
+        headers: {},
+        body: JSON.stringify({ installation: { id: "123" }, action: "opened" }),
+      },
+      ...createBaseReplayParams({ dispatched }),
+    });
+
+    expect(dispatched).toHaveLength(1);
+    expect(dispatched[0]!.installationId).toBe(0);
+  });
+
   test("shared replay-time Slack thread store allows queued thread follow-up after bootstrap", async () => {
     const sharedStore = createSlackThreadSessionStore();
     const processedWithSharedStore: SlackV1BootstrapPayload[] = [];

--- a/src/lifecycle/webhook-replay.test.ts
+++ b/src/lifecycle/webhook-replay.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import type { Logger } from "pino";
 import type { AppConfig } from "../config.ts";
 import type { SlackV1BootstrapPayload } from "../slack/safety-rails.ts";
+import { createSlackThreadSessionStore } from "../slack/thread-session-store.ts";
 import type { WebhookEvent } from "../webhook/types.ts";
 import { replayQueuedWebhook } from "./webhook-replay.ts";
 
@@ -46,6 +47,25 @@ function createTestConfig(): AppConfig {
   };
 }
 
+function createBaseReplayParams(overrides?: {
+  processed?: SlackV1BootstrapPayload[];
+  dispatched?: WebhookEvent[];
+}) {
+  const processed = overrides?.processed ?? [];
+  const dispatched = overrides?.dispatched ?? [];
+
+  return {
+    config: createTestConfig(),
+    logger: createTestLogger(),
+    dispatchGitHubEvent: async (event: WebhookEvent) => {
+      dispatched.push(event);
+    },
+    handleSlackAllowedEvent: async (payload: SlackV1BootstrapPayload) => {
+      processed.push(payload);
+    },
+  };
+}
+
 describe("replayQueuedWebhook", () => {
   test("replays queued GitHub webhook through the event router", async () => {
     const dispatched: WebhookEvent[] = [];
@@ -59,12 +79,7 @@ describe("replayQueuedWebhook", () => {
         headers: {},
         body: JSON.stringify({ installation: { id: 123 }, action: "opened" }),
       },
-      config: createTestConfig(),
-      logger: createTestLogger(),
-      dispatchGitHubEvent: async (event) => {
-        dispatched.push(event);
-      },
-      handleSlackBootstrap: async () => undefined,
+      ...createBaseReplayParams({ dispatched }),
     });
 
     expect(dispatched).toEqual([
@@ -97,12 +112,7 @@ describe("replayQueuedWebhook", () => {
           },
         }),
       },
-      config: createTestConfig(),
-      logger: createTestLogger(),
-      dispatchGitHubEvent: async () => undefined,
-      handleSlackBootstrap: async (payload) => {
-        processed.push(payload);
-      },
+      ...createBaseReplayParams({ processed }),
     });
 
     expect(processed).toHaveLength(0);
@@ -128,12 +138,7 @@ describe("replayQueuedWebhook", () => {
           },
         }),
       },
-      config: createTestConfig(),
-      logger: createTestLogger(),
-      dispatchGitHubEvent: async () => undefined,
-      handleSlackBootstrap: async (payload) => {
-        processed.push(payload);
-      },
+      ...createBaseReplayParams({ processed }),
     });
 
     expect(processed).toEqual([
@@ -146,5 +151,103 @@ describe("replayQueuedWebhook", () => {
         replyTarget: "thread-only",
       },
     ]);
+  });
+
+  test("ignores malformed GitHub JSON without dispatching", async () => {
+    const dispatched: WebhookEvent[] = [];
+
+    const result = await replayQueuedWebhook({
+      entry: {
+        id: 4,
+        source: "github",
+        deliveryId: "delivery-malformed-github",
+        eventName: "issues",
+        headers: {},
+        body: "{not-json",
+      },
+      ...createBaseReplayParams({ dispatched }),
+    });
+
+    expect(result).toEqual({ status: "ignored", source: "github", reason: "malformed_json" });
+    expect(dispatched).toHaveLength(0);
+  });
+
+  test("ignores malformed Slack JSON without dispatching", async () => {
+    const processed: SlackV1BootstrapPayload[] = [];
+
+    const result = await replayQueuedWebhook({
+      entry: {
+        id: 5,
+        source: "slack",
+        headers: {},
+        body: "{not-json",
+      },
+      ...createBaseReplayParams({ processed }),
+    });
+
+    expect(result).toEqual({ status: "ignored", source: "slack", reason: "malformed_json" });
+    expect(processed).toHaveLength(0);
+  });
+
+  test("shared replay-time Slack thread store allows queued thread follow-up after bootstrap", async () => {
+    const sharedStore = createSlackThreadSessionStore();
+    const processedWithSharedStore: SlackV1BootstrapPayload[] = [];
+    const processedWithoutSharedStore: SlackV1BootstrapPayload[] = [];
+
+    const bootstrapEntry = {
+      id: 6,
+      source: "slack" as const,
+      headers: {},
+      body: JSON.stringify({
+        type: "event_callback",
+        event: {
+          type: "message",
+          channel: "C123KODIAI",
+          channel_type: "channel",
+          ts: "1700000000.000888",
+          user: "U888USER",
+          text: "<@U123BOT> start thread",
+        },
+      }),
+    };
+    const followUpEntry = {
+      id: 7,
+      source: "slack" as const,
+      headers: {},
+      body: JSON.stringify({
+        type: "event_callback",
+        event: {
+          type: "message",
+          channel: "C123KODIAI",
+          channel_type: "channel",
+          ts: "1700000000.000889",
+          thread_ts: "1700000000.000888",
+          user: "U888USER",
+          text: "follow-up without mention token",
+        },
+      }),
+    };
+
+    await replayQueuedWebhook({
+      entry: bootstrapEntry,
+      slackThreadSessionStore: sharedStore,
+      ...createBaseReplayParams({ processed: processedWithSharedStore }),
+    });
+    await replayQueuedWebhook({
+      entry: followUpEntry,
+      slackThreadSessionStore: sharedStore,
+      ...createBaseReplayParams({ processed: processedWithSharedStore }),
+    });
+
+    await replayQueuedWebhook({
+      entry: followUpEntry,
+      ...createBaseReplayParams({ processed: processedWithoutSharedStore }),
+    });
+
+    expect(processedWithSharedStore.map((payload) => payload.text)).toEqual([
+      "<@U123BOT> start thread",
+      "follow-up without mention token",
+    ]);
+    expect(processedWithoutSharedStore).toHaveLength(0);
   });
 });

--- a/src/lifecycle/webhook-replay.ts
+++ b/src/lifecycle/webhook-replay.ts
@@ -30,7 +30,8 @@ export async function replayQueuedWebhook(params: {
       logger.warn({ err, id: entry.id, source: entry.source }, "Failed to parse queued GitHub webhook body");
       return { status: "ignored", source: "github", reason: "malformed_json" };
     }
-    const installation = payload.installation as { id: number } | undefined;
+    const installation = payload.installation as { id?: unknown } | undefined;
+    const installationId = typeof installation?.id === "number" ? installation.id : 0;
     if (typeof installation?.id !== "number") {
       logger.warn({ id: entry.id, source: entry.source }, "Queued GitHub webhook replay missing installation id; dispatching with legacy sentinel");
     }
@@ -38,7 +39,7 @@ export async function replayQueuedWebhook(params: {
       id: entry.deliveryId ?? `replay-${entry.id}`,
       name: entry.eventName ?? "unknown",
       payload,
-      installationId: installation?.id ?? 0,
+      installationId,
     });
     return { status: "dispatched", source: "github" };
   }

--- a/src/lifecycle/webhook-replay.ts
+++ b/src/lifecycle/webhook-replay.ts
@@ -8,6 +8,7 @@ import type { WebhookQueueEntry } from "./types.ts";
 
 export type ReplayQueuedWebhookResult =
   | { status: "dispatched"; source: "github" | "slack" }
+  | { status: "ignored"; source: "github" | "slack"; reason: "malformed_json" }
   | { status: "ignored"; source: "slack"; reason: string }
   | { status: "ignored"; source: string; reason: "unsupported_source" };
 
@@ -16,14 +17,23 @@ export async function replayQueuedWebhook(params: {
   config: AppConfig;
   logger: Logger;
   dispatchGitHubEvent: (event: WebhookEvent) => Promise<void> | void;
-  handleSlackBootstrap: (payload: SlackV1BootstrapPayload) => Promise<void> | void;
+  handleSlackAllowedEvent: (payload: SlackV1BootstrapPayload) => Promise<void> | void;
   slackThreadSessionStore?: SlackThreadSessionStore;
 }): Promise<ReplayQueuedWebhookResult> {
-  const { entry, config, logger, dispatchGitHubEvent, handleSlackBootstrap } = params;
+  const { entry, config, logger, dispatchGitHubEvent, handleSlackAllowedEvent } = params;
 
   if (entry.source === "github") {
-    const payload = JSON.parse(entry.body) as Record<string, unknown>;
+    let payload: Record<string, unknown>;
+    try {
+      payload = JSON.parse(entry.body) as Record<string, unknown>;
+    } catch (err) {
+      logger.warn({ err, id: entry.id, source: entry.source }, "Failed to parse queued GitHub webhook body");
+      return { status: "ignored", source: "github", reason: "malformed_json" };
+    }
     const installation = payload.installation as { id: number } | undefined;
+    if (typeof installation?.id !== "number") {
+      logger.warn({ id: entry.id, source: entry.source }, "Queued GitHub webhook replay missing installation id; dispatching with legacy sentinel");
+    }
     await dispatchGitHubEvent({
       id: entry.deliveryId ?? `replay-${entry.id}`,
       name: entry.eventName ?? "unknown",
@@ -34,7 +44,13 @@ export async function replayQueuedWebhook(params: {
   }
 
   if (entry.source === "slack") {
-    const payload = JSON.parse(entry.body) as unknown;
+    let payload: unknown;
+    try {
+      payload = JSON.parse(entry.body) as unknown;
+    } catch (err) {
+      logger.warn({ err, id: entry.id, source: entry.source }, "Failed to parse queued Slack webhook body");
+      return { status: "ignored", source: "slack", reason: "malformed_json" };
+    }
     const eventCallback = toSlackEventCallback(payload);
     if (!eventCallback) {
       logger.info({ id: entry.id, source: entry.source, reason: "unsupported_payload" }, "Queued Slack webhook replay ignored");
@@ -65,7 +81,7 @@ export async function replayQueuedWebhook(params: {
       }
     }
 
-    await handleSlackBootstrap(decision.bootstrap);
+    await handleSlackAllowedEvent(decision.bootstrap);
     return { status: "dispatched", source: "slack" };
   }
 

--- a/src/lifecycle/webhook-replay.ts
+++ b/src/lifecycle/webhook-replay.ts
@@ -1,0 +1,74 @@
+import type { Logger } from "pino";
+import type { AppConfig } from "../config.ts";
+import { evaluateSlackV1Rails, type SlackV1BootstrapPayload } from "../slack/safety-rails.ts";
+import { createSlackThreadSessionStore, type SlackThreadSessionStore } from "../slack/thread-session-store.ts";
+import { toSlackEventCallback } from "../slack/types.ts";
+import type { WebhookEvent } from "../webhook/types.ts";
+import type { WebhookQueueEntry } from "./types.ts";
+
+export type ReplayQueuedWebhookResult =
+  | { status: "dispatched"; source: "github" | "slack" }
+  | { status: "ignored"; source: "slack"; reason: string }
+  | { status: "ignored"; source: string; reason: "unsupported_source" };
+
+export async function replayQueuedWebhook(params: {
+  entry: WebhookQueueEntry;
+  config: AppConfig;
+  logger: Logger;
+  dispatchGitHubEvent: (event: WebhookEvent) => Promise<void> | void;
+  handleSlackBootstrap: (payload: SlackV1BootstrapPayload) => Promise<void> | void;
+  slackThreadSessionStore?: SlackThreadSessionStore;
+}): Promise<ReplayQueuedWebhookResult> {
+  const { entry, config, logger, dispatchGitHubEvent, handleSlackBootstrap } = params;
+
+  if (entry.source === "github") {
+    const payload = JSON.parse(entry.body) as Record<string, unknown>;
+    const installation = payload.installation as { id: number } | undefined;
+    await dispatchGitHubEvent({
+      id: entry.deliveryId ?? `replay-${entry.id}`,
+      name: entry.eventName ?? "unknown",
+      payload,
+      installationId: installation?.id ?? 0,
+    });
+    return { status: "dispatched", source: "github" };
+  }
+
+  if (entry.source === "slack") {
+    const payload = JSON.parse(entry.body) as unknown;
+    const eventCallback = toSlackEventCallback(payload);
+    if (!eventCallback) {
+      logger.info({ id: entry.id, source: entry.source, reason: "unsupported_payload" }, "Queued Slack webhook replay ignored");
+      return { status: "ignored", source: "slack", reason: "unsupported_payload" };
+    }
+
+    const threadSessionStore = params.slackThreadSessionStore ?? createSlackThreadSessionStore();
+    const decision = evaluateSlackV1Rails({
+      payload: eventCallback,
+      slackBotUserId: config.slackBotUserId,
+      slackKodiaiChannelId: config.slackKodiaiChannelId,
+      isThreadSessionStarted: ({ channel, threadTs }) => threadSessionStore.isThreadStarted({ channel, threadTs }),
+    });
+
+    if (decision.decision === "ignore") {
+      logger.info({ id: entry.id, source: entry.source, reason: decision.reason }, "Queued Slack webhook replay ignored by safety rails");
+      return { status: "ignored", source: "slack", reason: decision.reason };
+    }
+
+    if (decision.reason === "mention_only_bootstrap") {
+      const started = threadSessionStore.markThreadStarted({
+        channel: decision.bootstrap.channel,
+        threadTs: decision.bootstrap.threadTs,
+      });
+      if (!started) {
+        logger.info({ id: entry.id, source: entry.source, reason: "duplicate_bootstrap" }, "Queued Slack webhook replay ignored as duplicate thread starter");
+        return { status: "ignored", source: "slack", reason: "duplicate_bootstrap" };
+      }
+    }
+
+    await handleSlackBootstrap(decision.bootstrap);
+    return { status: "dispatched", source: "slack" };
+  }
+
+  logger.warn({ id: entry.id, source: entry.source }, "Queued webhook replay ignored: unsupported source");
+  return { status: "ignored", source: entry.source, reason: "unsupported_source" };
+}


### PR DESCRIPTION
## Summary

Fixes Slack queued-webhook startup replay so replayed Slack events pass through the same safety rails as live Slack events instead of reconstructing a bootstrap payload directly.

Changes:
- Adds `replayQueuedWebhook(...)` as a focused replay unit for GitHub and Slack queue entries.
- Routes queued Slack replay through `toSlackEventCallback(...)` + `evaluateSlackV1Rails(...)` before dispatching to the Slack assistant handler.
- Preserves GitHub replay behavior through the same extracted unit.
- Shares a replay-time Slack thread-session store across queued entries so a queued bootstrap can authorize later queued thread follow-ups.
- Adds regression coverage for GitHub replay, Slack wrong-channel replay suppression, and valid Slack mention replay.

## Verification

- `bun test ./src/lifecycle/webhook-replay.test.ts ./src/routes/slack-events.test.ts ./src/routes/webhooks.test.ts` → 21 pass, 0 fail
- `bun run tsc --noEmit` → pass
- `git diff --check` → pass
- `bun run lint` → pass
