### PR TITLE
Harden review completion paths

### DIFF
--- a/src/execution/executor.test.ts
+++ b/src/execution/executor.test.ts
@@ -358,6 +358,7 @@ function createTestableExecutor(deps: {
       const executorHandoffStartedAt = Date.now();
       let executorHandoffDurationMs: number | undefined;
       let remoteRuntimeDurationMs: number | undefined;
+      let registeredMcpBearerToken: string | undefined;
 
       const buildExecutorPhaseTimings = (params: {
         handoffStatus: "completed" | "degraded" | "unavailable";
@@ -501,19 +502,6 @@ function createTestableExecutor(deps: {
         const { buildSecurityClaudeMd } = await import("./executor.ts");
         await writeFile(join(context.workspace.dir, "CLAUDE.md"), buildSecurityClaudeMd());
 
-        // Generate token
-        const mcpBearerToken = Buffer.from(
-          crypto.getRandomValues(new Uint8Array(32)),
-        ).toString("hex");
-
-        // Register
-        const factories: Record<string, () => unknown> = {};
-        for (const [name, server] of Object.entries(mcpServers)) {
-          const captured = server;
-          factories[name] = () => captured;
-        }
-        mcpJobRegistry.register(mcpBearerToken, factories as never, (timeoutSeconds + 60) * 1000);
-
         // Create workspace
         const workspaceDir = await createWorkspaceDirFn({
           mountBase: "/mnt/kodiai-workspaces",
@@ -539,6 +527,17 @@ function createTestableExecutor(deps: {
             token: context.workspace.token,
           });
         }
+
+        const mcpBearerToken = Buffer.from(
+          crypto.getRandomValues(new Uint8Array(32)),
+        ).toString("hex");
+        const factories: Record<string, () => unknown> = {};
+        for (const [name, server] of Object.entries(mcpServers)) {
+          const captured = server;
+          factories[name] = () => captured;
+        }
+        mcpJobRegistry.register(mcpBearerToken, factories as never, (timeoutSeconds + 60) * 1000);
+        registeredMcpBearerToken = mcpBearerToken;
 
         const { buildAcaJobSpec } = await import("../jobs/aca-launcher.ts");
         const spec = buildAcaJobSpec({
@@ -585,6 +584,7 @@ function createTestableExecutor(deps: {
             });
           } catch {}
           mcpJobRegistry.unregister(mcpBearerToken);
+          registeredMcpBearerToken = undefined;
           return {
             conclusion: "error",
             costUsd: undefined,
@@ -615,6 +615,7 @@ function createTestableExecutor(deps: {
 
         if (status === "failed") {
           mcpJobRegistry.unregister(mcpBearerToken);
+          registeredMcpBearerToken = undefined;
           return {
             conclusion: "error",
             costUsd: undefined,
@@ -652,6 +653,7 @@ function createTestableExecutor(deps: {
           }),
         );
         mcpJobRegistry.unregister(mcpBearerToken);
+        registeredMcpBearerToken = undefined;
 
         return {
           ...jobResult,
@@ -667,6 +669,10 @@ function createTestableExecutor(deps: {
         const durationMs = Date.now() - startTime;
         const errorMessage = err instanceof Error ? err.message : String(err);
         logger.error({ err, durationMs }, "Execution failed");
+        if (registeredMcpBearerToken) {
+          mcpJobRegistry.unregister(registeredMcpBearerToken);
+          registeredMcpBearerToken = undefined;
+        }
         return {
           conclusion: "error",
           costUsd: undefined,
@@ -851,7 +857,7 @@ test("ACA dispatch: failed path — no cancel, failure result returned", async (
   expect(result.durationMs).toBe(3000);
 });
 
-test("ACA dispatch: registry — token registered before launch, unregistered after completion", async () => {
+test("ACA dispatch: registry — token registered immediately before launch, unregistered after completion", async () => {
   tmpDir = await mkdtemp(join(tmpdir(), "kodiai-executor-test-"));
   const config = makeConfig();
   const logger = makeLogger();
@@ -860,7 +866,69 @@ test("ACA dispatch: registry — token registered before launch, unregistered af
 
   const registeredTokens: string[] = [];
   const unregisteredTokens: string[] = [];
+  const operationOrder: string[] = [];
   let tokenAtLaunchTime: string | undefined;
+
+  const wrappedRegistry = {
+    register: (token: string, factories: never, ttlMs?: number) => {
+      operationOrder.push("register");
+      registeredTokens.push(token);
+      registry.register(token, factories, ttlMs);
+    },
+    unregister: (token: string) => {
+      operationOrder.push("unregister");
+      unregisteredTokens.push(token);
+      registry.unregister(token);
+    },
+    hasToken: registry.hasToken.bind(registry),
+    getFactory: registry.getFactory.bind(registry),
+  };
+
+  const executor = createTestableExecutor({
+    githubApp,
+    logger,
+    config,
+    mcpJobRegistry: wrappedRegistry as never,
+    launchFn: async () => {
+      operationOrder.push("launch");
+      // At launch time, token should already be registered
+      tokenAtLaunchTime = registeredTokens[0];
+      return { executionName: "exec-registry" };
+    },
+    pollFn: async () => ({ status: "succeeded", durationMs: 1000 }),
+    readResultFn: async () => makeJobResult(),
+    createWorkspaceDirFn: async () => {
+      operationOrder.push("workspace");
+      return tmpDir!;
+    },
+  });
+
+  const context = makeContext(tmpDir!);
+  await executor.execute(context);
+
+  // Token is minted and registered only after the agent workspace exists, so TTL starts immediately before launch.
+  expect(operationOrder.slice(0, 3)).toEqual(["workspace", "register", "launch"]);
+  expect(registeredTokens.length).toBe(1);
+  expect(tokenAtLaunchTime).toBeDefined();
+  expect(tokenAtLaunchTime).toBe(registeredTokens[0]);
+
+  // Token was unregistered after completion
+  expect(unregisteredTokens.length).toBe(1);
+  expect(unregisteredTokens[0]).toBe(registeredTokens[0]);
+
+  // Registry is clean after completion
+  expect(registry.hasToken(registeredTokens[0]!)).toBe(false);
+});
+
+test("ACA dispatch: registry — token unregistered even when launch throws", async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), "kodiai-executor-test-"));
+  const config = makeConfig();
+  const logger = makeLogger();
+  const githubApp = makeGithubApp();
+  const registry = createMcpJobRegistry();
+
+  const registeredTokens: string[] = [];
+  const unregisteredTokens: string[] = [];
 
   const wrappedRegistry = {
     register: (token: string, factories: never, ttlMs?: number) => {
@@ -880,29 +948,18 @@ test("ACA dispatch: registry — token registered before launch, unregistered af
     logger,
     config,
     mcpJobRegistry: wrappedRegistry as never,
-    launchFn: async (opts) => {
-      // At launch time, token should already be registered
-      tokenAtLaunchTime = registeredTokens[0];
-      return { executionName: "exec-registry" };
+    launchFn: async () => {
+      throw new Error("launch failed");
     },
-    pollFn: async () => ({ status: "succeeded", durationMs: 1000 }),
-    readResultFn: async () => makeJobResult(),
     createWorkspaceDirFn: async () => tmpDir!,
   });
 
-  const context = makeContext(tmpDir!);
-  await executor.execute(context);
+  const result = await executor.execute(makeContext(tmpDir!));
 
-  // Token was registered before launch
+  expect(result.conclusion).toBe("error");
+  expect(result.errorMessage).toBe("launch failed");
   expect(registeredTokens.length).toBe(1);
-  expect(tokenAtLaunchTime).toBeDefined();
-  expect(tokenAtLaunchTime).toBe(registeredTokens[0]);
-
-  // Token was unregistered after completion
-  expect(unregisteredTokens.length).toBe(1);
-  expect(unregisteredTokens[0]).toBe(registeredTokens[0]);
-
-  // Registry is clean after completion
+  expect(unregisteredTokens).toEqual(registeredTokens);
   expect(registry.hasToken(registeredTokens[0]!)).toBe(false);
 });
 

--- a/src/execution/executor.ts
+++ b/src/execution/executor.ts
@@ -325,6 +325,7 @@ export function createExecutor(deps: {
       const executorHandoffStartedAt = Date.now();
       let executorHandoffDurationMs: number | undefined;
       let remoteRuntimeDurationMs: number | undefined;
+      let registeredMcpBearerToken: string | undefined;
 
       try {
         // Load repo config (.kodiai.yml) with defaults
@@ -480,18 +481,6 @@ export function createExecutor(deps: {
 
         // --- ACA Job dispatch ---
 
-        // Generate per-job bearer token (32 bytes → 64 hex chars)
-        const mcpBearerToken = Buffer.from(
-          crypto.getRandomValues(new Uint8Array(32)),
-        ).toString("hex");
-
-        // Register MCP server factories in the registry under this token.
-        // Each factory re-calls the server creator on every invocation so the
-        // HTTP handler gets a fresh McpServer per request — required because
-        // McpServer.connect() can only be called once per instance.
-        const factories = buildMcpServerFactories(mcpServerDeps);
-        mcpJobRegistry.register(mcpBearerToken, factories, (timeoutSeconds + 60) * 1000);
-
         // Create workspace dir on Azure Files and stage a repo snapshot for the agent.
         // WORKSPACE_DIR holds control/artifact files plus a full repo copy under ./repo
         // so the remote agent can use Read/Grep/Glob/git tools against real project files.
@@ -511,6 +500,16 @@ export function createExecutor(deps: {
           promptSections: context.promptSections,
           token: context.workspace.token,
         });
+
+        // Generate and register the per-job bearer token only after the remote
+        // workspace is staged. This keeps the registry TTL aligned with the
+        // ACA launch window instead of burning it during local handoff work.
+        const mcpBearerToken = Buffer.from(
+          crypto.getRandomValues(new Uint8Array(32)),
+        ).toString("hex");
+        const factories = buildMcpServerFactories(mcpServerDeps);
+        mcpJobRegistry.register(mcpBearerToken, factories, (timeoutSeconds + 60) * 1000);
+        registeredMcpBearerToken = mcpBearerToken;
 
         // Build and launch the ACA job
         const spec = buildAcaJobSpec({
@@ -588,6 +587,7 @@ export function createExecutor(deps: {
             remoteRuntimeDetail: "remote runtime timed out",
           });
           mcpJobRegistry.unregister(mcpBearerToken);
+          registeredMcpBearerToken = undefined;
           return {
             conclusion: "error",
             costUsd: undefined,
@@ -647,6 +647,7 @@ export function createExecutor(deps: {
             // best effort only
           }
           mcpJobRegistry.unregister(mcpBearerToken);
+          registeredMcpBearerToken = undefined;
           return {
             conclusion: "error",
             costUsd: undefined,
@@ -687,6 +688,7 @@ export function createExecutor(deps: {
 
         // Unregister after reading result
         mcpJobRegistry.unregister(mcpBearerToken);
+        registeredMcpBearerToken = undefined;
 
         // Merge published / publishEvents from MCP callbacks (fired during pollUntilComplete)
         return {
@@ -707,6 +709,10 @@ export function createExecutor(deps: {
         const errorMessage =
           err instanceof Error ? err.message : String(err);
         logger.error({ err, durationMs }, "Execution failed");
+        if (registeredMcpBearerToken) {
+          mcpJobRegistry.unregister(registeredMcpBearerToken);
+          registeredMcpBearerToken = undefined;
+        }
 
         const executorPhaseTimings = buildExecutorPhaseTimings({
           handoffStatus: executorHandoffDurationMs === undefined ? "degraded" : "completed",

--- a/src/execution/mcp/http-server.test.ts
+++ b/src/execution/mcp/http-server.test.ts
@@ -71,6 +71,20 @@ describe("createMcpJobRegistry", () => {
     reg.register("tok-exp", { test_server: makeFactory() }, -1); // already expired
     expect(reg.hasToken("tok-exp")).toBe(false);
   });
+
+  test("inspectToken distinguishes missing from expired tokens", () => {
+    const reg = createMcpJobRegistry();
+    reg.register("tok-exp", { test_server: makeFactory() }, -1);
+
+    expect(reg.inspectToken("missing-token")).toEqual({
+      ok: false,
+      reason: "missing",
+    });
+    expect(reg.inspectToken("tok-exp")).toMatchObject({
+      ok: false,
+      reason: "expired",
+    });
+  });
 });
 
 describe("createMcpHttpRoutes", () => {
@@ -98,6 +112,27 @@ describe("createMcpHttpRoutes", () => {
     expect(res.status).toBe(401);
     const body = await res.json() as { error: string };
     expect(body.error).toBe("Unauthorized");
+  });
+
+  test("unauthorized requests log missing versus expired token reasons", async () => {
+    const registry = createMcpJobRegistry();
+    registry.register("expired-token", { test_server: makeFactory() }, -1);
+    const warnings: Array<Record<string, unknown>> = [];
+    const logger = {
+      warn: (data: Record<string, unknown>) => warnings.push(data),
+    };
+    const app = createMcpHttpRoutes(registry, logger as never);
+
+    const missing = await mcpPost(app, "test_server", "missing-token");
+    const expired = await mcpPost(app, "test_server", "expired-token");
+
+    expect(missing.status).toBe(401);
+    expect(expired.status).toBe(401);
+    expect(warnings).toContainEqual(expect.objectContaining({ authFailureReason: "missing" }));
+    expect(warnings).toContainEqual(expect.objectContaining({ authFailureReason: "expired" }));
+    expect(warnings.find((entry) => entry.authFailureReason === "expired")).toEqual(
+      expect.objectContaining({ ttlRemainingMs: expect.any(Number) }),
+    );
   });
 
   test("valid token + unknown server name → 404", async () => {

--- a/src/execution/mcp/http-server.ts
+++ b/src/execution/mcp/http-server.ts
@@ -20,6 +20,21 @@ type McpJobEntry = {
 export function createMcpJobRegistry() {
   const registry = new Map<string, McpJobEntry>();
 
+  const inspectToken = (token: string):
+    | { ok: true; ttlRemainingMs: number }
+    | { ok: false; reason: "missing" | "expired"; ttlRemainingMs?: number } => {
+    const entry = registry.get(token);
+    if (!entry) return { ok: false, reason: "missing" };
+
+    const ttlRemainingMs = entry.expiresAt - Date.now();
+    if (ttlRemainingMs <= 0) {
+      registry.delete(token);
+      return { ok: false, reason: "expired", ttlRemainingMs };
+    }
+
+    return { ok: true, ttlRemainingMs };
+  };
+
   return {
     register(
       token: string,
@@ -33,28 +48,18 @@ export function createMcpJobRegistry() {
       registry.delete(token);
     },
 
+    inspectToken,
+
     hasToken(token: string): boolean {
-      const entry = registry.get(token);
-      if (!entry) return false;
-      // Treat expired entries as absent (lazy expiry).
-      if (entry.expiresAt <= Date.now()) {
-        registry.delete(token);
-        return false;
-      }
-      return true;
+      return inspectToken(token).ok;
     },
 
     getFactory(
       token: string,
       serverName: string,
     ): (() => McpSdkServerConfigWithInstance) | undefined {
-      const entry = registry.get(token);
-      if (!entry) return undefined;
-      if (entry.expiresAt <= Date.now()) {
-        registry.delete(token);
-        return undefined;
-      }
-      return entry.factories[serverName];
+      if (!inspectToken(token).ok) return undefined;
+      return registry.get(token)?.factories[serverName];
     },
   };
 }
@@ -84,9 +89,24 @@ export function createMcpHttpRoutes(
     const authHeader = c.req.header("Authorization");
     const token = authHeader?.replace(/^Bearer /, "");
 
-    if (!token || !registry.hasToken(token)) {
+    if (!token) {
       logger?.warn(
-        { tokenPrefix: token?.slice(0, 8) },
+        { tokenPrefix: undefined, authFailureReason: "missing" },
+        "MCP HTTP: unauthorized",
+      );
+      return c.json({ error: "Unauthorized" }, 401);
+    }
+
+    const authState = registry.inspectToken(token);
+    if (!authState.ok) {
+      logger?.warn(
+        {
+          tokenPrefix: token.slice(0, 8),
+          authFailureReason: authState.reason,
+          ...(authState.ttlRemainingMs !== undefined
+            ? { ttlRemainingMs: authState.ttlRemainingMs }
+            : {}),
+        },
         "MCP HTTP: unauthorized",
       );
       return c.json({ error: "Unauthorized" }, 401);

--- a/src/handlers/review.test.ts
+++ b/src/handlers/review.test.ts
@@ -16302,10 +16302,107 @@ describe("createReviewHandler failure fallback publication", () => {
     await workspaceFixture.cleanup();
   });
 
+  test("enables checkpoint preservation for full reviews even when timeout risk is low", async () => {
+    const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
+    const workspaceFixture = await createWorkspaceFixture();
+    const executeContexts: Array<Record<string, unknown>> = [];
+
+    createReviewHandler({
+      eventRouter: {
+        register: (eventKey, handler) => {
+          handlers.set(eventKey, handler);
+        },
+        dispatch: async () => undefined,
+      },
+      jobQueue: {
+        enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) =>
+          fn(createQueueRunMetadata()),
+        getQueueSize: () => 0,
+        getPendingCount: () => 0,
+        getActiveJobs: getEmptyActiveJobs,
+      } as unknown as JobQueue,
+      workspaceManager: {
+        create: async () => ({
+          dir: workspaceFixture.dir,
+          cleanup: async () => undefined,
+        }),
+        cleanupStale: async () => 0,
+      } as WorkspaceManager,
+      githubApp: {
+        getAppSlug: () => "kodiai",
+        getInstallationOctokit: async () => ({
+          rest: {
+            pulls: {
+              listReviewComments: async () => ({ data: [] }),
+              listReviews: async () => ({ data: [] }),
+              listCommits: async () => ({ data: [] }),
+              createReview: async () => ({ data: {} }),
+            },
+            issues: {
+              listComments: async () => ({ data: [] }),
+              createComment: async () => ({ data: { id: 900 } }),
+              updateComment: async () => ({ data: {} }),
+            },
+            reactions: {
+              createForIssue: async () => ({ data: {} }),
+            },
+            search: {
+              issuesAndPullRequests: async () => ({ data: { total_count: 0 } }),
+            },
+          },
+        }) as never,
+      } as unknown as GitHubApp,
+      executor: {
+        execute: async (context: Record<string, unknown>) => {
+          executeContexts.push(context);
+          return {
+            conclusion: "success",
+            published: false,
+            durationMs: 1,
+            numTurns: 1,
+            sessionId: "session-full-review-checkpoint",
+            costUsd: 0,
+          };
+        },
+      } as never,
+      telemetryStore: noopTelemetryStore,
+      knowledgeStore: createKnowledgeStoreStub() as never,
+      diffContextCollector: async () => ({
+        changedFiles: ["README.md", "src/a.ts", "src/b.ts"],
+        numstatLines: ["1\t1\tREADME.md", "1\t1\tsrc/a.ts", "1\t1\tsrc/b.ts"],
+        diffContent: undefined,
+        strategy: "github-file-list-fallback",
+        mergeBaseRecovered: false,
+        deepenAttempts: 0,
+        unshallowAttempted: false,
+        diffRange: "github-api:file-list",
+      }),
+      logger: createNoopLogger(),
+    });
+
+    const handler = handlers.get("pull_request.review_requested");
+    expect(handler).toBeDefined();
+
+    await handler!(
+      buildReviewRequestedEvent({
+        requested_reviewer: { login: "kodiai[bot]" },
+      }),
+    );
+
+    expect(executeContexts.length).toBe(1);
+    expect(executeContexts[0]).toMatchObject({
+      taskType: "review.full",
+      enableCheckpointTool: true,
+    });
+
+    await workspaceFixture.cleanup();
+  });
+
   test("schedules a reduced-scope retry after max-turns when checkpoint evidence has remaining scope", async () => {
     const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
     const workspaceFixture = await createWorkspaceFixture();
     const createdCommentBodies: string[] = [];
+    const { logger, entries } = createCaptureLogger();
     let queuedRetryJob: ((metadata: JobQueueRunMetadata) => Promise<unknown>) | undefined;
 
     createReviewHandler({
@@ -16404,7 +16501,7 @@ describe("createReviewHandler failure fallback publication", () => {
         unshallowAttempted: false,
         diffRange: "github-api:file-list",
       }),
-      logger: createNoopLogger(),
+      logger,
     });
 
     const handler = handlers.get("pull_request.review_requested");
@@ -16420,6 +16517,10 @@ describe("createReviewHandler failure fallback publication", () => {
     expect(boundedComment).toBeDefined();
     expect(boundedComment).toContain("Scheduling a reduced-scope retry.");
     expect(queuedRetryJob).toBeDefined();
+
+    const retryLog = entries.find((entry) => entry.message === "Enqueueing retry with reduced scope");
+    expect(retryLog?.data?.retryTimeout).toEqual(expect.any(Number));
+    expect(retryLog!.data!.retryTimeout as number).toBeGreaterThan(30);
 
     await workspaceFixture.cleanup();
   });

--- a/src/handlers/review.ts
+++ b/src/handlers/review.ts
@@ -3643,6 +3643,7 @@ export function createReviewHandler(deps: {
         );
 
         const checkpointEnabled =
+          reviewRouting.taskType === TASK_TYPES.REVIEW_FULL ||
           timeoutEstimate.riskLevel === "medium" ||
           timeoutEstimate.riskLevel === "high";
 
@@ -5254,7 +5255,7 @@ export function createReviewHandler(deps: {
                       break;
                     case "zero-evidence-failure": {
                       retryState = "not scheduled (zero-evidence timeout)";
-                      const retryTimeout = Math.max(30, Math.floor(timeoutDuration / 2));
+                      const retryRemoteRuntimeBudgetSeconds = Math.max(30, Math.floor(timeoutDuration / 2));
                       const retryScope = computeRetryScope({
                         allFiles: riskScores,
                         filesAlreadyReviewed: timeoutReviewedFiles,
@@ -5272,7 +5273,7 @@ export function createReviewHandler(deps: {
                           }, 0),
                           languageComplexity,
                           isLargePR: false,
-                          baseTimeoutSeconds: retryTimeout,
+                          baseTimeoutSeconds: retryRemoteRuntimeBudgetSeconds,
                         });
                         retryPlan = {
                           decision: "schedule-continuation",
@@ -5282,8 +5283,11 @@ export function createReviewHandler(deps: {
                           continuationNumber: 1,
                           continuationFiles,
                           scopeRatio: retryScope.scopeRatio,
-                          timeoutSeconds: retryTimeout,
-                          checkpointEnabled: timeoutEstimate.riskLevel === "medium" || timeoutEstimate.riskLevel === "high",
+                          timeoutSeconds: timeoutEstimate.totalTimeoutSeconds,
+                          checkpointEnabled:
+                            reviewRouting.taskType === TASK_TYPES.REVIEW_FULL ||
+                            timeoutEstimate.riskLevel === "medium" ||
+                            timeoutEstimate.riskLevel === "high",
                           timeoutEstimate,
                           firstPass: timeoutFirstPass,
                           checkpoint,


### PR DESCRIPTION
## Summary
- enable checkpoint preservation for all full reviews so max-turn failures have structured progress evidence
- register per-job MCP bearer tokens only after workspace staging and always unregister them on launch/result failures
- add MCP auth diagnostics that distinguish missing vs expired tokens
- size reduced-scope retry timeouts from the recomputed timeout estimate, including infra overhead

## Verification
- bun test ./src/execution/mcp/http-server.test.ts ./src/execution/executor.test.ts ./src/handlers/review.test.ts
- bun run tsc --noEmit
- bun run lint
- git diff --check

Note: broad `bun test` still fails in checked-in tmp/claude-code-* fixtures because action dependencies such as @actions/core, @actions/github, and shell-quote are absent in this workspace; product-targeted tests pass.