### PR TITLE
Classify and dedupe usage-limit mention errors

### DIFF
--- a/src/handlers/mention.test.ts
+++ b/src/handlers/mention.test.ts
@@ -12785,3 +12785,130 @@ describe("createMentionHandler mention derived-context cache", () => {
     await workspaceFixture.cleanup();
   });
 });
+
+
+test("review-comment error fallback checks parent existence before choosing top-level comment", async () => {
+  const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
+  const workspaceFixture = await createWorkspaceFixture("mention:\n  enabled: true\nreview:\n  autoApprove: true\n");
+
+  const prNumber = 109;
+  const featureSha = (await $`git -C ${workspaceFixture.dir} rev-parse feature`.quiet())
+    .text()
+    .trim();
+  await $`git --git-dir ${workspaceFixture.remoteDir} update-ref refs/pull/${prNumber}/head ${featureSha}`.quiet();
+
+  const { logger, infoCalls } = createMockLogger();
+  const issueReplies: string[] = [];
+  let getReviewCommentCalls = 0;
+  let createReplyCalls = 0;
+
+  const eventRouter: EventRouter = {
+    register: (eventKey, handler) => {
+      handlers.set(eventKey, handler);
+    },
+    dispatch: async () => undefined,
+  };
+
+  const jobQueue: JobQueue = {
+    enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn(createQueueRunMetadata()),
+    getQueueSize: () => 0,
+    getPendingCount: () => 0,
+    getActiveJobs: getEmptyActiveJobs,
+  };
+
+  const workspaceManager: WorkspaceManager = {
+    create: async (_installationId: number, options: CloneOptions) => {
+      await $`git -C ${workspaceFixture.dir} checkout ${options.ref}`.quiet();
+      return { dir: workspaceFixture.dir, cleanup: async () => undefined };
+    },
+    cleanupStale: async () => 0,
+  };
+
+  const octokit = {
+    rest: {
+      reactions: {
+        createForIssueComment: async () => ({ data: {} }),
+        createForPullRequestReviewComment: async () => ({ data: {} }),
+      },
+      pulls: {
+        get: async () => ({
+          data: {
+            title: "Test PR",
+            body: "",
+            user: { login: "octocat" },
+            head: { ref: "feature", repo: { name: "repo", owner: { login: "acme" } } },
+            base: { ref: "main" },
+          },
+        }),
+        list: async () => ({ data: [] }),
+        listReviews: async () => ({ data: [] }),
+        listReviewComments: async () => ({ data: [] }),
+        getReviewComment: async () => {
+          getReviewCommentCalls += 1;
+          throw Object.assign(new Error("Not Found"), { status: 404 });
+        },
+        createReplyForReviewComment: async () => {
+          createReplyCalls += 1;
+          return { data: {} };
+        },
+        createReview: async () => ({ data: {} }),
+      },
+      issues: {
+        listComments: async () => ({ data: [] }),
+        createComment: async ({ body }: { body: string }) => {
+          issueReplies.push(body);
+          return { data: { id: issueReplies.length } };
+        },
+      },
+    },
+  };
+
+  createMentionHandler({
+    eventRouter,
+    jobQueue,
+    workspaceManager,
+    githubApp: {
+      getAppSlug: () => "kodiai",
+      getInstallationOctokit: async () => octokit as never,
+    } as unknown as GitHubApp,
+    executor: {
+      execute: async () => ({
+        conclusion: "error",
+        published: false,
+        durationMs: 1,
+        errorMessage: "Claude Code returned an error result: You've hit your limit · resets 10:50pm (UTC)",
+        toolUseNames: [],
+        usedRepoInspectionTools: false,
+      }),
+    } as never,
+    telemetryStore: noopTelemetryStore,
+    logger,
+  });
+
+  const handler = handlers.get("pull_request_review_comment.created");
+  expect(handler).toBeDefined();
+
+  await handler!(
+    buildReviewCommentMentionEvent({
+      prNumber,
+      baseRef: "main",
+      headRef: "feature",
+      headRepoOwner: "acme",
+      headRepoName: "repo",
+      commentBody: "@kodiai review",
+      commentId: 3177222400,
+    }),
+  );
+
+  expect(getReviewCommentCalls).toBe(1);
+  expect(createReplyCalls).toBe(0);
+  expect(issueReplies).toHaveLength(1);
+  expect(issueReplies[0]).toContain("You've hit your limit");
+  expect(issueReplies[0]).toContain("kodiai:error:usage-limit");
+
+  const completionLog = infoCalls.find((entry) => entry.message === "Mention execution completed");
+  expect(completionLog?.bindings.failureSubtype).toBe("usage_limit");
+  expect(completionLog?.bindings.errorCategory).toBe("usage_limit");
+
+  await workspaceFixture.cleanup();
+});

--- a/src/handlers/mention.ts
+++ b/src/handlers/mention.ts
@@ -122,6 +122,15 @@ type MentionErrorPostResult = {
   delivery: MentionErrorDelivery;
 };
 
+type MentionExecutionFailureSubtype = "usage_limit";
+
+function classifyMentionExecutionFailureSubtype(errorMessage: string | undefined): MentionExecutionFailureSubtype | undefined {
+  if (errorMessage === undefined) {
+    return undefined;
+  }
+  return classifyError(new Error(errorMessage), false) === "usage_limit" ? "usage_limit" : undefined;
+}
+
 const MENTION_RETRIEVAL_MAX_CONTEXT_CHARS = 1200;
 
 function buildMentionQueueKey(owner: string, repo: string, issueOrPrNumber: number): string {
@@ -1411,22 +1420,53 @@ export function createMentionHandler(deps: {
 
         async function postMentionError(errorBody: string): Promise<MentionErrorPostResult> {
           const sanitizedBody = sanitizeOutgoingMentions(errorBody, possibleHandles);
-          // Prefer replying in-thread for inline review comment mentions.
+          // Prefer replying in-thread for inline review comment mentions, but only
+          // after proving the parent still exists. GitHub returns 404 when users
+          // delete stale review comments between webhook receipt and error
+          // publication; probing first avoids a noisy failed reply attempt.
           if (mention.surface === "pr_review_comment" && mention.prNumber !== undefined) {
+            let parentReviewCommentExists = true;
             try {
-              await octokit.rest.pulls.createReplyForReviewComment({
+              await octokit.rest.pulls.getReviewComment({
                 owner: mention.owner,
                 repo: mention.repo,
-                pull_number: mention.prNumber,
                 comment_id: mention.commentId,
-                body: sanitizedBody,
               });
-              return { posted: true, delivery: "review-thread-reply" };
             } catch (err) {
-              logger.warn(
-                { err, prNumber: mention.prNumber, commentId: mention.commentId },
-                "Failed to post in-thread error reply; falling back to top-level error comment",
-              );
+              const status = typeof err === "object" && err !== null
+                ? (err as { status?: unknown }).status
+                : undefined;
+              if (status === 404) {
+                parentReviewCommentExists = false;
+                logger.info(
+                  { prNumber: mention.prNumber, commentId: mention.commentId },
+                  "Skipping in-thread error reply because parent review comment no longer exists",
+                );
+              } else {
+                logger.warn(
+                  { err, prNumber: mention.prNumber, commentId: mention.commentId },
+                  "Could not verify parent review comment before posting error reply; falling back to top-level error comment",
+                );
+                parentReviewCommentExists = false;
+              }
+            }
+
+            if (parentReviewCommentExists) {
+              try {
+                await octokit.rest.pulls.createReplyForReviewComment({
+                  owner: mention.owner,
+                  repo: mention.repo,
+                  pull_number: mention.prNumber,
+                  comment_id: mention.commentId,
+                  body: sanitizedBody,
+                });
+                return { posted: true, delivery: "review-thread-reply" };
+              } catch (err) {
+                logger.warn(
+                  { err, prNumber: mention.prNumber, commentId: mention.commentId },
+                  "Failed to post in-thread error reply; falling back to top-level error comment",
+                );
+              }
             }
           }
 
@@ -2930,6 +2970,12 @@ export function createMentionHandler(deps: {
           }
         }
 
+        const mentionExecutionErrorCategory = result.errorMessage !== undefined
+          ? classifyError(new Error(result.errorMessage), result.isTimeout ?? false, result.published)
+          : undefined;
+        const mentionFailureSubtype = result.failureSubtype
+          ?? classifyMentionExecutionFailureSubtype(result.errorMessage);
+
         logger.info(
           {
             surface: mention.surface,
@@ -2946,7 +2992,8 @@ export function createMentionHandler(deps: {
             durationMs: result.durationMs,
             sessionId: result.sessionId,
             stopReason: result.stopReason,
-            failureSubtype: result.failureSubtype,
+            failureSubtype: mentionFailureSubtype,
+            errorCategory: mentionExecutionErrorCategory,
             usedRepoInspectionTools: result.usedRepoInspectionTools ?? false,
             toolUseNames: result.toolUseNames ?? [],
             mentionDerivedContextCacheStatus,

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -1,7 +1,8 @@
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, mock } from "bun:test";
 import {
   classifyError,
   formatErrorComment,
+  postOrUpdateErrorComment,
   type ErrorCategory,
 } from "./errors";
 
@@ -65,6 +66,15 @@ describe("classifyError", () => {
     ).toBe("api_error");
   });
 
+  test("returns 'usage_limit' for Claude Code usage limit errors", () => {
+    expect(
+      classifyError(new Error("Claude Code returned an error result: You've hit your limit · resets 10:50pm (UTC)"), false),
+    ).toBe("usage_limit");
+    expect(
+      classifyError(new Error("usage limit exceeded"), false),
+    ).toBe("usage_limit");
+  });
+
   test("returns 'internal_error' as default", () => {
     expect(
       classifyError(new Error("something unexpected happened"), false),
@@ -89,6 +99,7 @@ describe("formatErrorComment", () => {
     "config_error",
     "clone_error",
     "internal_error",
+    "usage_limit",
   ];
 
   test("produces correct markdown structure for each category", () => {
@@ -99,6 +110,7 @@ describe("formatErrorComment", () => {
       config_error: "Kodiai found a configuration problem",
       clone_error: "Kodiai couldn't access the repository",
       internal_error: "Kodiai encountered an error",
+      usage_limit: "Kodiai hit its Claude usage limit",
     };
 
     for (const category of categories) {
@@ -144,6 +156,12 @@ describe("formatErrorComment", () => {
     expect(result).toContain("report");
   });
 
+  test("includes suggestion for usage_limit", () => {
+    const result = formatErrorComment("usage_limit", "Claude Code returned an error result: You've hit your limit · resets 10:50pm (UTC)");
+    expect(result).toContain("try again after the reset time");
+    expect(result).toContain("kodiai:error:usage-limit");
+  });
+
   test("redacts GitHub tokens in detail", () => {
     const token = "ghs_" + "a".repeat(36);
     const result = formatErrorComment("internal_error", `Error with token ${token}`);
@@ -163,3 +181,48 @@ describe("formatErrorComment", () => {
     expect(result).toContain("[REDACTED_GITHUB_TOKEN]");
   });
 });
+
+// --- postOrUpdateErrorComment duplicate handling ---
+
+describe("postOrUpdateErrorComment", () => {
+  test("updates a recent usage-limit error comment instead of creating a duplicate", async () => {
+    const createdAt = new Date(Date.now() - 60_000).toISOString();
+    const existingBody = wrapUsageLimitBody("first failure");
+    const replacementBody = wrapUsageLimitBody("second failure");
+    const createComment = mock(async () => ({ data: { id: 2 } }));
+    const updateComment = mock(async () => ({ data: { id: 1 } }));
+    const listComments = mock(async () => ({
+      data: [
+        {
+          id: 1,
+          body: existingBody,
+          created_at: createdAt,
+          user: { login: "kodiai[bot]" },
+        },
+      ],
+    }));
+    const logger = { error: mock(() => undefined) };
+
+    const result = await postOrUpdateErrorComment(
+      {
+        rest: {
+          issues: { createComment, updateComment, listComments },
+        },
+      } as never,
+      { owner: "acme", repo: "repo", issueNumber: 42 },
+      replacementBody,
+      logger as never,
+    );
+
+    expect(result).toEqual({ ok: true, resolution: "updated", method: "update-comment" });
+    expect(listComments).toHaveBeenCalledTimes(1);
+    expect(updateComment).toHaveBeenCalledTimes(1);
+    const updateCall = updateComment.mock.calls[0] as unknown[] | undefined;
+    expect(updateCall?.[0]).toMatchObject({ comment_id: 1, body: replacementBody });
+    expect(createComment).not.toHaveBeenCalled();
+  });
+});
+
+function wrapUsageLimitBody(detail: string): string {
+  return `<details>\n<summary>Kodiai encountered an error</summary>\n\n${formatErrorComment("usage_limit", detail)}\n\n</details>`;
+}

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -14,14 +14,15 @@ import type { Octokit } from "@octokit/rest";
 import type { Logger } from "pino";
 import { redactGitHubTokens } from "./sanitizer.ts";
 
-/** The six user-facing error categories */
+/** User-facing error categories. */
 export type ErrorCategory =
   | "timeout"
   | "timeout_partial"
   | "api_error"
   | "config_error"
   | "clone_error"
-  | "internal_error";
+  | "internal_error"
+  | "usage_limit";
 
 export type ErrorCommentPublicationMethod = "create-comment" | "update-comment";
 export type ErrorCommentPublicationResolution = "created" | "updated" | "failed";
@@ -62,6 +63,10 @@ export function classifyError(
 
   if (message.includes(".kodiai.yml")) return "config_error";
 
+  if (/you(?:'|’)ve hit your limit|you have hit your limit|usage limit/i.test(message)) {
+    return "usage_limit";
+  }
+
   if (status !== undefined && status >= 400 && status < 600) return "api_error";
 
   // API errors checked before clone errors: "rate limit" contains "git"
@@ -81,6 +86,7 @@ const HEADERS: Record<ErrorCategory, string> = {
   config_error: "Kodiai found a configuration problem",
   clone_error: "Kodiai couldn't access the repository",
   internal_error: "Kodiai encountered an error",
+  usage_limit: "Kodiai hit its Claude usage limit",
 };
 
 /** Actionable suggestions for each error category */
@@ -95,7 +101,12 @@ const SUGGESTIONS: Record<ErrorCategory, string> = {
   clone_error:
     "Verify the repository is accessible and the branch exists.",
   internal_error: "If this persists, please report this issue.",
+  usage_limit:
+    "Kodiai cannot run another Claude review until the provider usage limit resets. Please try again after the reset time shown above.",
 };
+
+const USAGE_LIMIT_ERROR_MARKER = "<!-- kodiai:error:usage-limit -->";
+const USAGE_LIMIT_DEDUPE_WINDOW_MS = 15 * 60 * 1000;
 
 /**
  * Format an error into a user-facing markdown comment.
@@ -115,7 +126,46 @@ export function formatErrorComment(
   const suggestion = SUGGESTIONS[category];
   const sanitizedDetail = redactGitHubTokens(detail);
 
-  return `> **${header}**\n\n_${sanitizedDetail}_\n\n${suggestion}`;
+  return [
+    `> **${header}**\n\n_${sanitizedDetail}_\n\n${suggestion}`,
+    category === "usage_limit" ? USAGE_LIMIT_ERROR_MARKER : undefined,
+  ].filter((line): line is string => line !== undefined).join("\n\n");
+}
+
+async function findRecentUsageLimitErrorComment(
+  octokit: Octokit,
+  target: {
+    owner: string;
+    repo: string;
+    issueNumber: number;
+  },
+): Promise<number | undefined> {
+  const listComments = octokit.rest.issues.listComments;
+  if (typeof listComments !== "function") {
+    return undefined;
+  }
+
+  const { data } = await listComments({
+    owner: target.owner,
+    repo: target.repo,
+    issue_number: target.issueNumber,
+    per_page: 100,
+  });
+
+  const cutoffMs = Date.now() - USAGE_LIMIT_DEDUPE_WINDOW_MS;
+  const recent = data
+    .filter((comment) => {
+      const body = typeof comment.body === "string" ? comment.body : "";
+      const login = comment.user?.login ?? "";
+      const createdAtMs = Date.parse(comment.created_at ?? "");
+      return body.includes(USAGE_LIMIT_ERROR_MARKER)
+        && login.includes("kodiai")
+        && Number.isFinite(createdAtMs)
+        && createdAtMs >= cutoffMs;
+    })
+    .sort((a, b) => Date.parse(b.created_at ?? "") - Date.parse(a.created_at ?? ""));
+
+  return recent[0]?.id;
 }
 
 /**
@@ -158,6 +208,19 @@ export async function postOrUpdateErrorComment(
         body,
       });
       return { ok: true, resolution: "updated", method };
+    }
+
+    if (body.includes(USAGE_LIMIT_ERROR_MARKER)) {
+      const duplicateCommentId = await findRecentUsageLimitErrorComment(octokit, target);
+      if (duplicateCommentId !== undefined) {
+        await octokit.rest.issues.updateComment({
+          owner: target.owner,
+          repo: target.repo,
+          comment_id: duplicateCommentId,
+          body,
+        });
+        return { ok: true, resolution: "updated", method: "update-comment" };
+      }
     }
 
     await octokit.rest.issues.createComment({


### PR DESCRIPTION
## Summary
- Classify Claude usage-limit failures as a dedicated `usage_limit` category/subtype.
- Add a hidden marker and 15-minute dedupe window so repeated usage-limit error comments update the recent bot comment instead of creating duplicates.
- Check review-comment parent existence before attempting an in-thread error reply; deleted parents now go straight to top-level fallback.

## Root cause
Recent explicit review failures on `xbmc/repo-scripts#2823` were app-level `conclusion:error` results caused by Claude Code usage limits, not Kodiai routing or max-turn exhaustion. One review-comment fallback also attempted to reply to a deleted parent review comment and had to recover from a GitHub 404.

## Test Plan
- `bun test ./src/lib/errors.test.ts ./src/handlers/mention.test.ts`
- `bun run tsc --noEmit`
- `bun run lint`