### PR TITLE
Default clean reviews to comments

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -73,7 +73,7 @@ GitHub webhook
 - **Large PR triage**: PRs exceeding configured thresholds are triaged by file risk scores. Lower-risk files may be skipped to stay within LLM context limits.
 - **Dependency bump detection**: PRs that are pure dependency updates (npm, pip, etc.) get a specialized review flow with changelog and advisory enrichment.
 - **Guardrails**: A post-processing pipeline validates LLM output for epistemic quality — suppressing hallucinated line references, fabricated claims, and overconfident findings.
-- **Auto-approval**: If configured and all findings are below the severity threshold, Kodiai can submit an approving review.
+- **Clean-review publication**: By default, clean reviews publish approval-shaped issue comments without changing GitHub's review approval state. Repositories can opt in to approving GitHub reviews with `review.autoApprove: true`.
 - **Fork-based write mode**: For repos where Kodiai lacks push access, write operations go through a fork managed by a bot user account.
 
 ## Request Lifecycle: Mentions

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,7 +14,8 @@ timeoutSeconds: 600
 
 review:
   enabled: true
-  autoApprove: true
+  # Default is false: clean reviews publish as comments unless you opt in to GitHub approvals.
+  autoApprove: false
   triggers:
     onOpened: true
     onReadyForReview: true
@@ -175,9 +176,9 @@ Use the nested `review.triggers.onSynchronize` shape. Legacy `review.onSynchroni
 | | |
 |---|---|
 | **Type** | `boolean` |
-| **Default** | `true` |
+| **Default** | `false` |
 
-If `true`, Kodiai submits an approving review when no critical/major findings exist. Set to `false` to always submit as a comment-only review.
+If `true`, Kodiai submits an approving GitHub review when the review completes cleanly with no published findings. The default is `false`, so clean reviews publish the same approval-shaped content as a normal PR issue comment instead of changing GitHub's review approval state. Set this to `true` only for repositories that explicitly want Kodiai to approve PRs.
 
 ### `review.prompt`
 

--- a/docs/runbooks/review-requested-debug.md
+++ b/docs/runbooks/review-requested-debug.md
@@ -191,12 +191,13 @@ Expected success and recovery outcomes:
     - `explicitReviewRequest=true`
     - `publishResolution=executor`
     - `reviewOutputKey=<key>`
-- **Fresh approval publish**
+- **Fresh clean-review publish**
   - `Explicit mention review idempotency check passed`
-  - `Submitted approval review for explicit mention request`
+  - Default (`review.autoApprove: false`): `Submitted approval-shaped comment for explicit mention request`
+  - Opt-in (`review.autoApprove: true`): `Submitted approval review for explicit mention request`
   - `Mention execution completed` with:
     - `explicitReviewRequest=true`
-    - `publishResolution=approval-bridge`
+    - `publishResolution=comment-approval` by default, or `approval-bridge` when `review.autoApprove: true`
     - `reviewOutputKey=<key>`
 - **Already published / idempotent skip**
   - `Skipping explicit mention review publish because output already exists`
@@ -209,8 +210,8 @@ Expected success and recovery outcomes:
 
 Failure-path outcomes are also explicit:
 
-- `publishResolution=publish-failure-fallback` means the approval publish failed and Kodiai posted an error comment instead.
-- `publishResolution=publish-failure-comment-failed` means the approval publish failed and even the fallback error comment could not be delivered.
+- `publishResolution=publish-failure-fallback` means the clean-review publish failed and Kodiai posted an error comment instead.
+- `publishResolution=publish-failure-comment-failed` means the clean-review publish failed and even the fallback error comment could not be delivered.
 
 `reviewOutputKey` is the durable correlation key across the idempotency logs, the evidence bundle, and the final completion log.
 

--- a/src/execution/config.test.ts
+++ b/src/execution/config.test.ts
@@ -34,7 +34,7 @@ test("returns defaults when no .kodiai.yml exists", async () => {
     expect(config.review.triggers.onOpened).toBe(true);
     expect(config.review.triggers.onReadyForReview).toBe(true);
     expect(config.review.triggers.onReviewRequested).toBe(true);
-    expect(config.review.autoApprove).toBe(true);
+    expect(config.review.autoApprove).toBe(false);
     expect(config.review.skipAuthors).toEqual([]);
     expect(config.review.skipPaths).toEqual([]);
     expect(config.review.prompt).toBeUndefined();
@@ -276,7 +276,7 @@ test("parses review.prompt from YAML", async () => {
     const { config } = await loadRepoConfig(dir);
     expect(config.review.prompt).toBe("Focus on security issues");
     expect(config.review.enabled).toBe(true);
-    expect(config.review.autoApprove).toBe(true);
+    expect(config.review.autoApprove).toBe(false);
   } finally {
     await rm(dir, { recursive: true });
   }

--- a/src/execution/config.ts
+++ b/src/execution/config.ts
@@ -110,7 +110,7 @@ const reviewSchema = z
   .object({
     enabled: z.boolean().default(true),
     triggers: reviewTriggersSchema,
-    autoApprove: z.boolean().default(true),
+    autoApprove: z.boolean().default(false),
     prompt: z.string().optional(),
     skipAuthors: z.array(z.string()).default([]),
     skipPaths: z.array(z.string()).default([]),
@@ -177,7 +177,7 @@ const reviewSchema = z
       onReviewRequested: true,
       onSynchronize: false,
     },
-    autoApprove: true,
+    autoApprove: false,
     skipAuthors: [],
     skipPaths: [],
     mode: "standard",

--- a/src/handlers/mention.test.ts
+++ b/src/handlers/mention.test.ts
@@ -9074,6 +9074,174 @@ describe("createMentionHandler review command", () => {
     await workspaceFixture.cleanup();
   });
 
+  test("explicit PR review mention posts approval-shaped issue comment when autoApprove is disabled", async () => {
+    const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
+    const workspaceFixture = await createWorkspaceFixture("mention:\n  enabled: true\nreview:\n  autoApprove: false\n");
+
+    const prNumber = 104;
+    const featureSha = (await $`git -C ${workspaceFixture.dir} rev-parse feature`.quiet())
+      .text()
+      .trim();
+    await $`git --git-dir ${workspaceFixture.remoteDir} update-ref refs/pull/${prNumber}/head ${featureSha}`.quiet();
+
+    const { logger, infoCalls } = createMockLogger();
+    const createdReviews: Array<{ event: string; body: string }> = [];
+    const issueReplies: string[] = [];
+    let capturedQueueLane: string | undefined;
+    let capturedTaskType: string | undefined;
+
+    const eventRouter: EventRouter = {
+      register: (eventKey, handler) => {
+        handlers.set(eventKey, handler);
+      },
+      dispatch: async () => undefined,
+    };
+
+    const jobQueue: JobQueue = {
+      enqueue: async <T>(
+        _installationId: number,
+        fn: (metadata: JobQueueRunMetadata) => Promise<T>,
+        context?: JobQueueContext,
+      ) => {
+        capturedQueueLane = context?.lane;
+        return fn(createQueueRunMetadata());
+      },
+      getQueueSize: () => 0,
+      getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
+    };
+
+    const workspaceManager: WorkspaceManager = {
+      create: async (_installationId: number, options: CloneOptions) => {
+        await $`git -C ${workspaceFixture.dir} checkout ${options.ref}`.quiet();
+        return { dir: workspaceFixture.dir, cleanup: async () => undefined };
+      },
+      cleanupStale: async () => 0,
+    };
+
+    const octokit = {
+      rest: {
+        reactions: {
+          createForIssueComment: async () => ({ data: {} }),
+          createForPullRequestReviewComment: async () => ({ data: {} }),
+        },
+        pulls: {
+          get: async () => ({
+            data: {
+              title: "Test PR",
+              body: "",
+              user: { login: "octocat" },
+              head: { ref: "feature" },
+              base: { ref: "main" },
+            },
+          }),
+          list: async () => ({ data: [] }),
+          listReviews: async () => ({ data: [] }),
+          listReviewComments: async () => ({ data: [] }),
+          createReplyForReviewComment: async () => ({ data: {} }),
+          createReview: async ({ event, body }: { event: string; body: string }) => {
+            createdReviews.push({ event, body });
+            return { data: {} };
+          },
+        },
+        issues: {
+          listComments: async () => ({ data: [] }),
+          createComment: async ({ body }: { body: string }) => {
+            issueReplies.push(body);
+            return { data: {} };
+          },
+        },
+      },
+    };
+
+    createMentionHandler({
+      eventRouter,
+      jobQueue,
+      workspaceManager,
+      githubApp: {
+        getAppSlug: () => "kodiai",
+        getInstallationOctokit: async () => octokit as never,
+      } as unknown as GitHubApp,
+      executor: {
+        execute: async (context: { taskType?: string }) => {
+          capturedTaskType = context.taskType;
+          return {
+            conclusion: "success",
+            published: false,
+            costUsd: 0,
+            numTurns: 3,
+            durationMs: 1,
+            sessionId: "session-mention-approve",
+            model: "claude-sonnet-4-5-20250929",
+            inputTokens: 1,
+            outputTokens: 1,
+            cacheReadTokens: 0,
+            cacheCreationTokens: 0,
+            stopReason: "end_turn",
+            toolUseNames: ["Glob", "Read"],
+            usedRepoInspectionTools: true,
+          };
+        },
+      } as never,
+      telemetryStore: noopTelemetryStore,
+      logger,
+    });
+
+    const handler = handlers.get("issue_comment.created");
+    expect(handler).toBeDefined();
+
+    await handler!(
+      buildPrIssueCommentMentionEvent({
+        prNumber,
+        commentBody: "@kodiai review",
+      }),
+    );
+
+    expect(capturedQueueLane).toBe("interactive-review");
+    expect(capturedTaskType).toBe("review.small-diff");
+
+    expect(createdReviews).toHaveLength(0);
+    expect(issueReplies).toHaveLength(1);
+    expect(issueReplies[0]).toContain("<details>");
+    expect(issueReplies[0]).toContain("<summary>kodiai response</summary>");
+    expect(issueReplies[0]).toContain("Decision: APPROVE");
+    expect(issueReplies[0]).toContain("Issues: none");
+    expect(issueReplies[0]).toContain("Evidence:");
+    expect(issueReplies[0]).toContain("- Review prompt covered 1 changed file.");
+    expect(issueReplies[0]).toContain("- Repo inspection tools were used to verify the changed code.");
+    expect(extractReviewOutputKey(issueReplies[0])).toBeDefined();
+
+    const idempotencyLog = infoCalls.find((entry) =>
+      entry.message === "Explicit mention review idempotency check passed",
+    );
+    const idempotencyReviewOutputKey =
+      typeof idempotencyLog?.bindings.reviewOutputKey === "string"
+        ? idempotencyLog.bindings.reviewOutputKey
+        : null;
+    expect(idempotencyReviewOutputKey).toBeDefined();
+    expect(extractReviewOutputKey(issueReplies[0])).toBe(idempotencyReviewOutputKey);
+    expect(idempotencyLog?.bindings.idempotencyDecision).toBe("publish");
+    expect(idempotencyLog?.bindings.gate).toBe("review-output-idempotency");
+    expect(idempotencyLog?.bindings.gateResult).toBe("accepted");
+
+    const publishAttemptLog = infoCalls.find((entry) =>
+      entry.message === "Submitted approval-shaped comment for explicit mention request",
+    );
+    expect(publishAttemptLog?.bindings.reviewOutputKey).toBe(idempotencyLog?.bindings.reviewOutputKey);
+    expect(publishAttemptLog?.bindings.publishAttemptOutcome).toBe("submitted-comment");
+
+    const completionLog = infoCalls.find((entry) => entry.message === "Mention execution completed");
+    expect(completionLog?.bindings.reviewOutputKey).toBe(idempotencyLog?.bindings.reviewOutputKey);
+    expect(completionLog?.bindings.explicitReviewRequest).toBe(true);
+    expect(completionLog?.bindings.taskType).toBe("review.full");
+    expect(completionLog?.bindings.lane).toBe("interactive-review");
+    expect(completionLog?.bindings.published).toBe(true);
+    expect(completionLog?.bindings.executorPublished).toBe(false);
+    expect(completionLog?.bindings.publishResolution).toBe("comment-approval");
+
+    await workspaceFixture.cleanup();
+  });
+
   test("logs stale predecessor telemetry when an explicit review claim finds an older family attempt", async () => {
     const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
     const { logger, infoCalls } = createMockLogger();

--- a/src/handlers/mention.ts
+++ b/src/handlers/mention.ts
@@ -104,6 +104,7 @@ type MentionPublishResolution =
   | "none"
   | "executor"
   | "approval-bridge"
+  | "comment-approval"
   | "idempotency-skip"
   | "duplicate-suppressed"
   | "publish-failure-fallback"
@@ -2630,7 +2631,6 @@ export function createMentionHandler(deps: {
           !result.published &&
           result.usedRepoInspectionTools === true &&
           reviewOutputKey &&
-          config.review.autoApprove &&
           !explicitReviewHasUnpublishedFindings;
 
         if (explicitReviewRequest && mention.prNumber !== undefined && !explicitReviewPublishEligible) {
@@ -2645,9 +2645,7 @@ export function createMentionHandler(deps: {
                     ? "missing-inspection-evidence"
                     : !reviewOutputKey
                       ? "missing-review-output-key"
-                      : !config.review.autoApprove
-                        ? "auto-approve-disabled"
-                        : "not-eligible";
+                      : "not-eligible";
 
           logger.info(
             {
@@ -2749,22 +2747,33 @@ export function createMentionHandler(deps: {
                 );
               } else {
                 setReviewWorkPhase("publish");
-                await publishOctokit.rest.pulls.createReview({
-                  owner: mention.owner,
-                  repo: mention.repo,
-                  pull_number: mention.prNumber,
-                  event: "APPROVE",
-                  body: sanitizeOutgoingMentions(
-                    buildApprovedReviewBody({ reviewOutputKey, evidence: approvalEvidence }),
-                    [appSlug, "claude", "kodai"],
-                  ),
-                });
+                const cleanReviewBody = sanitizeOutgoingMentions(
+                  buildApprovedReviewBody({ reviewOutputKey, evidence: approvalEvidence }),
+                  [appSlug, "claude", "kodai"],
+                );
+                if (config.review.autoApprove) {
+                  await publishOctokit.rest.pulls.createReview({
+                    owner: mention.owner,
+                    repo: mention.repo,
+                    pull_number: mention.prNumber,
+                    event: "APPROVE",
+                    body: cleanReviewBody,
+                  });
+                  publishResolution = "approval-bridge";
+                } else {
+                  await publishOctokit.rest.issues.createComment({
+                    owner: mention.owner,
+                    repo: mention.repo,
+                    issue_number: mention.prNumber,
+                    body: cleanReviewBody,
+                  });
+                  publishResolution = "comment-approval";
+                }
                 mentionOutputPublished = true;
-                publishResolution = "approval-bridge";
                 logger.info(
                   {
                     evidenceType: "review",
-                    outcome: "submitted-approval",
+                    outcome: config.review.autoApprove ? "submitted-approval" : "published-comment-approval",
                     deliveryId: event.id,
                     installationId: event.installationId,
                     owner: mention.owner,
@@ -2772,9 +2781,11 @@ export function createMentionHandler(deps: {
                     repo: `${mention.owner}/${mention.repo}`,
                     prNumber: mention.prNumber,
                     reviewOutputKey,
-                    publishAttemptOutcome: "submitted-approval",
+                    publishAttemptOutcome: config.review.autoApprove ? "submitted-approval" : "submitted-comment",
                   },
-                  "Submitted approval review for explicit mention request",
+                  config.review.autoApprove
+                    ? "Submitted approval review for explicit mention request"
+                    : "Submitted approval-shaped comment for explicit mention request",
                 );
               }
             }

--- a/src/handlers/review.test.ts
+++ b/src/handlers/review.test.ts
@@ -2062,6 +2062,116 @@ describe("createReviewHandler review_requested idempotency", () => {
     expect(createdIssueComments).toHaveLength(0);
   });
 
+  test("clean review posts approval-shaped issue comment when autoApprove is disabled", async () => {
+    const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
+    const workspaceFixture = await createWorkspaceFixture({ autoApprove: false });
+
+    const createdReviews: Array<{ body?: string | null }> = [];
+    const createdIssueComments: string[] = [];
+    let executeCount = 0;
+
+    const eventRouter: EventRouter = {
+      register: (eventKey, handler) => {
+        handlers.set(eventKey, handler);
+      },
+      dispatch: async () => undefined,
+    };
+
+    const jobQueue: JobQueue = {
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
+      getQueueSize: () => 0,
+      getPendingCount: () => 0,
+      getActiveJobs: getEmptyActiveJobs,
+    };
+
+    const workspaceManager: WorkspaceManager = {
+      create: async () => ({
+        dir: workspaceFixture.dir,
+        cleanup: async () => undefined,
+      }),
+      cleanupStale: async () => 0,
+    };
+
+    const octokit = {
+      rest: {
+        pulls: {
+          listReviewComments: async () => ({ data: [] }),
+          listReviews: async () => ({ data: createdReviews.map((review, index) => ({ id: index + 1, body: review.body ?? null })) }),
+          createReview: async ({ body }: { body?: string }) => {
+            createdReviews.push({ body: body ?? null });
+            return { data: { id: createdReviews.length } };
+          },
+        },
+        reactions: {
+          createForIssue: async () => ({ data: {} }),
+        },
+        issues: {
+          listComments: async () => ({ data: [] }),
+          createComment: async (params: { body: string }) => {
+            createdIssueComments.push(params.body);
+            return { data: { id: createdIssueComments.length, body: params.body } };
+          },
+          updateComment: async () => ({ data: {} }),
+        },
+      },
+      request: async () => ({ data: {} }),
+    };
+
+    createReviewHandler({
+      eventRouter,
+      jobQueue,
+      workspaceManager,
+      githubApp: {
+        getAppSlug: () => "kodiai",
+        getInstallationOctokit: async () => octokit as never,
+        initialize: async () => undefined,
+        checkConnectivity: async () => true,
+        getInstallationToken: async () => "token",
+      } as unknown as GitHubApp,
+      executor: {
+        execute: async () => {
+          executeCount++;
+          return {
+            conclusion: "success",
+            costUsd: 0,
+            numTurns: 1,
+            durationMs: 1,
+            sessionId: "session-clean-comment-only",
+            executorPhaseTimings: [
+              { name: "executor handoff", status: "completed", durationMs: 50 },
+              { name: "remote runtime", status: "completed", durationMs: 500 },
+            ],
+          };
+        },
+      } as never,
+      telemetryStore: noopTelemetryStore,
+      logger: createNoopLogger(),
+    });
+
+    const handler = handlers.get("pull_request.review_requested");
+    expect(handler).toBeDefined();
+
+    await handler!(buildReviewRequestedEvent({ requested_reviewer: { login: "kodiai[bot]" } }));
+
+    await workspaceFixture.cleanup();
+
+    expect(executeCount).toBe(1);
+    expect(createdReviews).toHaveLength(0);
+    expect(createdIssueComments).toHaveLength(1);
+    expect(createdIssueComments[0]).toContain("Decision: APPROVE");
+    expect(createdIssueComments[0]).toContain("Issues: none");
+    expect(createdIssueComments[0]).toContain("<summary>Review Details</summary>");
+    expect(createdIssueComments[0]).toContain(buildReviewOutputMarker(buildReviewOutputKey({
+      installationId: 42,
+      owner: "acme",
+      repo: "repo",
+      prNumber: 101,
+      action: "review_requested",
+      deliveryId: "delivery-123",
+      headSha: "abcdef1234567890",
+    })));
+  });
+
   test("published approval review receives Review Details instead of creating a separate issue comment", async () => {
     const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
     const workspaceFixture = await createWorkspaceFixture({ autoApprove: true });
@@ -4390,7 +4500,7 @@ describe("createReviewHandler cost warning (CONFIG-11)", () => {
     await $`git -C ${dir} commit -m "feature"`.quiet();
     await $`git -C ${dir} remote add origin ${dir}`.quiet();
 
-    let costWarningBody: string | undefined;
+    const commentBodies: string[] = [];
 
     const eventRouter: EventRouter = {
       register: (eventKey, handler) => { handlers.set(eventKey, handler); },
@@ -4415,7 +4525,7 @@ describe("createReviewHandler cost warning (CONFIG-11)", () => {
         issues: {
           listComments: async () => ({ data: [] }),
           createComment: async (params: { body: string }) => {
-            costWarningBody = params.body;
+            commentBodies.push(params.body);
             return { data: {} };
           },
         },
@@ -4450,6 +4560,7 @@ describe("createReviewHandler cost warning (CONFIG-11)", () => {
     );
 
     await rm(dir, { recursive: true, force: true });
+    const costWarningBody = commentBodies.find((body) => body.includes("cost warning"));
     expect(costWarningBody).toBeDefined();
     expect(costWarningBody!).toContain("cost warning");
     expect(costWarningBody!).toContain("$2.5000");
@@ -6012,7 +6123,7 @@ describe("createReviewHandler finding extraction", () => {
     expect(updateCommentCalls).toBe(0);
     expect(completedAttemptIds).toEqual(["attempt-review-details-standalone-1"]);
     expect(
-      entries.some((entry) => entry.message === "Skipping degraded Review Details fallback comment because publish rights were superseded"),
+      entries.some((entry) => entry.message === "Skipping clean review publication because publish rights were superseded"),
     ).toBeTrue();
 
     await workspaceFixture.cleanup();
@@ -6296,12 +6407,12 @@ describe("createReviewHandler finding extraction", () => {
       }),
     );
 
-    expect(listCommentsCalls).toBe(1);
+    expect(listCommentsCalls).toBeGreaterThanOrEqual(1);
     expect(createCommentCalls).toBe(0);
     expect(updateCommentCalls).toBe(0);
     expect(completedAttemptIds).toEqual(["attempt-review-details-standalone-recheck-1"]);
     expect(
-      entries.some((entry) => entry.message === "Skipping degraded Review Details fallback comment because publish rights were superseded"),
+      entries.some((entry) => entry.message === "Skipping clean review publication because publish rights were superseded"),
     ).toBeTrue();
 
     await workspaceFixture.cleanup();

--- a/src/handlers/review.ts
+++ b/src/handlers/review.ts
@@ -4717,7 +4717,7 @@ export function createReviewHandler(deps: {
                 }
               }
             } else {
-              const approvalWillOwnCanonicalSurface = config.review.autoApprove && result.conclusion === "success";
+              const approvalWillOwnCanonicalSurface = result.conclusion === "success";
 
               if (!approvalWillOwnCanonicalSurface && canPublishVisibleOutput("degraded Review Details fallback comment")) {
                 setReviewWorkPhase("publish");
@@ -6300,9 +6300,10 @@ export function createReviewHandler(deps: {
           }
         }
 
-        // Auto-approval: only when autoApprove is enabled AND execution succeeded AND
-        // the model produced zero GitHub-visible output (no summary comment, no inline comments).
-        if (config.review.autoApprove && result.conclusion === "success") {
+        // Clean review publication: when no output was produced, publish the clean
+        // result either as an approving pull review (explicit opt-in) or as a
+        // normal issue comment (default behavior).
+        if (result.conclusion === "success") {
           try {
             // If the review execution published any output (summary comment, inline comments, etc.),
             // do NOT auto-approve. Auto-approval is only valid when the bot produced zero output.
@@ -6343,10 +6344,43 @@ export function createReviewHandler(deps: {
                 },
                 "Skipping auto-approval because review output marker was published",
               );
+              if (
+                canonicalReviewDetailsBody &&
+                canPublishVisibleOutput("degraded Review Details fallback comment")
+              ) {
+                setReviewWorkPhase("publish");
+                const reviewDetailsCommentId = await upsertDegradedReviewDetailsFallbackComment({
+                  octokit,
+                  owner: apiOwner,
+                  repo: apiRepo,
+                  prNumber: pr.number,
+                  reviewOutputKey,
+                  body: canonicalReviewDetailsBody,
+                  botHandles: [appSlug, "claude"],
+                  recheckCanPublish: () =>
+                    canPublishVisibleOutput("degraded Review Details fallback comment"),
+                });
+
+                finalizePublicationPhaseTiming();
+                if (
+                  reviewDetailsCommentId !== undefined &&
+                  canPublishVisibleOutput("finalized Review Details timing update")
+                ) {
+                  await octokit.rest.issues.updateComment({
+                    owner: apiOwner,
+                    repo: apiRepo,
+                    comment_id: reviewDetailsCommentId,
+                    body: sanitizeOutgoingMentions(canonicalReviewDetailsBody, [appSlug, "claude"]),
+                  });
+                }
+              }
               return;
             }
 
-            if (!canPublishVisibleOutput("auto-approval")) {
+            const cleanReviewPublicationReason = config.review.autoApprove
+              ? "auto-approval"
+              : "clean review publication";
+            if (!canPublishVisibleOutput(cleanReviewPublicationReason)) {
               return;
             }
 
@@ -6365,25 +6399,29 @@ export function createReviewHandler(deps: {
               reviewDetailsBlock: canonicalReviewDetailsBody,
             });
 
+            const cleanReviewSurfaceKind: CanonicalSurfaceKind = config.review.autoApprove
+              ? "pull_review"
+              : "issue_comment";
+
             const canonicalApprovalReview = await upsertCanonicalReviewSurface({
               octokit,
               owner: apiOwner,
               repo: apiRepo,
               prNumber: pr.number,
               reviewOutputKey,
-              preferredKind: "pull_review",
+              preferredKind: cleanReviewSurfaceKind,
               body: approvalBody,
               botHandles: [appSlug, "claude"],
-              pullReviewEvent: "APPROVE",
-              recheckCanPublish: () => canPublishVisibleOutput("auto-approval"),
+              ...(config.review.autoApprove ? { pullReviewEvent: "APPROVE" as const } : {}),
+              recheckCanPublish: () => canPublishVisibleOutput(cleanReviewPublicationReason),
             });
 
             finalizePublicationPhaseTiming();
 
             if (
-              canonicalApprovalReview?.kind === "pull_review"
+              canonicalApprovalReview?.kind === cleanReviewSurfaceKind
               && canonicalReviewDetailsBody
-              && canPublishVisibleOutput("finalized approval canonical Review Details merge")
+              && canPublishVisibleOutput("finalized clean review canonical Review Details merge")
             ) {
               await upsertCanonicalReviewSurface({
                 octokit,
@@ -6391,23 +6429,23 @@ export function createReviewHandler(deps: {
                 repo: apiRepo,
                 prNumber: pr.number,
                 reviewOutputKey,
-                preferredKind: "pull_review",
+                preferredKind: cleanReviewSurfaceKind,
                 reviewDetailsBlock: buildReviewDetailsBody(),
                 botHandles: [appSlug, "claude"],
                 summaryBody: canonicalApprovalReview.body,
                 canonicalSurface: canonicalApprovalReview,
                 requireDegradationDisclosure: authorClassification.searchEnrichment.degraded,
                 reviewBoundedness,
-                pullReviewEvent: "APPROVE",
+                ...(config.review.autoApprove ? { pullReviewEvent: "APPROVE" as const } : {}),
                 recheckCanPublish: () =>
-                  canPublishVisibleOutput("finalized approval canonical Review Details merge"),
+                  canPublishVisibleOutput("finalized clean review canonical Review Details merge"),
               });
             }
 
             logger.info(
               {
                 evidenceType: "review",
-                outcome: "submitted-approval",
+                outcome: config.review.autoApprove ? "submitted-approval" : "published-comment-approval",
                 deliveryId: event.id,
                 installationId: event.installationId,
                 owner: apiOwner,
@@ -6420,12 +6458,16 @@ export function createReviewHandler(deps: {
             );
             logger.info(
               { prNumber: pr.number, reviewOutputKey },
-              "Submitted silent approval (no issues found)",
+              config.review.autoApprove
+                ? "Submitted silent approval (no issues found)"
+                : "Published clean review comment (no issues found)",
             );
           } catch (err) {
             logger.error(
               { err, prNumber: pr.number },
-              "Failed to submit approval",
+              config.review.autoApprove
+                ? "Failed to submit approval"
+                : "Failed to publish clean review comment",
             );
           }
         }


### PR DESCRIPTION
## Summary
- default `review.autoApprove` to `false`
- publish clean automatic and explicit review results as approval-shaped issue comments unless `review.autoApprove: true` is configured
- keep GitHub approval reviews available as an explicit opt-in and document the flag in config, architecture, and runbook docs

## Verification
- `bun test ./src/execution/config.test.ts ./src/handlers/review.test.ts ./src/handlers/mention.test.ts` — 377 pass, 0 fail
- `bun run tsc --noEmit` — exit 0
- `git diff --check origin/main...HEAD` — exit 0
