### PR TITLE
Route tiny reviews through small-diff fast path

### DIFF
--- a/src/execution/agent-entrypoint.test.ts
+++ b/src/execution/agent-entrypoint.test.ts
@@ -3,13 +3,33 @@ import { mkdtemp, mkdir, rm, symlink, writeFile, lstat } from "node:fs/promises"
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { $ } from "bun";
-import { main, MCP_SERVER_NAMES } from "./agent-entrypoint.ts";
+import { main, MCP_SERVER_NAMES, extractNormalizedToolTarget } from "./agent-entrypoint.ts";
 import type { EntrypointDeps } from "./agent-entrypoint.ts";
 import type { Query, SDKResultMessage, SDKRateLimitInfo } from "@anthropic-ai/claude-agent-sdk";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+describe("extractNormalizedToolTarget", () => {
+  test("normalizes tool targets without raw output", () => {
+    expect(extractNormalizedToolTarget({
+      type: "tool_use",
+      name: "Bash",
+      input: { command: "git diff origin/master...HEAD -- file.cpp" },
+    })).toBe("git diff");
+    expect(extractNormalizedToolTarget({
+      type: "tool_use",
+      name: "Read",
+      input: { file_path: "src/file.ts" },
+    })).toBe("src/file.ts");
+    expect(extractNormalizedToolTarget({
+      type: "tool_use",
+      name: "Grep",
+      input: { pattern: "ClassPathToName" },
+    })).toBe("ClassPathToName");
+  });
+});
 
 /** Minimal valid agent config JSON */
 const VALID_AGENT_CONFIG = JSON.stringify({

--- a/src/execution/agent-entrypoint.ts
+++ b/src/execution/agent-entrypoint.ts
@@ -77,7 +77,7 @@ function defaultDeps(): EntrypointDeps {
   };
 }
 
-type AssistantContentPart = {
+export type AssistantContentPart = {
   type?: string;
   name?: string;
   input?: unknown;
@@ -107,6 +107,32 @@ function extractToolCommand(input: unknown): string | undefined {
     const candidate = (input as { command?: unknown }).command;
     return typeof candidate === "string" ? candidate : undefined;
   }
+  return undefined;
+}
+
+export function extractNormalizedToolTarget(part: AssistantContentPart): string | undefined {
+  if (part.type !== "tool_use" || typeof part.input !== "object" || part.input === null) {
+    return undefined;
+  }
+
+  const input = part.input as Record<string, unknown>;
+  if (typeof input.command === "string") {
+    const [program, ...rest] = input.command.trim().split(/\s+/);
+    if (program === "git" && typeof rest[0] === "string") {
+      return `git ${rest[0]}`;
+    }
+    return program || "bash";
+  }
+  if (typeof input.file_path === "string") {
+    return input.file_path;
+  }
+  if (typeof input.pattern === "string") {
+    return input.pattern.slice(0, 80);
+  }
+  if (typeof input.glob === "string") {
+    return input.glob.slice(0, 80);
+  }
+
   return undefined;
 }
 
@@ -278,6 +304,7 @@ export async function main(deps?: Partial<EntrypointDeps>): Promise<void> {
     let lastRateLimitEvent: SDKRateLimitEvent | undefined;
     const toolUseNames: string[] = [];
     let usedRepoInspectionTools = false;
+    let currentTurn = 0;
 
     for await (const message of sdkQueryResult) {
       if (message.type === "system" && (message as SystemInitMessage).subtype === "init") {
@@ -295,6 +322,7 @@ export async function main(deps?: Partial<EntrypointDeps>): Promise<void> {
           `sdk init tools=${initTools.join(",") || "none"} mcpServers=${initMcpServers.join(",") || "none"}`,
         );
       } else if (message.type === "assistant") {
+        currentTurn++;
         const parts = ((message as { message?: { content?: AssistantContentPart[] } }).message?.content ?? []) as AssistantContentPart[];
         for (const part of parts) {
           const toolName = extractToolUseName(part);
@@ -306,6 +334,10 @@ export async function main(deps?: Partial<EntrypointDeps>): Promise<void> {
           }
           if (isRepoInspectionToolUse(part)) {
             usedRepoInspectionTools = true;
+          }
+          const target = extractNormalizedToolTarget(part);
+          if (target) {
+            await appendDiagnostic(`turn=${currentTurn} tool=${toolName} target=${target}`);
           }
         }
       } else if (message.type === "result") {

--- a/src/execution/executor.test.ts
+++ b/src/execution/executor.test.ts
@@ -471,17 +471,27 @@ function createTestableExecutor(deps: {
 
         const hasGitTools = await $`git -C ${context.workspace.dir} rev-parse --is-inside-work-tree`.quiet().nothrow()
           .then((result) => result.exitCode === 0 && result.stdout.toString().trim() === "true");
+        const { TASK_TYPES } = await import("../llm/task-types.ts");
+        const { SMALL_DIFF_REVIEW_BASE_TOOLS } = await import("../lib/review-routing.ts");
+        const isSmallDiffReview = taskType === TASK_TYPES.REVIEW_SMALL_DIFF;
         const isReadOnlyPrMention =
           isMentionEvent &&
           !isWriteMode &&
           context.prNumber !== undefined &&
-          taskType !== "review.full";
-        const baseTools = isReadOnlyPrMention
-          ? ["Read", "Grep", ...(hasGitTools ? ["Bash(git diff:*)", "Bash(git status:*)"] : [])]
-          : ["Read", "Grep", "Glob", ...(hasGitTools ? ["Bash(git diff:*)", "Bash(git log:*)", "Bash(git show:*)", "Bash(git status:*)"] : [])];
+          taskType === TASK_TYPES.MENTION_RESPONSE;
+        const baseTools = isSmallDiffReview
+          ? [
+              "Read",
+              "Grep",
+              "Glob",
+              ...(hasGitTools ? SMALL_DIFF_REVIEW_BASE_TOOLS.filter((tool) => tool.startsWith("Bash(")) : []),
+            ]
+          : isReadOnlyPrMention
+            ? ["Read", "Grep", ...(hasGitTools ? ["Bash(git diff:*)", "Bash(git status:*)"] : [])]
+            : ["Read", "Grep", "Glob", ...(hasGitTools ? ["Bash(git diff:*)", "Bash(git log:*)", "Bash(git show:*)", "Bash(git status:*)"] : [])];
         const writeTools = isWriteMode ? ["Edit", "Write", "MultiEdit"] : [];
         const mcpTools = buildAllowedMcpTools(Object.keys(mcpServers));
-        const allowedTools = [...baseTools, ...writeTools, ...mcpTools];
+        const allowedTools = context.allowedToolsOverride ?? [...baseTools, ...writeTools, ...mcpTools];
 
         const { buildPrompt } = await import("./prompt.ts");
         const prompt = context.prompt ?? buildPrompt(context);
@@ -1222,6 +1232,67 @@ test("ACA dispatch: explicit review mention stages a review bundle transport wit
     baseRef: "main",
     originUrl: "https://github.com/xbmc/xbmc.git",
   });
+});
+
+test("ACA dispatch: explicit small-diff review mention uses constrained review toolset", async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), "kodiai-executor-test-"));
+  const sourceRepoDir = join(tmpDir, "source");
+  await mkdir(join(sourceRepoDir, "src"), { recursive: true });
+  await writeFile(join(sourceRepoDir, "src", "feature.ts"), "export const feature = 'base';\n");
+  await $`git -C ${sourceRepoDir} init --initial-branch=main`.quiet();
+  await $`git -C ${sourceRepoDir} config user.email test@example.com`.quiet();
+  await $`git -C ${sourceRepoDir} config user.name "Test User"`.quiet();
+  await $`git -C ${sourceRepoDir} remote add origin https://github.com/xbmc/xbmc.git`.quiet();
+  await $`git -C ${sourceRepoDir} add .`.quiet();
+  await $`git -C ${sourceRepoDir} commit -m base`.quiet();
+  await $`git -C ${sourceRepoDir} branch -M main`.quiet();
+  await $`git -C ${sourceRepoDir} checkout -b pr-mention`.quiet();
+  await writeFile(join(sourceRepoDir, "src", "feature.ts"), "export const feature = 'updated';\n");
+  await $`git -C ${sourceRepoDir} commit -am feature`.quiet();
+  await $`git -C ${sourceRepoDir} update-ref refs/remotes/origin/main $(git -C ${sourceRepoDir} rev-parse main)`.quiet();
+
+  const config = makeConfig();
+  const logger = makeLogger();
+  const registry = createMcpJobRegistry();
+
+  const executor = createTestableExecutor({
+    githubApp: makeGithubApp(),
+    logger,
+    config,
+    mcpJobRegistry: registry,
+    launchFn: async () => ({ executionName: "exec-small-diff-review" }),
+    pollFn: async () => ({ status: "succeeded", durationMs: 1000 }),
+    readResultFn: async () => makeJobResult(),
+    createWorkspaceDirFn: async () => tmpDir!,
+  });
+
+  await executor.execute(
+    makeContext(sourceRepoDir, {
+      eventType: "issue_comment.created",
+      prNumber: 80,
+      taskType: "review.small-diff",
+      maxTurnsOverride: 8,
+      enableInlineTools: true,
+    }),
+  );
+
+  const rawAgentConfig = await readFile(join(tmpDir!, "agent-config.json"), "utf-8");
+  const agentConfig = JSON.parse(rawAgentConfig) as {
+    maxTurns: number;
+    allowedTools: string[];
+    taskType: string;
+  };
+
+  expect(agentConfig.taskType).toBe("review.small-diff");
+  expect(agentConfig.maxTurns).toBe(8);
+  expect(agentConfig.allowedTools).toContain("Read");
+  expect(agentConfig.allowedTools).toContain("Grep");
+  expect(agentConfig.allowedTools).toContain("Glob");
+  expect(agentConfig.allowedTools).toContain("Bash(git diff:*)");
+  expect(agentConfig.allowedTools).toContain("Bash(git show:*)");
+  expect(agentConfig.allowedTools).not.toContain("Bash(git log:*)");
+  expect(agentConfig.allowedTools).not.toContain("Bash(git status:*)");
+  expect(agentConfig.allowedTools).toContain("mcp__github_inline_comment__create_inline_comment");
 });
 
 test("ACA dispatch: conversational PR mention keeps reduced toolset", async () => {

--- a/src/execution/executor.ts
+++ b/src/execution/executor.ts
@@ -31,6 +31,8 @@ import {
   createAzureFilesWorkspaceDir,
 } from "../jobs/workspace.ts";
 import type { PromptSectionRecord } from "../telemetry/types.ts";
+import { TASK_TYPES } from "../llm/task-types.ts";
+import { SMALL_DIFF_REVIEW_BASE_TOOLS } from "../lib/review-routing.ts";
 
 export function buildSecurityClaudeMd(): string {
   return `# Security Policy
@@ -434,31 +436,41 @@ export function createExecutor(deps: {
         // handler for trigger semantics, but they still need the broader review tool
         // budget. Only conversational PR mentions keep the reduced tool surface.
         const hasGitTools = await hasGitWorkspace(context.workspace.dir);
+        const isSmallDiffReview = taskType === TASK_TYPES.REVIEW_SMALL_DIFF;
         const isReadOnlyPrMention =
           isMentionEvent &&
           !isWriteMode &&
           context.prNumber !== undefined &&
-          taskType !== "review.full";
-        const baseTools = isReadOnlyPrMention
+          taskType === TASK_TYPES.MENTION_RESPONSE;
+        const baseTools = isSmallDiffReview
           ? [
-              "Read",
-              "Grep",
-              ...(hasGitTools ? ["Bash(git diff:*)", "Bash(git status:*)"] : []),
-            ]
-          : [
               "Read",
               "Grep",
               "Glob",
               ...(hasGitTools
-                ? ["Bash(git diff:*)", "Bash(git log:*)", "Bash(git show:*)", "Bash(git status:*)"]
+                ? SMALL_DIFF_REVIEW_BASE_TOOLS.filter((tool) => tool.startsWith("Bash("))
                 : []),
-            ];
+            ]
+          : isReadOnlyPrMention
+            ? [
+                "Read",
+                "Grep",
+                ...(hasGitTools ? ["Bash(git diff:*)", "Bash(git status:*)"] : []),
+              ]
+            : [
+                "Read",
+                "Grep",
+                "Glob",
+                ...(hasGitTools
+                  ? ["Bash(git diff:*)", "Bash(git log:*)", "Bash(git show:*)", "Bash(git status:*)"]
+                  : []),
+              ];
 
         const writeTools = isWriteMode ? ["Edit", "Write", "MultiEdit"] : [];
         // Compute server names from the same deps (no instance construction yet)
         const mcpServerNames = Object.keys(buildMcpServerFactories(mcpServerDeps));
         const mcpTools = buildAllowedMcpTools(mcpServerNames);
-        const allowedTools = [...baseTools, ...writeTools, ...mcpTools];
+        const allowedTools = context.allowedToolsOverride ?? [...baseTools, ...writeTools, ...mcpTools];
 
         // Build prompt
         const prompt = context.prompt ?? buildPrompt(context);

--- a/src/execution/review-prompt.test.ts
+++ b/src/execution/review-prompt.test.ts
@@ -16,6 +16,7 @@ import {
   buildReviewedCategoriesLine,
   buildReviewPrompt,
   buildReviewPromptDetails,
+  buildSmallDiffScopeSection,
   buildSuppressionRulesSection,
   buildToneGuidelinesSection,
   buildEpistemicBoundarySection,
@@ -28,6 +29,24 @@ import {
 import type { ClusterPatternMatch } from "../knowledge/cluster-types.ts";
 import { projectContributorExperienceContract } from "../contributor/experience-contract.ts";
 import type { StructuralImpactPayload } from "../structural-impact/types.ts";
+
+describe("small-diff review prompt scope", () => {
+  test("adds a tiny-diff scope contract when requested", () => {
+    const result = buildReviewPromptDetails(baseContext({ smallDiffReview: true }));
+
+    expect(buildSmallDiffScopeSection()).toContain("Inspect `git diff` first.");
+    expect(result.text).toContain("## Tiny-diff scope contract");
+    expect(result.text).toContain("Do not do generalized architecture exploration.");
+    expect(result.sections.some((section) => section.sectionName === "review-small-diff-scope")).toBe(true);
+  });
+
+  test("omits the tiny-diff scope contract for normal reviews", () => {
+    const result = buildReviewPromptDetails(baseContext());
+
+    expect(result.text).not.toContain("## Tiny-diff scope contract");
+    expect(result.sections.some((section) => section.sectionName === "review-small-diff-scope")).toBe(false);
+  });
+});
 
 function baseContext(overrides: Record<string, unknown> = {}) {
   return {

--- a/src/execution/review-prompt.ts
+++ b/src/execution/review-prompt.ts
@@ -1605,6 +1605,20 @@ function buildDepBumpSection(ctx: DepBumpContext): string {
   return lines.join("\n");
 }
 
+export function buildSmallDiffScopeSection(): string {
+  return [
+    "## Tiny-diff scope contract",
+    "",
+    "This is a small diff (≤2 files, ≤20 lines). Follow these constraints:",
+    "- Inspect `git diff` first.",
+    "- Read only the changed file and directly adjacent context.",
+    "- Broaden scope only if the diff itself proves an ambiguity that cannot be resolved without wider context.",
+    "- Do not do generalized architecture exploration.",
+    "- If no actionable issue exists, end without additional exploratory turns.",
+    "- Produce a merge decision after one focused inspection pass.",
+  ].join("\n");
+}
+
 /**
  * Build the system prompt for PR auto-review.
  *
@@ -1624,6 +1638,7 @@ export function buildReviewPromptDetails(context: {
   changedFiles: string[];
   customInstructions?: string;
   checkpointEnabled?: boolean;
+  smallDiffReview?: boolean;
   // Review mode & severity control fields
   mode?: "standard" | "enhanced";
   severityMinLevel?: "critical" | "major" | "medium" | "minor";
@@ -1767,6 +1782,10 @@ export function buildReviewPromptDetails(context: {
     prContextLines.push("", "PR description:", "---", prBodyTruncated.text, "---");
   }
   pushSection("review-pr-context", prContextLines);
+
+  if (context.smallDiffReview) {
+    pushSection("review-small-diff-scope", buildSmallDiffScopeSection().split("\n"));
+  }
 
   const changeContextLines = ["Changed files:"];
   for (const file of changedFilesCapped) {
@@ -2309,6 +2328,7 @@ export function buildReviewPrompt(context: {
   changedFiles: string[];
   customInstructions?: string;
   checkpointEnabled?: boolean;
+  smallDiffReview?: boolean;
   mode?: "standard" | "enhanced";
   severityMinLevel?: "critical" | "major" | "medium" | "minor";
   focusAreas?: string[];

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -58,6 +58,9 @@ export type ExecutionContext = {
   /** Optional max turns override. When set, overrides config.maxTurns. */
   maxTurnsOverride?: number;
 
+  /** Optional allowed-tools override. When set, replaces the default base/write/MCP tool list. */
+  allowedToolsOverride?: string[];
+
   /** Optional model override. When set, overrides config.model. */
   modelOverride?: string;
 

--- a/src/handlers/mention.test.ts
+++ b/src/handlers/mention.test.ts
@@ -7875,6 +7875,10 @@ describe("createMentionHandler review command", () => {
 
     expect(issueReplies).toHaveLength(1);
     expect(issueReplies[0]).toContain("I ran out of steps analyzing this and wasn't able to post a complete response.");
+    expect(issueReplies[0]).toContain("This was a tiny-diff review");
+    expect(issueReplies[0]).toContain("small-diff routing diagnostics");
+    expect(issueReplies[0]).not.toContain("Ask a more targeted question");
+    expect(issueReplies[0]).not.toContain("This can happen on PRs with large or complex diffs");
     expect(issueReplies[0]).not.toContain("I completed the review run but couldn't publish a GitHub review/comment from it.");
 
     await workspaceFixture.cleanup();
@@ -9026,7 +9030,7 @@ describe("createMentionHandler review command", () => {
     );
 
     expect(capturedQueueLane).toBe("interactive-review");
-    expect(capturedTaskType).toBe("review.full");
+    expect(capturedTaskType).toBe("review.small-diff");
 
     expect(createdReviews).toHaveLength(1);
     expect(createdReviews[0]?.event).toBe("APPROVE");
@@ -10247,7 +10251,7 @@ describe("createMentionHandler review command", () => {
       }),
     );
 
-    expect(capturedTaskType).toBe("review.full");
+    expect(capturedTaskType).toBe("review.small-diff");
     expect(capturedReviewOutputKey).toBeDefined();
     expect(capturedReviewOutputKey).toContain("kodiai-review-output:v1:");
 
@@ -10361,14 +10365,15 @@ describe("createMentionHandler review command", () => {
       }),
     );
 
-    expect(capturedTaskType).toBe("review.full");
+    expect(capturedTaskType).toBe("review.small-diff");
     expect(capturedReviewOutputKey).toBeDefined();
     expect(capturedReviewOutputKey).toContain("kodiai-review-output:v1:");
     expect(capturedTriggerBody).toBe("review");
     expect(capturedPrompt).toContain("You are reviewing pull request #102 in acme/repo.");
     expect(capturedPrompt).toContain("If NO issues found: do nothing -- no summary, no comments. The calling code handles silent approval.");
+    expect(capturedPrompt).toContain("## Tiny-diff scope contract");
     expect(capturedPrompt).not.toContain("You MUST post a reply when you are mentioned.");
-    expect(capturedMaxTurnsOverride).toBeUndefined();
+    expect(capturedMaxTurnsOverride).toBe(8);
     expect(capturedEnableInlineTools).toBe(true);
 
     await workspaceFixture.cleanup();
@@ -10749,11 +10754,11 @@ describe("createMentionHandler review command", () => {
       }),
     );
 
-    expect(capturedTaskType).toBe("review.full");
+    expect(capturedTaskType).toBe("review.small-diff");
     expect(capturedReviewOutputKey).toBeDefined();
     expect(capturedReviewOutputKey).toContain("kodiai-review-output:v1:");
     expect(capturedTriggerBody).toBe("please retry review");
-    expect(capturedMaxTurnsOverride).toBeUndefined();
+    expect(capturedMaxTurnsOverride).toBe(8);
 
     await workspaceFixture.cleanup();
   });

--- a/src/handlers/mention.ts
+++ b/src/handlers/mention.ts
@@ -50,6 +50,12 @@ import {
 import { buildIssueCodeContext } from "../execution/issue-code-context.ts";
 import { buildMentionPrompt, buildMentionPromptDetails } from "../execution/mention-prompt.ts";
 import { buildReviewPrompt, buildReviewPromptDetails, matchPathInstructions } from "../execution/review-prompt.ts";
+import { TASK_TYPES } from "../llm/task-types.ts";
+import {
+  resolveReviewRoutingLineCount,
+  resolveReviewTaskRouting,
+  type ReviewTaskRouting,
+} from "../lib/review-routing.ts";
 import { buildPromptSectionRecord, type PromptBuildResult } from "../execution/prompt-section-metrics.ts";
 import { buildRetrievalVariants } from "../knowledge/multi-query-retrieval.ts";
 import { analyzeDiff, classifyFileLanguage, parseNumstatPerFile } from "../execution/diff-analysis.ts";
@@ -2369,6 +2375,10 @@ export function createMentionHandler(deps: {
         let prompt: string;
         let promptSections: import("../telemetry/types.ts").PromptSectionRecord[] = [];
         let explicitReviewPromptFileCount: number | undefined;
+        let explicitReviewRouting: ReviewTaskRouting = {
+          taskType: TASK_TYPES.REVIEW_FULL,
+          routingReason: "standard",
+        };
         if (explicitReviewRequest && mention.prNumber !== undefined) {
           const explicitReviewPrNumber = mention.prNumber;
           const { data: explicitReviewPr } = await octokit.rest.pulls.get({
@@ -2405,6 +2415,33 @@ export function createMentionHandler(deps: {
             numstatLines: promptDiffContext.numstatLines,
             fileCategories: config.review.fileCategories as Record<string, string[]> | undefined,
           });
+          const diffAnalysisLinesChanged = (diffAnalysis.metrics.totalLinesAdded ?? 0) +
+            (diffAnalysis.metrics.totalLinesRemoved ?? 0);
+          const prApiLinesChanged = (explicitReviewPr.additions ?? 0) + (explicitReviewPr.deletions ?? 0);
+          const explicitReviewLinesChanged = resolveReviewRoutingLineCount({
+            diffLinesChanged: diffAnalysisLinesChanged,
+            prApiLinesChanged,
+          });
+          explicitReviewRouting = resolveReviewTaskRouting({
+            changedFileCount: promptChangedFiles.length,
+            linesChanged: explicitReviewLinesChanged,
+          });
+          logger.info(
+            {
+              surface: mention.surface,
+              owner: mention.owner,
+              repo: mention.repo,
+              prNumber: mention.prNumber,
+              gate: "review-routing",
+              taskType: explicitReviewRouting.taskType,
+              routingReason: explicitReviewRouting.routingReason,
+              changedFiles: promptChangedFiles.length,
+              linesChanged: explicitReviewLinesChanged,
+              maxTurns: explicitReviewRouting.maxTurnsOverride ?? null,
+              lane: "interactive-review",
+            },
+            "Mention review routing decision",
+          );
           const matchedPathInstructions = matchPathInstructions(
             config.review.pathInstructions,
             promptChangedFiles,
@@ -2463,6 +2500,7 @@ export function createMentionHandler(deps: {
             outputLanguage: config.review.outputLanguage,
             prLabels,
             isDraft: explicitReviewPr.draft,
+            smallDiffReview: explicitReviewRouting.taskType === TASK_TYPES.REVIEW_SMALL_DIFF,
             largePRContext: tieredFiles.isLargePR ? {
               fullReviewFiles: tieredFiles.full.map((file) => file.filePath),
               abbreviatedFiles: tieredFiles.abbreviated.map((file) => file.filePath),
@@ -2479,7 +2517,7 @@ export function createMentionHandler(deps: {
             buildPromptSectionRecord({
               deliveryId: event.id,
               repo: `${mention.owner}/${mention.repo}`,
-              taskType: "review.full",
+              taskType: explicitReviewRouting.taskType,
               promptKind: "review.user-prompt",
               sections: reviewPromptResult.sections,
             }),
@@ -2524,7 +2562,7 @@ export function createMentionHandler(deps: {
         // large PRs do not terminate mid-tool-call before any publish step occurs.
         const mentionMaxTurns =
           explicitReviewRequest
-            ? undefined
+            ? explicitReviewRouting.maxTurnsOverride
             : (!writeEnabled && mention.prNumber !== undefined)
               ? (prDiffContext !== undefined ? 12 : 20)
               : undefined; // undefined → falls through to config.maxTurns
@@ -2557,7 +2595,7 @@ export function createMentionHandler(deps: {
           deliveryId: event.id,
           botHandles: possibleHandles,
           writeMode: writeEnabled,
-          taskType: explicitReviewRequest ? "review.full" : "mention.response",
+          taskType: explicitReviewRequest ? explicitReviewRouting.taskType : "mention.response",
           eventType: `${event.name}.${action ?? ""}`.replace(/\.$/, ""),
           triggerBody: explicitReviewRequest ? userQuestion : mention.commentBody,
           prompt,
@@ -3796,9 +3834,15 @@ export function createMentionHandler(deps: {
               [
                 "I ran out of steps analyzing this and wasn't able to post a complete response.",
                 "",
-                "This can happen on PRs with large or complex diffs. To get a response:",
-                "- Ask a more targeted question (e.g. `@kodiai review LangInfo.cpp only`)",
-                "- Or mention me again — the next run may complete within the step budget",
+                ...(explicitReviewRouting.routingReason === "tiny-diff"
+                  ? [
+                      "This was a tiny-diff review, so this indicates an execution-budget or tool-loop problem rather than PR size. The run has been recorded with small-diff routing diagnostics.",
+                    ]
+                  : [
+                      "This can happen on PRs with large or complex diffs. To get a response:",
+                      "- Ask a more targeted question (e.g. `@kodiai review LangInfo.cpp only`)",
+                      "- Or mention me again — the next run may complete within the step budget",
+                    ]),
               ].join("\n"),
               "kodiai response",
             );

--- a/src/handlers/review.test.ts
+++ b/src/handlers/review.test.ts
@@ -12758,7 +12758,7 @@ describe("createReviewHandler review prompt section telemetry", () => {
 
     expect(promptSectionEntries).toHaveLength(1);
     expect(promptSectionEntries[0]?.promptKind).toBe("review.user-prompt");
-    expect(promptSectionEntries[0]?.taskType).toBe("review.full");
+    expect(promptSectionEntries[0]?.taskType).toBe("review.small-diff");
     expect(promptSectionEntries[0]?.sections.length).toBeGreaterThan(1);
     expect(promptSectionEntries[0]?.sections.map((section) => section.sectionName)).toEqual(
       expect.arrayContaining([
@@ -12945,7 +12945,7 @@ describe("createReviewHandler review prompt section telemetry", () => {
       "delivery-123-retry-1",
     ]);
     for (const entry of promptSectionEntries) {
-      expect(entry.taskType).toBe("review.full");
+      expect(entry.taskType).toBe("review.small-diff");
       expect(entry.sections.length).toBeGreaterThan(1);
       expect(entry.sections.map((section) => section.sectionName)).toEqual(
         expect.arrayContaining([

--- a/src/handlers/review.ts
+++ b/src/handlers/review.ts
@@ -64,6 +64,10 @@ import {
 import {
   resolveReviewProfile,
 } from "../lib/auto-profile.ts";
+import {
+  resolveReviewRoutingLineCount,
+  resolveReviewTaskRouting,
+} from "../lib/review-routing.ts";
 import { prioritizeFindings } from "../lib/finding-prioritizer.ts";
 import { computeConfidence, matchesSuppression } from "../knowledge/confidence.ts";
 import { applyEnforcement } from "../enforcement/index.ts";
@@ -3596,6 +3600,33 @@ export function createReviewHandler(deps: {
           ? timeoutEstimate
           : null;
 
+        const diffAnalysisLinesChanged = (diffAnalysis?.metrics.totalLinesAdded ?? 0) +
+          (diffAnalysis?.metrics.totalLinesRemoved ?? 0);
+        const prApiLinesChanged = Math.max(0, (pr.additions ?? 0) + (pr.deletions ?? 0));
+        const reviewRoutingLinesChanged = resolveReviewRoutingLineCount({
+          diffLinesChanged: diffAnalysisLinesChanged,
+          prApiLinesChanged,
+        });
+        const reviewRouting = resolveReviewTaskRouting({
+          changedFileCount: changedFiles.length,
+          linesChanged: reviewRoutingLinesChanged,
+        });
+
+        logger.info(
+          {
+            ...baseLog,
+            gate: "review-routing",
+            taskType: reviewRouting.taskType,
+            routingReason: reviewRouting.routingReason,
+            changedFiles: changedFiles.length,
+            linesChanged: reviewRoutingLinesChanged,
+            diffAnalysisLinesChanged,
+            prApiLinesChanged,
+            maxTurns: reviewRouting.maxTurnsOverride ?? null,
+          },
+          "Review routing decision",
+        );
+
         logger.info(
           {
             ...baseLog,
@@ -3903,6 +3934,7 @@ export function createReviewHandler(deps: {
           graphBlastRadius: graphBlastRadius ?? undefined,
           structuralImpact: structuralImpactForReview,
           reviewBoundedness,
+          smallDiffReview: reviewRouting.taskType === TASK_TYPES.REVIEW_SMALL_DIFF,
         } satisfies ReviewPromptBuildContext;
         const reviewPromptCacheState: {
           status: "hit" | "miss" | "degraded" | "bypass";
@@ -3923,7 +3955,7 @@ export function createReviewHandler(deps: {
           buildPromptSectionRecord({
             deliveryId: event.id,
             repo: `${apiOwner}/${apiRepo}`,
-            taskType: "review.full",
+            taskType: reviewRouting.taskType,
             promptKind: "review.user-prompt",
             sections: reviewPromptResult.sections,
           }),
@@ -3957,7 +3989,7 @@ export function createReviewHandler(deps: {
           commentId: undefined,
           botHandles: [githubApp.getAppSlug(), "claude"],
           eventType: `pull_request.${payload.action}`,
-          taskType: "review.full",
+          taskType: reviewRouting.taskType,
           triggerBody: reviewPrompt,
           prompt: reviewPrompt,
           promptSections: reviewPromptSections,
@@ -3970,6 +4002,7 @@ export function createReviewHandler(deps: {
           dynamicTimeoutSeconds: appliedTimeoutBudget
             ? appliedTimeoutBudget.totalTimeoutSeconds
             : undefined,
+          maxTurnsOverride: reviewRouting.maxTurnsOverride,
         });
         executorResult = result;
         executorPhaseTimings = result.executorPhaseTimings ?? buildExecutorUnavailablePhases(
@@ -5491,6 +5524,14 @@ export function createReviewHandler(deps: {
               const retryTimeoutEstimate = retryPlan.timeoutEstimate;
               const retryCheckpointEnabled = retryPlan.checkpointEnabled;
               const retryScopeRatio = retryPlan.scopeRatio;
+              const retryDeliveryId = `${event.id}-retry-1`;
+              const retryReviewWorkAttempt = reviewWorkCoordinator.claim({
+                familyKey: reviewFamilyKey,
+                source: "automatic-review",
+                lane: "review",
+                deliveryId: retryDeliveryId,
+                phase: "claimed",
+              });
 
               // Update resilience telemetry with retry plan
               if (config.telemetry.enabled) {
@@ -5535,15 +5576,6 @@ export function createReviewHandler(deps: {
                 },
                 "Enqueueing retry with reduced scope",
               );
-
-              const retryDeliveryId = `${event.id}-retry-1`;
-              const retryReviewWorkAttempt = reviewWorkCoordinator.claim({
-                familyKey: reviewFamilyKey,
-                source: "automatic-review",
-                lane: "review",
-                deliveryId: retryDeliveryId,
-                phase: "claimed",
-              });
 
               await persistContinuationFamilyState({
                 authoritativeAttemptId: retryReviewWorkAttempt.attemptId,
@@ -5669,6 +5701,7 @@ export function createReviewHandler(deps: {
                       // PR-issue linking (PRLINK-03) — reuse from initial review
                       linkedIssues: linkedIssueResult,
                       structuralImpact: structuralImpactForReview,
+                      smallDiffReview: reviewRouting.taskType === TASK_TYPES.REVIEW_SMALL_DIFF,
                     } satisfies ReviewPromptBuildContext;
                     const retryPromptCacheState: {
                       status: "hit" | "miss" | "degraded" | "bypass";
@@ -5689,7 +5722,7 @@ export function createReviewHandler(deps: {
                       buildPromptSectionRecord({
                         deliveryId: retryDeliveryId,
                         repo: `${apiOwner}/${apiRepo}`,
-                        taskType: "review.full",
+                        taskType: reviewRouting.taskType,
                         promptKind: "review.user-prompt",
                         sections: retryPromptResult.sections,
                       }),
@@ -5715,13 +5748,14 @@ export function createReviewHandler(deps: {
                       commentId: undefined,
                       botHandles: [githubApp.getAppSlug(), "claude"],
                       eventType: "pull_request.review-retry",
-                      taskType: "review.full",
+                      taskType: reviewRouting.taskType,
                       triggerBody: "",
                       prompt: retryPrompt,
                       promptSections: retryPromptSections,
                       reviewOutputKey: retryReviewOutputKey,
                       deliveryId: retryDeliveryId,
                       dynamicTimeoutSeconds: retryTimeout,
+                      maxTurnsOverride: reviewRouting.maxTurnsOverride,
                       knowledgeStore,
                       totalFiles: timeoutTotalFiles,
                       enableCheckpointTool: retryCheckpointEnabled,

--- a/src/lib/review-routing.test.ts
+++ b/src/lib/review-routing.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import { TASK_TYPES } from "../llm/task-types.ts";
+import {
+  countChangedLinesFromNumstat,
+  isSmallDiffReviewEligible,
+  resolveReviewRoutingLineCount,
+  resolveReviewTaskRouting,
+  SMALL_DIFF_MAX_TURNS,
+} from "./review-routing.ts";
+
+describe("review-routing", () => {
+  test("counts changed lines from numstat rows and ignores binary markers", () => {
+    expect(countChangedLinesFromNumstat([
+      "1\t1\tsrc/a.ts",
+      "-\t-\tassets/logo.png",
+      "3\t0\tsrc/b.ts",
+    ])).toBe(5);
+  });
+
+  test("falls back to PR API line totals when local diff analysis has no line count", () => {
+    expect(resolveReviewRoutingLineCount({ diffLinesChanged: 0, prApiLinesChanged: 42 })).toBe(42);
+    expect(resolveReviewRoutingLineCount({ diffLinesChanged: 2, prApiLinesChanged: 42 })).toBe(2);
+  });
+
+  test("treats missing local and PR API line counts as zero", () => {
+    expect(resolveReviewRoutingLineCount({ diffLinesChanged: 0 })).toBe(0);
+  });
+
+  test("treats a one-file two-line PR as small-diff eligible", () => {
+    expect(isSmallDiffReviewEligible({ changedFileCount: 1, linesChanged: 2 })).toBe(true);
+  });
+
+  test("requires both file count and line count thresholds", () => {
+    expect(isSmallDiffReviewEligible({ changedFileCount: 3, linesChanged: 2 })).toBe(false);
+    expect(isSmallDiffReviewEligible({ changedFileCount: 1, linesChanged: 21 })).toBe(false);
+  });
+
+  test("does not use small-diff routing when boundedness already escalated", () => {
+    expect(isSmallDiffReviewEligible({
+      changedFileCount: 1,
+      linesChanged: 2,
+      hasBoundednessEscalation: true,
+    })).toBe(false);
+  });
+
+  test("resolves tiny diffs to review.small-diff with an eight-turn override", () => {
+    expect(resolveReviewTaskRouting({ changedFileCount: 1, linesChanged: 2 })).toEqual({
+      taskType: TASK_TYPES.REVIEW_SMALL_DIFF,
+      routingReason: "tiny-diff",
+      maxTurnsOverride: SMALL_DIFF_MAX_TURNS,
+    });
+  });
+
+  test("resolves non-tiny diffs to review.full without a turn override", () => {
+    expect(resolveReviewTaskRouting({ changedFileCount: 4, linesChanged: 2 })).toEqual({
+      taskType: TASK_TYPES.REVIEW_FULL,
+      routingReason: "standard",
+    });
+  });
+});

--- a/src/lib/review-routing.ts
+++ b/src/lib/review-routing.ts
@@ -1,0 +1,71 @@
+import { TASK_TYPES } from "../llm/task-types.ts";
+
+export const SMALL_DIFF_MAX_FILES = 2;
+export const SMALL_DIFF_MAX_LINES = 20;
+export const SMALL_DIFF_MAX_TURNS = 8;
+
+export const SMALL_DIFF_REVIEW_BASE_TOOLS = [
+  "Read",
+  "Grep",
+  "Glob",
+  "Bash(git diff:*)",
+  "Bash(git show:*)",
+] as const;
+
+export type ReviewTaskRouting = {
+  taskType: string;
+  routingReason: "tiny-diff" | "standard";
+  maxTurnsOverride?: number;
+};
+
+export function countChangedLinesFromNumstat(numstatLines: string[]): number {
+  return numstatLines.reduce((sum, line) => {
+    const [additionsRaw, deletionsRaw] = line.split(/\s+/, 2);
+    const additions = Number.parseInt(additionsRaw ?? "", 10);
+    const deletions = Number.parseInt(deletionsRaw ?? "", 10);
+
+    return sum
+      + (Number.isFinite(additions) ? additions : 0)
+      + (Number.isFinite(deletions) ? deletions : 0);
+  }, 0);
+}
+
+export function resolveReviewRoutingLineCount(params: {
+  diffLinesChanged: number;
+  prApiLinesChanged?: number;
+}): number {
+  const diffLinesChanged = Math.max(0, params.diffLinesChanged);
+  const prApiLinesChanged = Math.max(0, params.prApiLinesChanged ?? 0);
+
+  return diffLinesChanged > 0 ? diffLinesChanged : prApiLinesChanged;
+}
+
+export function isSmallDiffReviewEligible(params: {
+  changedFileCount: number;
+  linesChanged: number;
+  hasBoundednessEscalation?: boolean;
+}): boolean {
+  const { changedFileCount, linesChanged, hasBoundednessEscalation = false } = params;
+  return !hasBoundednessEscalation
+    && changedFileCount <= SMALL_DIFF_MAX_FILES
+    && linesChanged <= SMALL_DIFF_MAX_LINES;
+}
+
+export function resolveReviewTaskRouting(params: {
+  changedFileCount: number;
+  linesChanged: number;
+  hasBoundednessEscalation?: boolean;
+}): ReviewTaskRouting {
+  if (isSmallDiffReviewEligible(params)) {
+    return {
+      taskType: TASK_TYPES.REVIEW_SMALL_DIFF,
+      routingReason: "tiny-diff",
+      maxTurnsOverride: SMALL_DIFF_MAX_TURNS,
+    };
+  }
+
+  return {
+    taskType: TASK_TYPES.REVIEW_FULL,
+    routingReason: "standard",
+  };
+}

--- a/src/llm/task-types.ts
+++ b/src/llm/task-types.ts
@@ -9,6 +9,8 @@
 export const TASK_TYPES = {
   /** Full PR review (agentic, Agent SDK default). */
   REVIEW_FULL: "review.full",
+  /** Tiny PR review fast path (agentic, Agent SDK default). */
+  REVIEW_SMALL_DIFF: "review.small-diff",
   /** PR summary label generation (non-agentic). */
   REVIEW_SUMMARY: "review.summary",
   /** @mention handling (agentic, Agent SDK default). */
@@ -42,6 +44,7 @@ export type TaskType = (typeof TASK_TYPES)[keyof typeof TASK_TYPES];
  */
 export const AGENTIC_TASK_TYPES: Set<string> = new Set([
   TASK_TYPES.REVIEW_FULL,
+  TASK_TYPES.REVIEW_SMALL_DIFF,
   TASK_TYPES.MENTION_RESPONSE,
   TASK_TYPES.SLACK_RESPONSE,
 ]);


### PR DESCRIPTION
## Summary

Fixes the tiny-PR max-turn failure mode seen on `xbmc/xbmc#28239` where explicit `@kodiai review` still ran as heavyweight `review.full` and exhausted the 25-turn budget on a one-file/two-line PR.

Changes:
- add `review.small-diff` task routing for tiny reviews (`<=2` files and `<=20` lines)
- apply small-diff routing to both automatic/manual review handler runs and explicit `@kodiai review` mention runs
- cap small-diff reviews at 8 turns
- constrain the small-diff tool surface to focused diff/file inspection plus publish MCP tools
- add a tiny-diff scope section to review prompts
- add compact per-turn tool-target diagnostics in `agent-diagnostics.log`
- adjust tiny-diff max-turn fallback wording so it does not blame large/complex diffs

## Root cause

The reported failure at https://github.com/xbmc/xbmc/pull/28239#issuecomment-4346827360 was not the automatic review handler path. It was an explicit `@kodiai review` comment handled by `src/handlers/mention.ts`, so previous review-handler-only fixes would not affect it.

Live evidence for delivery `2276d290-43ff-11f1-8dfe-39febf6a9d18` showed:
- `taskType: review.full`
- `maxTurns: 25`
- `numTurns: 26`
- `failureSubtype: error_max_turns`
- broad repo-inspection tools: `Bash`, `Read`, `Grep`, `Glob`

## Verification

Passed:

```sh
bun test ./src/handlers/review.test.ts ./src/handlers/mention.test.ts ./src/execution/executor.test.ts ./src/execution/agent-entrypoint.test.ts ./src/execution/review-prompt.test.ts ./src/lib/review-routing.test.ts
# 569 pass, 0 fail
```

Passed:

```sh
git diff --check
```

Typecheck note:

```sh
bun run tsc --noEmit
```

still fails on pre-existing M065 / continuation verifier type drift outside this change surface:
- `scripts/verify-m064-s03.ts`
- `scripts/verify-m065-s02.ts`
- `scripts/verify-m065-s02.test.ts`
- `scripts/verify-m065-s03.test.ts`
- `scripts/verify-m065.test.ts`
- `src/knowledge/continuation-operator-evidence.ts`
- `src/knowledge/continuation-operator-evidence.test.ts`

No typecheck errors remain in the files touched by this PR.
