### PR TITLE
Improve review timeout diagnostics and budgeting

### DIFF
--- a/docs/superpowers/specs/2026-04-28-small-diff-review-fast-path-design.md
+++ b/docs/superpowers/specs/2026-04-28-small-diff-review-fast-path-design.md
@@ -130,7 +130,7 @@ Add lightweight per-turn trace lines to `agent-diagnostics.log`:
 - compact target summary
 
 Examples:
-- `turn=1 tool=Bash target="git diff origin/master...HEAD"`
+- `turn=1 tool=Bash target="git diff origin/main...HEAD"`
 - `turn=2 tool=Read target="xbmc/platform/android/activity/JNIXBMCNsdManagerDiscoveryListener.cpp"`
 - `turn=3 tool=Grep target="ClassPathToName"`
 

--- a/docs/superpowers/specs/2026-04-28-small-diff-review-fast-path-design.md
+++ b/docs/superpowers/specs/2026-04-28-small-diff-review-fast-path-design.md
@@ -1,0 +1,272 @@
+# Small-Diff Review Fast Path Design
+
+Date: 2026-04-28
+
+## Goal
+
+Prevent tiny pull requests from consuming the full `review.full` turn budget, while improving observability for future max-turn failures and making retry failures easier to diagnose.
+
+Primary motivating incident:
+- `xbmc/xbmc#28239` changed 1 file and 2 lines, but the initial review still exhausted the 25-turn `review.full` budget and fell back to a zero-evidence max-turn comment.
+- The reduced-scope retry then failed separately with MCP startup failures and ACA timeout, leaving no actionable output.
+
+## Problem Statement
+
+The current review pipeline already detects when a PR is tiny and low risk, but that signal is not used to change the remote review-agent execution contract.
+
+Today, even a one-line PR can still receive:
+- the heavyweight `review.full` prompt,
+- the full review tool surface,
+- the normal `maxTurns` budget,
+- full-review behavioral expectations (triage, broad inspection, citation-heavy reasoning).
+
+That is structurally mismatched to tiny diffs. Raising `maxTurns` globally would mask the problem and increase cost. The root issue is that the remote agent lacks a small-diff fast path.
+
+## Non-Goals
+
+This change does **not** attempt to:
+- redesign normal large/medium PR review behavior,
+- redesign the visible zero-evidence max-turn fallback comment UI,
+- guarantee retry success in every infrastructure failure mode,
+- change review severity policy or publication semantics.
+
+## User-Facing Outcome
+
+For very small PRs, Kodiai should:
+- inspect the diff quickly,
+- read only obviously relevant surrounding code,
+- publish findings or approval without spending 20+ turns on broad exploration,
+- fail with better diagnostics if something still goes wrong.
+
+This applies to both:
+- automatic PR reviews, and
+- explicit `@kodiai review` requests,
+when the run is still a `review.full`-class code review and the diff is tiny.
+
+## Recommended Approach
+
+Implement a dedicated **small-diff review mode** rather than tuning the existing full-review prompt with softer instructions.
+
+Reasoning:
+- Prompt-only steering has already proven insufficient.
+- A separate execution mode gives clear routing, telemetry, and test boundaries.
+- The cost/risk profile of tiny diffs is materially different from standard reviews.
+
+## Design Overview
+
+### 1. Introduce a new task type: `review.small-diff`
+
+When a review would normally run as `review.full`, route it to `review.small-diff` if the diff qualifies as tiny.
+
+Initial eligibility rule:
+- changed files <= 2
+- total changed lines <= 20
+- no bounded-review escalation already in force
+- no explicit signals that require broader scope (for example, future structural-impact or high-risk overrides)
+
+This should apply consistently to:
+- `pull_request.opened`
+- `pull_request.synchronize`
+- `pull_request.review_requested`
+- explicit `@kodiai review`
+
+If a run is not eligible, keep the existing `review.full` behavior unchanged.
+
+### 2. Give `review.small-diff` a narrower execution contract
+
+#### Max turns
+Use a lower cap than the repo-wide default.
+
+Initial target:
+- `maxTurns = 8`
+
+Rationale:
+- enough room for `git diff`, one or two file reads, one grep, and publication,
+- low enough to prevent endless inspection loops on tiny changes.
+
+#### Tool surface
+Restrict the tool contract to the minimum useful review set:
+- `Read`
+- `Grep`
+- `Glob`
+- `Bash(git diff:*)`
+- `Bash(git show:*)`
+- review publication MCP tools already used in normal review paths
+
+Avoid broad repo-inspection affordances unless they are already necessary for normal review publication.
+
+#### Prompt contract
+Create a small-diff-specific prompt path with these hard instructions:
+- inspect the diff first,
+- read only the changed file and directly adjacent context,
+- broaden scope only if the diff itself proves ambiguity,
+- do not do generalized architecture exploration,
+- produce a merge decision quickly,
+- if no actionable issue exists, end without additional exploratory turns.
+
+The prompt should preserve existing review correctness rules, publication rules, severity rules, and security rules. The change is scope discipline, not review standards.
+
+### 3. Add small-diff routing telemetry
+
+When a review is eligible for the fast path, log that explicitly.
+
+Suggested fields:
+- `gate: review-routing`
+- `taskType: review.small-diff`
+- `routingReason: tiny-diff`
+- `changedFiles`
+- `linesChanged`
+- `maxTurns`
+
+This makes it easy to distinguish “agent routed correctly but still failed” from “agent never took the fast path.”
+
+### 4. Improve per-turn diagnostics
+
+Current diagnostics are too coarse: they only show that tools like `Bash`, `Read`, `Grep`, `Glob` were used.
+
+Add lightweight per-turn trace lines to `agent-diagnostics.log`:
+- turn number
+- tool name
+- compact target summary
+
+Examples:
+- `turn=1 tool=Bash target="git diff origin/master...HEAD"`
+- `turn=2 tool=Read target="xbmc/platform/android/activity/JNIXBMCNsdManagerDiscoveryListener.cpp"`
+- `turn=3 tool=Grep target="ClassPathToName"`
+
+This must stay concise and secret-safe. Do not log arbitrary command output or prompt text. Log only the normalized action target.
+
+Purpose:
+- explain future max-turn failures quickly,
+- detect tool loops,
+- prove whether the small-diff contract is being followed.
+
+### 5. Improve retry failure classification
+
+The retry for `#28239` failed with:
+- MCP servers unavailable in the retry agent startup path,
+- ACA timeout,
+- generic `retryConclusion: error`.
+
+That is too vague.
+
+Improve retry result classification so logs and result handling can distinguish at least:
+- retry publish tooling unavailable / MCP startup failure,
+- retry remote timeout,
+- retry max-turn exhaustion,
+- retry generic execution error.
+
+This does **not** need to solve all retry infrastructure issues in the first pass. It needs to make them diagnosable and truthfully surfaced.
+
+## Component-Level Changes
+
+### `src/handlers/review.ts`
+
+Add routing logic that decides between:
+- `review.full`
+- `review.small-diff`
+
+Use already-computed diff metrics rather than recomputing a second classifier.
+
+Thread the chosen task type and max-turn override into executor launch and retry launch paths.
+
+### `src/execution/review-prompt.ts`
+
+Add a small-diff prompt builder or conditional path for `review.small-diff`.
+
+The new path should reuse existing correctness/security/publication rules where possible, but replace the broad review instructions with a constrained tiny-diff contract.
+
+### `src/execution/executor.ts`
+
+Support task-type-specific turn/tool routing for `review.small-diff`.
+
+If task-type-specific model overrides already exist generically, this should plug into the same routing layer rather than special-casing too much in the executor.
+
+### `src/execution/agent-entrypoint.ts`
+
+Extend `agent-diagnostics.log` emission with compact per-turn tool-target trace lines.
+
+This should be additive and must not expose secret values.
+
+### Retry path (`src/handlers/review.ts` + related execution result handling)
+
+Preserve the existing retry behavior, but classify retry failures more precisely and log the category explicitly.
+
+## Testing Strategy
+
+### Unit tests
+
+Add targeted tests for:
+
+1. **Routing eligibility**
+- tiny diff routes to `review.small-diff`
+- larger diff stays on `review.full`
+- explicit `@kodiai review` on tiny diff also routes to `review.small-diff`
+
+2. **Execution contract**
+- `review.small-diff` uses the reduced max-turn value
+- `review.small-diff` gets the reduced tool set
+- `review.full` remains unchanged
+
+3. **Prompt contract**
+- small-diff prompt contains the “inspect diff first / no broad exploration” constraints
+- full-review prompt remains unchanged for non-tiny diffs
+
+4. **Diagnostics**
+- per-turn tool trace lines are written in compact form
+- traces do not require raw tool output
+
+5. **Retry classification**
+- MCP startup failure maps to a specific retry error category
+- timeout maps distinctly from generic error
+
+### Regression tests
+
+Add a regression modeled on the `#28239` shape:
+- 1 file, 2 lines, low risk
+- verify the handler chooses the small-diff path
+- verify the agent config no longer uses the standard 25-turn full-review contract
+
+## Risks and Trade-offs
+
+### Risk: tiny-diff threshold is too aggressive
+A small textual diff can still be semantically risky.
+
+Mitigation:
+- keep the threshold conservative,
+- require both small file count and small line count,
+- allow existing boundedness / risk signals to opt out.
+
+### Risk: second review mode increases complexity
+True, but the behavior difference is real and already hurting reliability. The routing boundary is clearer than continually patching the single full-review mode.
+
+### Risk: diagnostics grow too noisy
+Mitigation:
+- log only turn number, tool name, and normalized target summary,
+- no command output, no prompt dumps, no secrets.
+
+## Success Criteria
+
+A successful implementation means:
+- a PR shaped like `#28239` routes to `review.small-diff`, not the standard `review.full` budget,
+- tiny-diff reviews no longer consume the full 25-turn budget under normal conditions,
+- if a tiny-diff review still fails, diagnostics clearly show which tools consumed the turns,
+- retry failures expose whether the problem was timeout, max-turns, or MCP/tooling startup.
+
+## Open Questions Resolved
+
+### Should the fast path apply only to automatic reviews?
+No. It should apply to **all** `review.full`-class runs, including explicit `@kodiai review`, when the diff is tiny.
+
+Reason:
+- the failure mode is about diff size and execution contract, not trigger source,
+- tiny diffs should behave consistently across automatic and explicit review flows.
+
+## Recommended Implementation Order
+
+1. Add tiny-diff eligibility and routing.
+2. Add `review.small-diff` execution contract (prompt, max turns, tools).
+3. Add targeted routing and executor tests.
+4. Add per-turn diagnostics.
+5. Add retry classification improvements.
+6. Run focused review-path verification, then broader typecheck/lint.

--- a/src/handlers/review.test.ts
+++ b/src/handlers/review.test.ts
@@ -16437,7 +16437,9 @@ describe("createReviewHandler failure fallback publication", () => {
     expect(standaloneReviewDetails).toBeUndefined();
 
     await workspaceFixture.cleanup();
-  });  test("falls back to standalone Review Details when max-turns canonical comment rebuild fails", async () => {
+  });
+
+  test("falls back to standalone Review Details when max-turns canonical comment rebuild fails", async () => {
     const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
     const workspaceFixture = await createWorkspaceFixture();
     const { logger, entries } = createCaptureLogger();

--- a/src/handlers/review.ts
+++ b/src/handlers/review.ts
@@ -6284,7 +6284,6 @@ export function createReviewHandler(deps: {
             "Try requesting another review if you want a fresh attempt.",
           ].join("\n");
 
-
           const octokit = await githubApp.getInstallationOctokit(event.installationId);
           if (canPublishVisibleOutput("failure fallback comment")) {
             setReviewWorkPhase("publish");
@@ -6298,7 +6297,6 @@ export function createReviewHandler(deps: {
               sanitizeOutgoingMentions(failureBody, [githubApp.getAppSlug(), "claude"]),
               logger,
             );
-
           }
         }
 

--- a/src/handlers/review.ts
+++ b/src/handlers/review.ts
@@ -6284,6 +6284,7 @@ export function createReviewHandler(deps: {
             "Try requesting another review if you want a fresh attempt.",
           ].join("\n");
 
+
           const octokit = await githubApp.getInstallationOctokit(event.installationId);
           if (canPublishVisibleOutput("failure fallback comment")) {
             setReviewWorkPhase("publish");
@@ -6297,6 +6298,7 @@ export function createReviewHandler(deps: {
               sanitizeOutgoingMentions(failureBody, [githubApp.getAppSlug(), "claude"]),
               logger,
             );
+
           }
         }
 

--- a/src/lib/timeout-estimator.test.ts
+++ b/src/lib/timeout-estimator.test.ts
@@ -210,6 +210,20 @@ describe("estimateTimeoutRisk", () => {
     expect(result.totalTimeoutSeconds).toBe(MAX_TIMEOUT_BUDGET_SECONDS);
   });
 
+  test("timeout budgets separate remote runtime from infra overhead", () => {
+    const result = estimateTimeoutRisk({
+      fileCount: 1,
+      linesChanged: 10,
+      languageComplexity: 1.0,
+      isLargePR: false,
+      baseTimeoutSeconds: baseTimeout,
+    });
+
+    expect(result.remoteRuntimeBudgetSeconds).toBe(423);
+    expect(result.infraOverheadBudgetSeconds).toBe(DEFAULT_INFRA_OVERHEAD_BUDGET_SECONDS);
+    expect(result.totalTimeoutSeconds).toBe(603);
+  });
+
   test("reasoning string contains key metrics", () => {
     const result = estimateTimeoutRisk({
       fileCount: 10,

--- a/src/lib/timeout-estimator.test.ts
+++ b/src/lib/timeout-estimator.test.ts
@@ -225,9 +225,10 @@ describe("estimateTimeoutRisk", () => {
     const fileScore = Math.min(fileCount / 100, 1.0);
     const lineScore = Math.min(linesChanged / 5000, 1.0);
     const complexity = fileScore * 0.4 + lineScore * 0.4 + languageComplexity * 0.2;
-    const expectedRemoteRuntimeBudgetSeconds = Math.min(
-      Math.round(baseTimeout * (0.5 + complexity)),
-      MAX_TIMEOUT_BUDGET_SECONDS - DEFAULT_INFRA_OVERHEAD_BUDGET_SECONDS,
+    const maxRemoteRuntimeBudgetSeconds =
+      MAX_TIMEOUT_BUDGET_SECONDS - DEFAULT_INFRA_OVERHEAD_BUDGET_SECONDS;
+    const expectedRemoteRuntimeBudgetSeconds = Math.round(
+      Math.max(30, Math.min(baseTimeout * (0.5 + complexity), maxRemoteRuntimeBudgetSeconds)),
     );
 
     expect(result.remoteRuntimeBudgetSeconds).toBe(expectedRemoteRuntimeBudgetSeconds);

--- a/src/lib/timeout-estimator.test.ts
+++ b/src/lib/timeout-estimator.test.ts
@@ -211,17 +211,30 @@ describe("estimateTimeoutRisk", () => {
   });
 
   test("timeout budgets separate remote runtime from infra overhead", () => {
+    const fileCount = 1;
+    const linesChanged = 10;
+    const languageComplexity = 1.0;
     const result = estimateTimeoutRisk({
-      fileCount: 1,
-      linesChanged: 10,
-      languageComplexity: 1.0,
+      fileCount,
+      linesChanged,
+      languageComplexity,
       isLargePR: false,
       baseTimeoutSeconds: baseTimeout,
     });
 
-    expect(result.remoteRuntimeBudgetSeconds).toBe(423);
+    const fileScore = Math.min(fileCount / 100, 1.0);
+    const lineScore = Math.min(linesChanged / 5000, 1.0);
+    const complexity = fileScore * 0.4 + lineScore * 0.4 + languageComplexity * 0.2;
+    const expectedRemoteRuntimeBudgetSeconds = Math.min(
+      Math.round(baseTimeout * (0.5 + complexity)),
+      MAX_TIMEOUT_BUDGET_SECONDS - DEFAULT_INFRA_OVERHEAD_BUDGET_SECONDS,
+    );
+
+    expect(result.remoteRuntimeBudgetSeconds).toBe(expectedRemoteRuntimeBudgetSeconds);
     expect(result.infraOverheadBudgetSeconds).toBe(DEFAULT_INFRA_OVERHEAD_BUDGET_SECONDS);
-    expect(result.totalTimeoutSeconds).toBe(603);
+    expect(result.totalTimeoutSeconds).toBe(
+      result.remoteRuntimeBudgetSeconds + result.infraOverheadBudgetSeconds,
+    );
   });
 
   test("reasoning string contains key metrics", () => {

--- a/src/lib/timeout-estimator.ts
+++ b/src/lib/timeout-estimator.ts
@@ -86,7 +86,7 @@ export function estimateTimeoutRisk(params: {
     riskLevel = "high";
   }
 
-  // Dynamic timeout: range [0.5x, 1.5x] of base, clamped [30, 1800]
+  // Dynamic timeout: range [0.5x, 1.5x] of base, clamped so total budget stays within platform max
   const rawTimeout = baseTimeoutSeconds * (0.5 + complexity);
   const maxRemoteRuntimeBudgetSeconds = Math.max(
     30,


### PR DESCRIPTION
## Summary

- Cherry-picks the review timeout diagnostics/budgeting fix onto current `main` after PR #122 landed.
- Adds the small-diff review fast path design doc to keep the design artifact with the related review-budget work.

## Verification

```text
bun test ./src/lib/timeout-estimator.test.ts \
  ./src/lib/review-utils.test.ts \
  ./src/lib/partial-review-formatter.test.ts \
  ./src/execution/executor.test.ts \
  ./src/handlers/review.test.ts

245 pass
0 fail
1120 expect() calls
```

Also ran:

```text
git diff --check origin/main...HEAD
```
