### PR TITLE
Handle production log failure cases

### DIFF
--- a/src/db/migrations/001-initial-schema.sql
+++ b/src/db/migrations/001-initial-schema.sql
@@ -281,7 +281,7 @@ CREATE TABLE IF NOT EXISTS learning_memories (
   id BIGSERIAL PRIMARY KEY,
   repo TEXT NOT NULL,
   owner TEXT NOT NULL,
-  finding_id INTEGER,
+  finding_id BIGINT,
   review_id INTEGER,
   source_repo TEXT NOT NULL,
   finding_text TEXT NOT NULL,

--- a/src/db/migrations/040-learning-memory-bigint-finding-id.down.sql
+++ b/src/db/migrations/040-learning-memory-bigint-finding-id.down.sql
@@ -1,0 +1,17 @@
+-- Rollback risk: learning_memories.finding_id may now contain GitHub review
+-- comment IDs larger than PostgreSQL INTEGER can represent. This down migration
+-- intentionally fails fast with a clear error if any such rows exist so rollback
+-- operators do not silently lose learning-memory references.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM learning_memories
+    WHERE finding_id > 2147483647 OR finding_id < -2147483648
+  ) THEN
+    RAISE EXCEPTION 'Cannot downgrade learning_memories.finding_id to INTEGER: out-of-range BIGINT values exist';
+  END IF;
+END $$;
+
+ALTER TABLE learning_memories
+  ALTER COLUMN finding_id TYPE INTEGER;

--- a/src/db/migrations/040-learning-memory-bigint-finding-id.sql
+++ b/src/db/migrations/040-learning-memory-bigint-finding-id.sql
@@ -1,0 +1,6 @@
+-- Promote learning memory finding IDs to BIGINT so GitHub review comment IDs
+-- larger than 32-bit signed integer range can be stored as finding references.
+-- GitHub IDs commonly exceed 2,147,483,647.
+
+ALTER TABLE learning_memories
+  ALTER COLUMN finding_id TYPE BIGINT;

--- a/src/handlers/feedback-sync.test.ts
+++ b/src/handlers/feedback-sync.test.ts
@@ -74,10 +74,19 @@ function buildCandidate(overrides: Partial<FindingCommentCandidate> = {}): Findi
 
 function createCaptureLogger(): {
   logger: Logger;
+  infos: Array<{ message: string; data?: Record<string, unknown> }>;
   warnings: Array<{ message: string; data?: Record<string, unknown> }>;
 } {
+  const infos: Array<{ message: string; data?: Record<string, unknown> }> = [];
   const warnings: Array<{ message: string; data?: Record<string, unknown> }> = [];
   const noop = () => undefined;
+  const info = (data: unknown, message?: string) => {
+    if (typeof data === "string") {
+      infos.push({ message: data });
+      return;
+    }
+    infos.push({ message: message ?? "", data: (data ?? {}) as Record<string, unknown> });
+  };
   const warn = (data: unknown, message?: string) => {
     if (typeof data === "string") {
       warnings.push({ message: data });
@@ -88,7 +97,7 @@ function createCaptureLogger(): {
 
   return {
     logger: {
-      info: noop,
+      info,
       warn,
       error: noop,
       debug: noop,
@@ -96,6 +105,7 @@ function createCaptureLogger(): {
       fatal: noop,
       child: () => createNoopLogger(),
     } as unknown as Logger,
+    infos,
     warnings,
   };
 }
@@ -296,6 +306,34 @@ describe("createFeedbackSyncHandler", () => {
     expect(
       warnings.some((entry) =>
         entry.message.includes("Feedback sync reaction persistence failed; continuing")
+      ),
+    ).toBe(true);
+  });
+
+  test("logs reaction permission denials as skipped diagnostics instead of warnings", async () => {
+    const { logger, infos, warnings } = createCaptureLogger();
+    const permissionError = Object.assign(new Error("Resource not accessible by integration"), {
+      status: 403,
+      response: { data: { message: "Resource not accessible by integration" } },
+    });
+    const { handlers, recorded } = createHarness({
+      candidates: [buildCandidate({ findingId: 1, commentId: 31 })],
+      listReactions: async () => {
+        throw permissionError;
+      },
+      logger,
+    });
+
+    const handler = handlers.get("pull_request.opened");
+    expect(handler).toBeDefined();
+
+    await handler!(buildPullRequestOpenedEvent());
+
+    expect(recorded).toHaveLength(0);
+    expect(warnings).toHaveLength(0);
+    expect(
+      infos.some((entry) =>
+        entry.message.includes("Feedback sync reaction fetch skipped; app lacks reaction read permission")
       ),
     ).toBe(true);
   });

--- a/src/handlers/feedback-sync.ts
+++ b/src/handlers/feedback-sync.ts
@@ -36,6 +36,40 @@ type ReactionEntry = {
   created_at?: string | null;
 };
 
+function isReactionPermissionDenied(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  const maybe = err as { status?: unknown; message?: unknown; response?: { data?: { message?: unknown } } };
+  const status = typeof maybe.status === "number" ? maybe.status : undefined;
+  const message = typeof maybe.message === "string"
+    ? maybe.message
+    : typeof maybe.response?.data?.message === "string"
+      ? maybe.response.data.message
+      : "";
+
+  return status === 403 && message.toLowerCase().includes("resource not accessible");
+}
+
+function logReactionFetchFailure(params: {
+  logger: Logger;
+  err: unknown;
+  repo: string;
+  commentId: number;
+}): void {
+  const { logger, err, repo, commentId } = params;
+  if (isReactionPermissionDenied(err)) {
+    logger.info(
+      { repo, commentId, reason: "reaction-permission-denied" },
+      "Feedback sync reaction fetch skipped; app lacks reaction read permission",
+    );
+    return;
+  }
+
+  logger.warn(
+    { err, repo, commentId },
+    "Feedback sync reaction fetch failed for review comment; continuing",
+  );
+}
+
 const DEFAULT_MAX_CANDIDATES = 100;
 const DEFAULT_RECENT_WINDOW_DAYS = 30;
 
@@ -166,10 +200,7 @@ export function createFeedbackSyncHandler(deps: {
 
           reactionsByCommentId.set(commentId, response.data as ReactionEntry[]);
         } catch (err) {
-          logger.warn(
-            { err, repo, commentId },
-            "Feedback sync reaction fetch failed for review comment; continuing",
-          );
+          logReactionFetchFailure({ logger, err, repo, commentId });
         }
       }
 

--- a/src/handlers/identity-suggest.test.ts
+++ b/src/handlers/identity-suggest.test.ts
@@ -217,6 +217,92 @@ describe("suggestIdentityLink", () => {
     expect(requests).toEqual(["https://slack.com/api/users.list"]);
   });
 
+  test("missing Slack users.list scope disables identity suggestions without warning", async () => {
+    const logger = createMockLogger();
+    const requests: string[] = [];
+    let missingScopeForFirstToken = true;
+    const fetchMock = mock(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      requests.push(url);
+      const authHeader = init?.headers instanceof Headers
+        ? init.headers.get("authorization")
+        : (init?.headers as Record<string, string> | undefined)?.authorization;
+      if (authHeader === "Bearer xoxb-missing-scope" && missingScopeForFirstToken) {
+        missingScopeForFirstToken = false;
+        return jsonResponse({ ok: false, error: "missing_scope" });
+      }
+      return jsonResponse({ ok: true, members: [] });
+    });
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+    await identitySuggest.suggestIdentityLink({
+      githubUsername: "scope-missing-user",
+      githubDisplayName: "Scope Missing User",
+      slackBotToken: "xoxb-missing-scope",
+      profileStore: createMockProfileStore(),
+      logger,
+    });
+    await identitySuggest.suggestIdentityLink({
+      githubUsername: "scope-missing-user-2",
+      githubDisplayName: "Scope Missing User 2",
+      slackBotToken: "xoxb-missing-scope",
+      profileStore: createMockProfileStore(),
+      logger,
+    });
+    await identitySuggest.suggestIdentityLink({
+      githubUsername: "scope-valid-user",
+      githubDisplayName: "Scope Valid User",
+      slackBotToken: "xoxb-valid-scope",
+      profileStore: createMockProfileStore(),
+      logger,
+    });
+
+    expect(requests).toEqual([
+      "https://slack.com/api/users.list",
+      "https://slack.com/api/users.list",
+    ]);
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  test("missing Slack users.list scope disable cache evicts old token entries", async () => {
+    const logger = createMockLogger();
+    const requests: string[] = [];
+    const fetchMock = mock(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const authHeader = init?.headers instanceof Headers
+        ? init.headers.get("authorization")
+        : (init?.headers as Record<string, string> | undefined)?.authorization;
+      requests.push(`${url}:${authHeader ?? ""}`);
+      return jsonResponse({ ok: false, error: "missing_scope" });
+    });
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+    for (let index = 0; index < 101; index++) {
+      await identitySuggest.suggestIdentityLink({
+        githubUsername: `scope-missing-${index}`,
+        githubDisplayName: `Scope Missing ${index}`,
+        slackBotToken: `xoxb-missing-scope-${index}`,
+        profileStore: createMockProfileStore(),
+        logger,
+      });
+    }
+
+    await identitySuggest.suggestIdentityLink({
+      githubUsername: "scope-missing-first-again",
+      githubDisplayName: "Scope Missing First Again",
+      slackBotToken: "xoxb-missing-scope-0",
+      profileStore: createMockProfileStore(),
+      logger,
+    });
+
+    expect(requests).toHaveLength(102);
+    expect(requests.at(-1)).toBe(
+      "https://slack.com/api/users.list:Bearer xoxb-missing-scope-0",
+    );
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
   test("high-confidence match sends one truthful DM body", async () => {
     const requests: Array<{ url: string; body: string | null }> = [];
     const logger = createMockLogger();

--- a/src/handlers/identity-suggest.ts
+++ b/src/handlers/identity-suggest.ts
@@ -22,6 +22,9 @@ type SlackMember = {
 let cachedMembers: SlackMember[] | null = null;
 let cachedMembersAt = 0;
 const MEMBER_CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+const MAX_DISABLED_SLACK_MEMBER_LOOKUP_TOKENS = 100;
+
+const slackMemberLookupDisabledReasonsByToken = new Map<string, string>();
 
 /** Track which GitHub usernames we've already suggested to avoid repeats. */
 const suggestedUsernames = new Set<string>();
@@ -29,6 +32,7 @@ const suggestedUsernames = new Set<string>();
 export function resetIdentitySuggestionStateForTests(): void {
   cachedMembers = null;
   cachedMembersAt = 0;
+  slackMemberLookupDisabledReasonsByToken.clear();
   suggestedUsernames.clear();
 }
 
@@ -36,6 +40,15 @@ async function fetchSlackMembers(
   botToken: string,
   logger: Logger,
 ): Promise<SlackMember[]> {
+  const disabledReason = slackMemberLookupDisabledReasonsByToken.get(botToken);
+  if (disabledReason) {
+    logger.debug(
+      { reason: disabledReason },
+      "Slack member lookup disabled for token; skipping identity suggestion",
+    );
+    return [];
+  }
+
   const now = Date.now();
   if (cachedMembers && now - cachedMembersAt < MEMBER_CACHE_TTL_MS) {
     return cachedMembers;
@@ -66,7 +79,23 @@ async function fetchSlackMembers(
   };
 
   if (!data.ok) {
-    throw new Error(`Slack users.list failed: ${data.error ?? "unknown"}`);
+    const errorCode = data.error ?? "unknown";
+    if (errorCode === "missing_scope") {
+      slackMemberLookupDisabledReasonsByToken.set(botToken, errorCode);
+      if (slackMemberLookupDisabledReasonsByToken.size > MAX_DISABLED_SLACK_MEMBER_LOOKUP_TOKENS) {
+        const oldestToken = slackMemberLookupDisabledReasonsByToken.keys().next().value;
+        if (oldestToken !== undefined) {
+          slackMemberLookupDisabledReasonsByToken.delete(oldestToken);
+        }
+      }
+      logger.info(
+        { reason: errorCode },
+        "Slack member lookup disabled; missing users.list scope",
+      );
+      return [];
+    }
+
+    throw new Error(`Slack users.list failed: ${errorCode}`);
   }
 
   const members: SlackMember[] = (data.members ?? [])

--- a/src/knowledge/memory-store.test.ts
+++ b/src/knowledge/memory-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeAll, afterAll, beforeEach } from "bun:test";
-import { createLearningMemoryStore } from "./memory-store.ts";
+import { createLearningMemoryStore, normalizeSafeInteger } from "./memory-store.ts";
 import { createDbClient, type Sql } from "../db/client.ts";
 import { runMigrations } from "../db/migrate.ts";
 import type { LearningMemoryStore, LearningMemoryRecord } from "./types.ts";
@@ -14,6 +14,31 @@ const mockLogger = {
   child: () => mockLogger,
   level: "silent",
 } as unknown as import("pino").Logger;
+
+describe("normalizeSafeInteger", () => {
+  test("rejects bigint values before precision-losing Number conversion", () => {
+    expect(() => normalizeSafeInteger(9007199254740993n, "test.bigint_id")).toThrow(
+      "test.bigint_id exceeds JavaScript safe integer range: 9007199254740993",
+    );
+  });
+
+  test("rejects string values before precision-losing Number conversion", () => {
+    expect(() => normalizeSafeInteger("9007199254740993", "test.string_id")).toThrow(
+      "test.string_id exceeds JavaScript safe integer range: 9007199254740993",
+    );
+  });
+
+  test("rejects non-integer string values", () => {
+    expect(() => normalizeSafeInteger("123.5", "test.string_id")).toThrow(
+      "test.string_id is not an integer: 123.5",
+    );
+  });
+
+  test("accepts safe bigint and string values", () => {
+    expect(normalizeSafeInteger(3164871419n, "test.bigint_id")).toBe(3164871419);
+    expect(normalizeSafeInteger("3164871419", "test.string_id")).toBe(3164871419);
+  });
+});
 
 function makeRecord(overrides: Partial<LearningMemoryRecord> = {}): LearningMemoryRecord {
   return {
@@ -93,6 +118,27 @@ describe.skipIf(!TEST_DB_URL)("LearningMemoryStore (pgvector)", () => {
     expect(rows[0]!.owner).toBe("owner");
     expect(rows[0]!.severity).toBe("major");
     expect(rows[0]!.embedding).not.toBeNull();
+  });
+
+  test("writeMemory stores GitHub-sized finding IDs above 32-bit integer range", async () => {
+    const githubReviewCommentId = 3_164_871_419;
+    const record = makeRecord({ findingId: githubReviewCommentId });
+    const embedding = makeEmbedding(44);
+
+    await store.writeMemory(record, embedding);
+
+    const rows = await sql`
+      SELECT id, finding_id
+      FROM learning_memories
+      WHERE finding_id = ${githubReviewCommentId}
+    `;
+    expect(rows.length).toBe(1);
+    expect(Number(rows[0]!.finding_id)).toBe(githubReviewCommentId);
+
+    const stored = await store.getMemoryRecord(rows[0]!.id);
+    expect(stored).not.toBeNull();
+    expect(stored!.findingId).toBe(githubReviewCommentId);
+    expect(typeof stored!.findingId).toBe("number");
   });
 
   test("writeMemory stores record and getMemoryRecord retrieves it", async () => {

--- a/src/knowledge/memory-store.ts
+++ b/src/knowledge/memory-store.ts
@@ -16,11 +16,11 @@ function float32ArrayToVectorString(arr: Float32Array): string {
 }
 
 type MemoryRow = {
-  id: number;
+  id: number | string | bigint;
   repo: string;
   owner: string;
-  finding_id: number;
-  review_id: number;
+  finding_id: number | string | bigint;
+  review_id: number | string | bigint;
   source_repo: string;
   finding_text: string;
   severity: string;
@@ -62,13 +62,38 @@ type RepairStateRow = {
 const DEFAULT_REPAIR_KEY = "default";
 const REPAIR_CORPUS = "learning_memories" as const satisfies EmbeddingRepairCorpus;
 
+export function normalizeSafeInteger(value: number | string | bigint, fieldName: string): number {
+  if (typeof value === "bigint") {
+    if (value > BigInt(Number.MAX_SAFE_INTEGER) || value < BigInt(Number.MIN_SAFE_INTEGER)) {
+      throw new Error(`${fieldName} exceeds JavaScript safe integer range: ${String(value)}`);
+    }
+    return Number(value);
+  }
+
+  if (typeof value === "string") {
+    if (!/^-?\d+$/.test(value)) {
+      throw new Error(`${fieldName} is not an integer: ${String(value)}`);
+    }
+    const bigintValue = BigInt(value);
+    if (bigintValue > BigInt(Number.MAX_SAFE_INTEGER) || bigintValue < BigInt(Number.MIN_SAFE_INTEGER)) {
+      throw new Error(`${fieldName} exceeds JavaScript safe integer range: ${String(value)}`);
+    }
+    return Number(bigintValue);
+  }
+
+  if (!Number.isSafeInteger(value)) {
+    throw new Error(`${fieldName} exceeds JavaScript safe integer range: ${String(value)}`);
+  }
+  return value;
+}
+
 function rowToRecord(row: MemoryRow): LearningMemoryRecord {
   return {
-    id: row.id,
+    id: normalizeSafeInteger(row.id, "learning_memories.id"),
     repo: row.repo,
     owner: row.owner,
-    findingId: row.finding_id,
-    reviewId: row.review_id,
+    findingId: normalizeSafeInteger(row.finding_id, "learning_memories.finding_id"),
+    reviewId: normalizeSafeInteger(row.review_id, "learning_memories.review_id"),
     sourceRepo: row.source_repo,
     findingText: row.finding_text,
     severity: row.severity as LearningMemoryRecord["severity"],


### PR DESCRIPTION
## Summary

Follow-up from the broad Kodiai log audit after v0.35. The audit found one real unresolved production error and two fail-open enrichment paths that were still logging as warning/error-level failures:

- `learning_memories.finding_id` was still `INTEGER`, but runtime now uses GitHub review comment IDs as finding references; recent IDs exceed 32-bit range.
- Slack identity suggestions log warning-level noise when the Slack bot token lacks `users.list` scope.
- Feedback reaction sync logs warning-level noise when the GitHub App cannot read review-comment reactions.

Changes:
- add migration `040-learning-memory-bigint-finding-id` to promote `learning_memories.finding_id` to `BIGINT`
- update the fresh schema to use `BIGINT`
- add a regression for GitHub-sized finding IDs in `memory-store.test.ts`
- disable Slack member lookup after `missing_scope` and log it as an info-level disabled diagnostic
- log GitHub reaction-read 403s as info-level skipped diagnostics instead of warning-level failures

## Log audit evidence

Recent failure classes after `2026-04-29T00:00:00Z`:

- Resolved by v0.35 / PR #120:
  - `error_max_turns` / `tool_use` on tiny explicit review for `xbmc/xbmc#28239`
  - old max-turn fallback on PR #120's initial oversized stacked branch
- Fixed in this PR:
  - `Failed to write memory`: `value "3164871419" is out of range for type integer`
  - `Learning memory write failed for finding (fail-open)` with the same integer overflow
  - `Identity suggestion check failed (non-blocking)`: Slack `users.list failed: missing_scope`
  - `Feedback sync reaction fetch failed for review comment; continuing`: GitHub reaction API 403
- Confirmed non-actionable / already handled:
  - `Diff collection degraded to GitHub file-list fallback`: existing fail-open behavior, review still proceeds
  - `MCP HTTP: unauthorized` + `ACA Job timed out`: tied to old pre-v0.35 retry/max-turn path; no recurrence after v0.35 deploy

Post-v0.35 deploy scan after `2026-04-30T00:45:00Z` showed 0 true issue signals on active revision `ca-kodiai--deploy-20260429-174526`.

## Verification

```sh
bun test ./src/knowledge/memory-store.test.ts ./src/handlers/identity-suggest.test.ts ./src/handlers/feedback-sync.test.ts
# 13 pass, 16 skip, 0 fail
```

The memory-store BIGINT regression is DB-backed and skipped locally because `TEST_DATABASE_URL` is not set in the clean worktree.

```sh
bun run tsc --noEmit 2>&1 | rg "src/handlers/feedback-sync|src/handlers/identity-suggest|src/knowledge/memory-store|src/db/migrations" || true
# no touched-file typecheck errors
```

```sh
git diff --check
# clean
```
