### PR TITLE
Fix explicit review timeout budget and stale base-ref fetches

### DIFF
--- a/src/handlers/mention.test.ts
+++ b/src/handlers/mention.test.ts
@@ -8910,6 +8910,125 @@ describe("createMentionHandler review command", () => {
     await workspaceFixture.cleanup();
   });
 
+  test("explicit PR review mention applies complexity-scaled timeout budget", async () => {
+    const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
+    const workspaceFixture = await createWorkspaceFixture("mention:\n  enabled: true\n");
+
+    const prNumber = 204;
+    await $`git -C ${workspaceFixture.dir} checkout feature`.quiet();
+    await $`mkdir -p ${join(workspaceFixture.dir, "src")}`.quiet();
+    await Bun.write(
+      join(workspaceFixture.dir, "src", "large-review-surface.ts"),
+      Array.from({ length: 3000 }, (_, index) => `export const value${index} = ${index};`).join("\n") + "\n",
+    );
+    await $`git -C ${workspaceFixture.dir} add src/large-review-surface.ts`.quiet();
+    await $`git -C ${workspaceFixture.dir} commit -m "large review surface"`.quiet();
+    const featureSha = (await $`git -C ${workspaceFixture.dir} rev-parse feature`.quiet())
+      .text()
+      .trim();
+    await $`git -C ${workspaceFixture.dir} push -f origin feature`.quiet();
+    await $`git --git-dir ${workspaceFixture.remoteDir} update-ref refs/pull/${prNumber}/head ${featureSha}`.quiet();
+
+    let capturedDynamicTimeoutSeconds: number | undefined;
+    let capturedTaskType: string | undefined;
+
+    createMentionHandler({
+      eventRouter: {
+        register: (eventKey, handler) => {
+          handlers.set(eventKey, handler);
+        },
+        dispatch: async () => undefined,
+      },
+      jobQueue: {
+        enqueue: async <T>(
+          _installationId: number,
+          fn: (metadata: JobQueueRunMetadata) => Promise<T>,
+        ) => fn(createQueueRunMetadata()),
+        getQueueSize: () => 0,
+        getPendingCount: () => 0,
+        getActiveJobs: getEmptyActiveJobs,
+      } as unknown as JobQueue,
+      workspaceManager: {
+        create: async (_installationId: number, options: CloneOptions) => {
+          await $`git -C ${workspaceFixture.dir} checkout ${options.ref}`.quiet();
+          return { dir: workspaceFixture.dir, cleanup: async () => undefined };
+        },
+        cleanupStale: async () => 0,
+      } as WorkspaceManager,
+      githubApp: {
+        getAppSlug: () => "kodiai",
+        getInstallationOctokit: async () => ({
+          rest: {
+            reactions: {
+              createForIssueComment: async () => ({ data: {} }),
+              createForPullRequestReviewComment: async () => ({ data: {} }),
+            },
+            pulls: {
+              get: async () => ({
+                data: {
+                  title: "Large explicit review PR",
+                  body: "",
+                  additions: 3000,
+                  deletions: 0,
+                  draft: false,
+                  labels: [],
+                  user: { login: "octocat" },
+                  head: { ref: "feature" },
+                  base: { ref: "main" },
+                },
+              }),
+              list: async () => ({ data: [] }),
+              listFiles: async () => ({ data: [{ filename: "src/large-review-surface.ts" }] }),
+              listReviews: async () => ({ data: [] }),
+              listReviewComments: async () => ({ data: [] }),
+              createReplyForReviewComment: async () => ({ data: {} }),
+              createReview: async () => ({ data: {} }),
+            },
+            issues: {
+              listComments: async () => ({ data: [] }),
+              createComment: async () => ({ data: {} }),
+            },
+          },
+        }) as never,
+      } as unknown as GitHubApp,
+      executor: {
+        execute: async (context: { dynamicTimeoutSeconds?: number; taskType?: string }) => {
+          capturedDynamicTimeoutSeconds = context.dynamicTimeoutSeconds;
+          capturedTaskType = context.taskType;
+          return {
+            conclusion: "success",
+            published: true,
+            costUsd: 0,
+            numTurns: 3,
+            durationMs: 1,
+            sessionId: "session-explicit-timeout-budget",
+            stopReason: "end_turn",
+            toolUseNames: ["Read"],
+            usedRepoInspectionTools: true,
+          };
+        },
+      } as never,
+      telemetryStore: noopTelemetryStore,
+      logger: createNoopLogger(),
+    });
+
+    const handler = handlers.get("issue_comment.created");
+    expect(handler).toBeDefined();
+
+    await handler!(
+      buildPrIssueCommentMentionEvent({
+        prNumber,
+        commentBody: "@kodiai review",
+      }),
+    );
+
+    expect(capturedTaskType).toBe("review.full");
+    expect(capturedDynamicTimeoutSeconds).toEqual(expect.any(Number));
+    expect(capturedDynamicTimeoutSeconds!).toBeGreaterThan(600);
+
+    await workspaceFixture.cleanup();
+  });
+
   test("explicit PR review mention stays on interactive-review/review.full and submits approval review when inspection evidence is present", async () => {
     const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
     const workspaceFixture = await createWorkspaceFixture("mention:\n  enabled: true\nreview:\n  autoApprove: true\n");

--- a/src/handlers/mention.ts
+++ b/src/handlers/mention.ts
@@ -22,6 +22,7 @@ import {
   commitAndPushToRemoteRef,
   pushHeadToRemoteRef,
   buildAuthFetchUrl,
+  fetchRemoteTrackingBranch,
   WritePolicyError,
   assertOriginIsFork,
   shouldUseGist,
@@ -1568,8 +1569,12 @@ export function createMentionHandler(deps: {
           // Ensure base branch exists as a remote-tracking ref so git diff tools can compare
           // origin/BASE...HEAD even in --single-branch workspaces.
           if (mention.baseRef) {
-            const fetchRemote1 = await buildAuthFetchUrl(workspace.dir, workspace.token);
-            await $`git -C ${workspace.dir} fetch ${fetchRemote1} ${mention.baseRef}:refs/remotes/origin/${mention.baseRef} --depth=1`.quiet();
+            await fetchRemoteTrackingBranch({
+              dir: workspace.dir,
+              branch: mention.baseRef,
+              token: workspace.token,
+              depth: 1,
+            });
           }
         }
 

--- a/src/handlers/mention.ts
+++ b/src/handlers/mention.ts
@@ -60,6 +60,7 @@ import { buildPromptSectionRecord, type PromptBuildResult } from "../execution/p
 import { buildRetrievalVariants } from "../knowledge/multi-query-retrieval.ts";
 import { analyzeDiff, classifyFileLanguage, parseNumstatPerFile } from "../execution/diff-analysis.ts";
 import { computeFileRiskScores, triageFilesByRisk } from "../lib/file-risk-scorer.ts";
+import { computeLanguageComplexity, estimateTimeoutRisk } from "../lib/timeout-estimator.ts";
 import { buildSearchCacheKey, createSearchCache, type SearchCacheOptions } from "../lib/search-cache.ts";
 import {
   type ErrorCategory,
@@ -2376,6 +2377,7 @@ export function createMentionHandler(deps: {
         let prompt: string;
         let promptSections: import("../telemetry/types.ts").PromptSectionRecord[] = [];
         let explicitReviewPromptFileCount: number | undefined;
+        let explicitReviewDynamicTimeoutSeconds: number | undefined;
         let explicitReviewRouting: ReviewTaskRouting = {
           taskType: TASK_TYPES.REVIEW_FULL,
           routingReason: "standard",
@@ -2427,6 +2429,17 @@ export function createMentionHandler(deps: {
             changedFileCount: promptChangedFiles.length,
             linesChanged: explicitReviewLinesChanged,
           });
+          const languageComplexity = computeLanguageComplexity(diffAnalysis.filesByLanguage);
+          const timeoutEstimate = estimateTimeoutRisk({
+            fileCount: promptChangedFiles.length,
+            linesChanged: explicitReviewLinesChanged,
+            languageComplexity,
+            isLargePR: diffAnalysis.isLargePR,
+            baseTimeoutSeconds: config.timeoutSeconds,
+          });
+          explicitReviewDynamicTimeoutSeconds = config.timeout.dynamicScaling !== false
+            ? timeoutEstimate.totalTimeoutSeconds
+            : undefined;
           logger.info(
             {
               surface: mention.surface,
@@ -2439,6 +2452,10 @@ export function createMentionHandler(deps: {
               changedFiles: promptChangedFiles.length,
               linesChanged: explicitReviewLinesChanged,
               maxTurns: explicitReviewRouting.maxTurnsOverride ?? null,
+              timeoutSeconds: explicitReviewDynamicTimeoutSeconds ?? null,
+              timeoutRiskLevel: timeoutEstimate.riskLevel,
+              remoteRuntimeBudgetSeconds: timeoutEstimate.remoteRuntimeBudgetSeconds,
+              infraOverheadBudgetSeconds: timeoutEstimate.infraOverheadBudgetSeconds,
               lane: "interactive-review",
             },
             "Mention review routing decision",
@@ -2603,6 +2620,7 @@ export function createMentionHandler(deps: {
           promptSections,
           reviewOutputKey,
           maxTurnsOverride: mentionMaxTurns,
+          dynamicTimeoutSeconds: explicitReviewDynamicTimeoutSeconds,
           knowledgeStore: deps.knowledgeStore,
           totalFiles: explicitReviewPromptFileCount,
           enableInlineTools: explicitReviewRequest ? true : undefined,

--- a/src/handlers/review.ts
+++ b/src/handlers/review.ts
@@ -140,7 +140,7 @@ import {
 } from "../knowledge/code-snippet-chunker.ts";
 import type { CodeSnippetStore } from "../knowledge/code-snippet-types.ts";
 import { $ } from "bun";
-import { fetchAndCheckoutPullRequestHeadRef, buildAuthFetchUrl } from "../jobs/workspace.ts";
+import { fetchAndCheckoutPullRequestHeadRef, buildAuthFetchUrl, fetchRemoteTrackingBranch } from "../jobs/workspace.ts";
 import {
   buildReviewFamilyKey,
   createReviewWorkCoordinator,
@@ -1406,7 +1406,7 @@ export async function collectDiffContext(params: {
       );
 
       const deepenResult = await diffCommandRunner(
-        ["fetch", fetchRemote, `${baseRef}:refs/remotes/origin/${baseRef}`, `--deepen=${step}`],
+        ["fetch", fetchRemote, `+${baseRef}:refs/remotes/origin/${baseRef}`, `--deepen=${step}`],
         commandTimeoutMs,
       );
       if (deepenResult.timedOut) {
@@ -1446,7 +1446,7 @@ export async function collectDiffContext(params: {
       );
 
       const unshallowResult = await diffCommandRunner(
-        ["fetch", fetchRemote, `${baseRef}:refs/remotes/origin/${baseRef}`, "--unshallow"],
+        ["fetch", fetchRemote, `+${baseRef}:refs/remotes/origin/${baseRef}`, "--unshallow"],
         commandTimeoutMs,
       );
       if (unshallowResult.timedOut) {
@@ -2413,8 +2413,12 @@ export function createReviewHandler(deps: {
 
         // Fetch base branch so git diff origin/BASE...HEAD works.
         // Explicit refspec needed because --single-branch clones don't track other branches.
-        const fetchRemoteReview = await buildAuthFetchUrl(workspace.dir, workspace.token);
-        await $`git -C ${workspace.dir} fetch ${fetchRemoteReview} ${pr.base.ref}:refs/remotes/origin/${pr.base.ref} --depth=1`.quiet();
+        await fetchRemoteTrackingBranch({
+          dir: workspace.dir,
+          branch: pr.base.ref,
+          token: workspace.token,
+          depth: 1,
+        });
 
         setReviewWorkPhase("load-config");
         // Load repo config (.kodiai.yml) with defaults
@@ -5613,8 +5617,12 @@ export function createReviewHandler(deps: {
                       });
                     }
 
-                    const fetchRemoteRetry = await buildAuthFetchUrl(retryWorkspace.dir, retryWorkspace.token);
-                    await $`git -C ${retryWorkspace.dir} fetch ${fetchRemoteRetry} ${pr.base.ref}:refs/remotes/origin/${pr.base.ref} --depth=1`.quiet();
+                    await fetchRemoteTrackingBranch({
+                      dir: retryWorkspace.dir,
+                      branch: pr.base.ref,
+                      token: retryWorkspace.token,
+                      depth: 1,
+                    });
 
                     const retryInstruction = [
                       result.isTimeout

--- a/src/jobs/workspace.test.ts
+++ b/src/jobs/workspace.test.ts
@@ -9,6 +9,7 @@ import {
   WritePolicyError,
   buildAuthFetchUrl,
   createWorkspaceManager,
+  fetchRemoteTrackingBranch,
 } from "./workspace.ts";
 import type { GitHubApp } from "../auth/github-app.ts";
 
@@ -211,6 +212,47 @@ async function setupBareAndClone(bareDir: string, cloneDir: string): Promise<str
     await rm(srcDir, { recursive: true, force: true });
   }
 }
+
+// ---------------------------------------------------------------------------
+// buildAuthFetchUrl tests
+// ---------------------------------------------------------------------------
+
+describe("fetchRemoteTrackingBranch", () => {
+  test("force-updates a stale remote-tracking branch after base history rewinds", async () => {
+    const tmpBase = await mkdtemp(join(tmpdir(), "kodiai-workspace-test-"));
+    const bareDir = join(tmpBase, "bare.git");
+    const cloneDir = join(tmpBase, "clone");
+
+    try {
+      await setupBareAndClone(bareDir, cloneDir);
+
+      const originalRemoteMain = (await $`git -C ${cloneDir} rev-parse refs/remotes/origin/main`.quiet()).text().trim();
+
+      await $`git -C ${cloneDir} checkout -B local-diverged refs/remotes/origin/main`.quiet();
+      await writeFile(join(cloneDir, "README.md"), "locally diverged\n");
+      await $`git -C ${cloneDir} add README.md`.quiet();
+      await $`git -C ${cloneDir} commit -m "local diverged remote tracking state"`.quiet();
+      const divergedSha = (await $`git -C ${cloneDir} rev-parse HEAD`.quiet()).text().trim();
+      await $`git -C ${cloneDir} update-ref refs/remotes/origin/main ${divergedSha}`.quiet();
+
+      const rejectedFetch = await $`git -C ${cloneDir} fetch origin main:refs/remotes/origin/main --depth=1`.quiet().nothrow();
+      expect(rejectedFetch.exitCode).toBe(1);
+      expect(rejectedFetch.stderr.toString()).toContain("non-fast-forward");
+
+      await fetchRemoteTrackingBranch({
+        dir: cloneDir,
+        branch: "main",
+        depth: 1,
+      });
+
+      const refreshedRemoteMain = (await $`git -C ${cloneDir} rev-parse refs/remotes/origin/main`.quiet()).text().trim();
+      expect(refreshedRemoteMain).toBe(originalRemoteMain);
+      expect(refreshedRemoteMain).not.toBe(divergedSha);
+    } finally {
+      await rm(tmpBase, { recursive: true, force: true });
+    }
+  });
+});
 
 // ---------------------------------------------------------------------------
 // buildAuthFetchUrl tests

--- a/src/jobs/workspace.ts
+++ b/src/jobs/workspace.ts
@@ -166,6 +166,36 @@ export async function buildAuthFetchUrl(dir: string, token: string | undefined):
   return makeAuthUrl(url, token);
 }
 
+/**
+ * Fetch a branch into its remote-tracking ref, force-updating the local tracking
+ * ref when the remote branch was rewound or the workspace has stale state.
+ *
+ * Git refuses non-fast-forward updates to refs/remotes/* unless the refspec is
+ * force-prefixed. Kodiai workspaces are ephemeral review/checkouts, so the
+ * remote-tracking ref should mirror the remote exactly instead of failing the
+ * review when a base branch moves backwards between clone and refresh.
+ */
+export async function fetchRemoteTrackingBranch(options: {
+  dir: string;
+  branch: string;
+  remoteName?: string;
+  token?: string;
+  depth?: number;
+}): Promise<void> {
+  const { dir, branch, remoteName = "origin", token, depth = 1 } = options;
+  validateBranchName(branch);
+  validateBranchName(remoteName);
+
+  try {
+    const strippedUrl = (await $`git -C ${dir} remote get-url ${remoteName}`.quiet()).text().trim();
+    const fetchUrl = makeAuthUrl(strippedUrl, token);
+    await $`git -C ${dir} fetch ${fetchUrl} +${branch}:refs/remotes/${remoteName}/${branch} --depth=${depth}`.quiet();
+  } catch (err) {
+    redactTokenFromError(err, token);
+    throw err;
+  }
+}
+
 function redactTokenFromError(err: unknown, token: string | undefined): void {
   if (!(err instanceof Error)) return;
 


### PR DESCRIPTION
## Summary
- Preserve full review-class budget for explicit `@kodiai review` mentions instead of mention caps.
- Add forced remote-tracking branch refresh for review base refs so stale/non-fast-forward refs do not crash review setup.
- Cover the stale base-ref failure with a regression test.

## Root cause for xbmc/xbmc#25316 failure
The explicit review job failed while preparing the PR workspace. Runtime logs showed `git fetch ... master:refs/remotes/origin/master --depth=1` rejected with `non-fast-forward`, which bubbled up as the generic “Kodiai encountered an error” comment. Review workspaces are ephemeral, so base remote-tracking refs should mirror the remote and be force-refreshed.

## Test Plan
- `bun test ./src/jobs/workspace.test.ts`
- `bun test ./src/handlers/mention.test.ts`
- `bun test ./src/handlers/review.test.ts`
- `bun run tsc --noEmit`
- `bun run lint`