### PR TITLE
Scale review max turns by timeout risk

### DIFF
--- a/src/handlers/mention.test.ts
+++ b/src/handlers/mention.test.ts
@@ -8930,6 +8930,7 @@ describe("createMentionHandler review command", () => {
     await $`git --git-dir ${workspaceFixture.remoteDir} update-ref refs/pull/${prNumber}/head ${featureSha}`.quiet();
 
     let capturedDynamicTimeoutSeconds: number | undefined;
+    let capturedMaxTurnsOverride: number | undefined;
     let capturedTaskType: string | undefined;
 
     createMentionHandler({
@@ -8992,8 +8993,9 @@ describe("createMentionHandler review command", () => {
         }) as never,
       } as unknown as GitHubApp,
       executor: {
-        execute: async (context: { dynamicTimeoutSeconds?: number; taskType?: string }) => {
+        execute: async (context: { dynamicTimeoutSeconds?: number; maxTurnsOverride?: number; taskType?: string }) => {
           capturedDynamicTimeoutSeconds = context.dynamicTimeoutSeconds;
+          capturedMaxTurnsOverride = context.maxTurnsOverride;
           capturedTaskType = context.taskType;
           return {
             conclusion: "success",
@@ -9025,6 +9027,8 @@ describe("createMentionHandler review command", () => {
     expect(capturedTaskType).toBe("review.full");
     expect(capturedDynamicTimeoutSeconds).toEqual(expect.any(Number));
     expect(capturedDynamicTimeoutSeconds!).toBeGreaterThan(600);
+    expect(capturedMaxTurnsOverride).toEqual(expect.any(Number));
+    expect(capturedMaxTurnsOverride!).toBeGreaterThan(25);
 
     await workspaceFixture.cleanup();
   });

--- a/src/handlers/mention.ts
+++ b/src/handlers/mention.ts
@@ -55,6 +55,7 @@ import { TASK_TYPES } from "../llm/task-types.ts";
 import {
   resolveReviewRoutingLineCount,
   resolveReviewTaskRouting,
+  resolveReviewMaxTurnsOverride,
   type ReviewTaskRouting,
 } from "../lib/review-routing.ts";
 import { buildPromptSectionRecord, type PromptBuildResult } from "../execution/prompt-section-metrics.ts";
@@ -2383,6 +2384,7 @@ export function createMentionHandler(deps: {
         let promptSections: import("../telemetry/types.ts").PromptSectionRecord[] = [];
         let explicitReviewPromptFileCount: number | undefined;
         let explicitReviewDynamicTimeoutSeconds: number | undefined;
+        let explicitReviewMaxTurnsOverride: number | undefined;
         let explicitReviewRouting: ReviewTaskRouting = {
           taskType: TASK_TYPES.REVIEW_FULL,
           routingReason: "standard",
@@ -2445,6 +2447,12 @@ export function createMentionHandler(deps: {
           explicitReviewDynamicTimeoutSeconds = config.timeout.dynamicScaling !== false
             ? timeoutEstimate.totalTimeoutSeconds
             : undefined;
+          explicitReviewMaxTurnsOverride = resolveReviewMaxTurnsOverride({
+            taskType: explicitReviewRouting.taskType,
+            routingMaxTurnsOverride: explicitReviewRouting.maxTurnsOverride,
+            timeoutRiskLevel: timeoutEstimate.riskLevel,
+            baseMaxTurns: config.maxTurns,
+          });
           logger.info(
             {
               surface: mention.surface,
@@ -2456,7 +2464,8 @@ export function createMentionHandler(deps: {
               routingReason: explicitReviewRouting.routingReason,
               changedFiles: promptChangedFiles.length,
               linesChanged: explicitReviewLinesChanged,
-              maxTurns: explicitReviewRouting.maxTurnsOverride ?? null,
+              maxTurns: explicitReviewMaxTurnsOverride ?? null,
+              maxTurnsSource: explicitReviewMaxTurnsOverride !== undefined ? "dynamic-risk" : "config",
               timeoutSeconds: explicitReviewDynamicTimeoutSeconds ?? null,
               timeoutRiskLevel: timeoutEstimate.riskLevel,
               remoteRuntimeBudgetSeconds: timeoutEstimate.remoteRuntimeBudgetSeconds,
@@ -2585,7 +2594,7 @@ export function createMentionHandler(deps: {
         // large PRs do not terminate mid-tool-call before any publish step occurs.
         const mentionMaxTurns =
           explicitReviewRequest
-            ? explicitReviewRouting.maxTurnsOverride
+            ? explicitReviewMaxTurnsOverride
             : (!writeEnabled && mention.prNumber !== undefined)
               ? (prDiffContext !== undefined ? 12 : 20)
               : undefined; // undefined → falls through to config.maxTurns

--- a/src/handlers/review.ts
+++ b/src/handlers/review.ts
@@ -67,6 +67,7 @@ import {
 import {
   resolveReviewRoutingLineCount,
   resolveReviewTaskRouting,
+  resolveReviewMaxTurnsOverride,
 } from "../lib/review-routing.ts";
 import { prioritizeFindings } from "../lib/finding-prioritizer.ts";
 import { computeConfidence, matchesSuppression } from "../knowledge/confidence.ts";
@@ -3615,6 +3616,12 @@ export function createReviewHandler(deps: {
           changedFileCount: changedFiles.length,
           linesChanged: reviewRoutingLinesChanged,
         });
+        const reviewMaxTurnsOverride = resolveReviewMaxTurnsOverride({
+          taskType: reviewRouting.taskType,
+          routingMaxTurnsOverride: reviewRouting.maxTurnsOverride,
+          timeoutRiskLevel: timeoutEstimate.riskLevel,
+          baseMaxTurns: config.maxTurns,
+        });
 
         logger.info(
           {
@@ -3626,7 +3633,8 @@ export function createReviewHandler(deps: {
             linesChanged: reviewRoutingLinesChanged,
             diffAnalysisLinesChanged,
             prApiLinesChanged,
-            maxTurns: reviewRouting.maxTurnsOverride ?? null,
+            maxTurns: reviewMaxTurnsOverride ?? null,
+            maxTurnsSource: reviewMaxTurnsOverride !== undefined ? "dynamic-risk" : "config",
           },
           "Review routing decision",
         );
@@ -4007,7 +4015,7 @@ export function createReviewHandler(deps: {
           dynamicTimeoutSeconds: appliedTimeoutBudget
             ? appliedTimeoutBudget.totalTimeoutSeconds
             : undefined,
-          maxTurnsOverride: reviewRouting.maxTurnsOverride,
+          maxTurnsOverride: reviewMaxTurnsOverride,
         });
         executorResult = result;
         executorPhaseTimings = result.executorPhaseTimings ?? buildExecutorUnavailablePhases(
@@ -5767,7 +5775,7 @@ export function createReviewHandler(deps: {
                       reviewOutputKey: retryReviewOutputKey,
                       deliveryId: retryDeliveryId,
                       dynamicTimeoutSeconds: retryTimeout,
-                      maxTurnsOverride: reviewRouting.maxTurnsOverride,
+                      maxTurnsOverride: reviewMaxTurnsOverride,
                       knowledgeStore,
                       totalFiles: timeoutTotalFiles,
                       enableCheckpointTool: retryCheckpointEnabled,

--- a/src/lib/review-routing.test.ts
+++ b/src/lib/review-routing.test.ts
@@ -5,7 +5,10 @@ import {
   isSmallDiffReviewEligible,
   resolveReviewRoutingLineCount,
   resolveReviewTaskRouting,
+  resolveReviewMaxTurnsOverride,
   SMALL_DIFF_MAX_TURNS,
+  HIGH_RISK_REVIEW_MAX_TURNS,
+  MEDIUM_RISK_REVIEW_MAX_TURNS,
 } from "./review-routing.ts";
 
 describe("review-routing", () => {
@@ -56,5 +59,36 @@ describe("review-routing", () => {
       taskType: TASK_TYPES.REVIEW_FULL,
       routingReason: "standard",
     });
+  });
+
+  test("keeps small-diff turn override ahead of risk scaling", () => {
+    expect(resolveReviewMaxTurnsOverride({
+      taskType: TASK_TYPES.REVIEW_SMALL_DIFF,
+      routingMaxTurnsOverride: SMALL_DIFF_MAX_TURNS,
+      timeoutRiskLevel: "high",
+      baseMaxTurns: 25,
+    })).toBe(SMALL_DIFF_MAX_TURNS);
+  });
+
+  test("raises standard full-review turn budget for medium and high timeout risk", () => {
+    expect(resolveReviewMaxTurnsOverride({
+      taskType: TASK_TYPES.REVIEW_FULL,
+      timeoutRiskLevel: "medium",
+      baseMaxTurns: 25,
+    })).toBe(MEDIUM_RISK_REVIEW_MAX_TURNS);
+
+    expect(resolveReviewMaxTurnsOverride({
+      taskType: TASK_TYPES.REVIEW_FULL,
+      timeoutRiskLevel: "high",
+      baseMaxTurns: 25,
+    })).toBe(HIGH_RISK_REVIEW_MAX_TURNS);
+  });
+
+  test("does not lower an explicitly higher repo maxTurns setting", () => {
+    expect(resolveReviewMaxTurnsOverride({
+      taskType: TASK_TYPES.REVIEW_FULL,
+      timeoutRiskLevel: "high",
+      baseMaxTurns: 100,
+    })).toBeUndefined();
   });
 });

--- a/src/lib/review-routing.ts
+++ b/src/lib/review-routing.ts
@@ -3,6 +3,10 @@ import { TASK_TYPES } from "../llm/task-types.ts";
 export const SMALL_DIFF_MAX_FILES = 2;
 export const SMALL_DIFF_MAX_LINES = 20;
 export const SMALL_DIFF_MAX_TURNS = 8;
+export const MEDIUM_RISK_REVIEW_MAX_TURNS = 50;
+export const HIGH_RISK_REVIEW_MAX_TURNS = 75;
+
+export type ReviewTimeoutRiskLevel = "low" | "medium" | "high";
 
 export const SMALL_DIFF_REVIEW_BASE_TOOLS = [
   "Read",
@@ -68,4 +72,27 @@ export function resolveReviewTaskRouting(params: {
     taskType: TASK_TYPES.REVIEW_FULL,
     routingReason: "standard",
   };
+}
+
+export function resolveReviewMaxTurnsOverride(params: {
+  taskType: string;
+  routingMaxTurnsOverride?: number;
+  timeoutRiskLevel: ReviewTimeoutRiskLevel;
+  baseMaxTurns: number;
+}): number | undefined {
+  if (params.routingMaxTurnsOverride !== undefined) {
+    return params.routingMaxTurnsOverride;
+  }
+
+  if (params.taskType !== TASK_TYPES.REVIEW_FULL) {
+    return undefined;
+  }
+
+  const scaledMaxTurns = params.timeoutRiskLevel === "high"
+    ? HIGH_RISK_REVIEW_MAX_TURNS
+    : params.timeoutRiskLevel === "medium"
+      ? MEDIUM_RISK_REVIEW_MAX_TURNS
+      : params.baseMaxTurns;
+
+  return scaledMaxTurns > params.baseMaxTurns ? scaledMaxTurns : undefined;
 }


### PR DESCRIPTION
## Summary
- Add risk-based max-turn scaling for standard `review.full` runs: medium risk gets 50 turns and high risk gets 75 turns.
- Preserve the existing small-diff 8-turn override and never lower repo-configured `maxTurns` when it is already higher.
- Wire the scaled turn override into automatic reviews, retries, and explicit `@kodiai review` mentions.

## Root cause
The live `xbmc/xbmc#25316` retry proved the timeout budget scaled correctly (`timeoutSeconds=1079`), but executor config still used `maxTurns=25` from repo config. The SDK stopped first on `error_max_turns` around `numTurns=26`, so timeout scaling alone was insufficient.

## Test Plan
- `bun test ./src/lib/review-routing.test.ts ./src/handlers/mention.test.ts`
- `bun test ./src/handlers/review.test.ts`
- `bun test ./src/execution/executor.test.ts`
- `bun run tsc --noEmit`
- `bun run lint`