### PR TITLE
Fix bounded review follow-ups and handoff latency

### DIFF
--- a/src/execution/executor.test.ts
+++ b/src/execution/executor.test.ts
@@ -1643,14 +1643,13 @@ test("prepareAgentWorkspace writes a review bundle transport for repos with trac
   }
 });
 
-test("prepareAgentWorkspace unshallows PR workspaces before writing a review bundle transport", async () => {
+test("prepareAgentWorkspace snapshots shallow PR workspaces without unshallowing", async () => {
   const tempRoot = await mkdtemp(join(tmpdir(), "kodiai-shallow-bundle-"));
   const bareRepoDir = join(tempRoot, "origin.git");
   const seedRepoDir = join(tempRoot, "seed");
   const shallowRepoDir = join(tempRoot, "shallow");
   const workspaceDir = await mkdtemp(join(tmpdir(), "kodiai-agent-shallow-workspace-"));
-  const cloneCheckDir = await mkdtemp(join(tmpdir(), "kodiai-bundle-clone-check-"));
-  const cleanupDirs = [tempRoot, workspaceDir, cloneCheckDir];
+  const cleanupDirs = [tempRoot, workspaceDir];
 
   try {
     await $`git init --bare ${bareRepoDir}`.quiet();
@@ -1682,35 +1681,26 @@ test("prepareAgentWorkspace unshallows PR workspaces before writing a review bun
       prompt: "Review this PR",
       model: "claude-sonnet-4-5-20250929",
       maxTurns: 25,
-      allowedTools: ["Read", "Grep", "Glob"],
+      allowedTools: ["Read", "Grep", "Glob", "Bash(git diff:*)", "Bash(git status:*)"],
       taskType: "review.full",
       mcpServerNames: ["github_comment"],
     }) as { repoCwd?: string; repoBundlePath?: string };
 
-    expect(result.repoCwd).toBeUndefined();
-    expect(result.repoBundlePath).toBe(join(workspaceDir, "repo.bundle"));
+    expect((await $`git -C ${shallowRepoDir} rev-parse --is-shallow-repository`.quiet().text()).trim()).toBe("true");
+    expect(result.repoBundlePath).toBeUndefined();
+    expect(result.repoCwd).toBe(join(workspaceDir, "repo"));
 
     const rawAgentConfig = await readFile(join(workspaceDir, "agent-config.json"), "utf-8");
     const agentConfig = JSON.parse(rawAgentConfig) as {
-      repoTransport?: {
-        kind?: string;
-        bundlePath?: string;
-        headRef?: string;
-        baseRef?: string;
-        originUrl?: string;
-      };
+      repoCwd?: string;
+      repoTransport?: unknown;
     };
 
-    expect(agentConfig.repoTransport).toEqual({
-      kind: "review-bundle",
-      bundlePath: join(workspaceDir, "repo.bundle"),
-      headRef: "pr-mention",
-      baseRef: "master",
-      originUrl: "file://" + bareRepoDir,
-    });
-
-    await $`git clone -b pr-mention ${join(workspaceDir, "repo.bundle")} ${cloneCheckDir}`.quiet();
-    expect((await $`git -C ${cloneCheckDir} diff origin/master...HEAD --stat`.quiet().text())).toContain("feature.txt");
+    expect(agentConfig.repoTransport).toBeUndefined();
+    expect(agentConfig.repoCwd).toBe(join(workspaceDir, "repo"));
+    expect((agentConfig as { allowedTools?: string[] }).allowedTools).toEqual(["Read", "Grep", "Glob"]);
+    expect(await readFile(join(workspaceDir, "repo", "feature.txt"), "utf-8")).toBe("one\ntwo\npr\n");
+    await expect(stat(join(workspaceDir, "repo", ".git"))).rejects.toThrow();
   } finally {
     await Promise.all(cleanupDirs.map((dir) => rm(dir, { recursive: true, force: true })));
   }

--- a/src/execution/executor.ts
+++ b/src/execution/executor.ts
@@ -252,7 +252,7 @@ async function exportGitWorkingTreeSnapshot(params: {
 }): Promise<string> {
   const repoCwd = join(params.workspaceDir, "repo");
   await mkdir(repoCwd, { recursive: true });
-  await $`git -C ${params.sourceRepoDir} archive HEAD | tar -x -C ${repoCwd}`.quiet();
+  await $`git -C ${params.sourceRepoDir} checkout-index -a -f --prefix=${repoCwd + "/"}`.quiet();
   return repoCwd;
 }
 

--- a/src/execution/executor.ts
+++ b/src/execution/executor.ts
@@ -27,7 +27,6 @@ import {
   readJobDiagnostics,
 } from "../jobs/aca-launcher.ts";
 import {
-  buildAuthFetchUrl,
   createAzureFilesWorkspaceDir,
 } from "../jobs/workspace.ts";
 import type { PromptSectionRecord } from "../telemetry/types.ts";
@@ -247,6 +246,20 @@ async function buildGitRepoTransport(params: {
   };
 }
 
+async function exportGitWorkingTreeSnapshot(params: {
+  sourceRepoDir: string;
+  workspaceDir: string;
+}): Promise<string> {
+  const repoCwd = join(params.workspaceDir, "repo");
+  await mkdir(repoCwd, { recursive: true });
+  await $`git -C ${params.sourceRepoDir} archive HEAD | tar -x -C ${repoCwd}`.quiet();
+  return repoCwd;
+}
+
+function filterGitToolsForSnapshot(allowedTools: string[]): string[] {
+  return allowedTools.filter((tool) => !tool.startsWith("Bash(git "));
+}
+
 export async function prepareAgentWorkspace(params: {
   sourceRepoDir: string;
   workspaceDir: string;
@@ -262,6 +275,7 @@ export async function prepareAgentWorkspace(params: {
   let repoCwd: string | undefined;
   let repoBundlePath: string | undefined;
   let repoTransport: RepoTransport | undefined;
+  let allowedTools = params.allowedTools;
 
   const sourceGitDir = join(params.sourceRepoDir, ".git");
   const sourceIsGitRepo = await stat(sourceGitDir).then(() => true).catch(() => false);
@@ -272,15 +286,19 @@ export async function prepareAgentWorkspace(params: {
       .then((value) => value.trim() === "true")
       .catch(() => false);
     if (sourceIsShallow) {
-      const fetchRemote = await buildAuthFetchUrl(params.sourceRepoDir, params.token);
-      await $`git -C ${params.sourceRepoDir} fetch --unshallow ${fetchRemote}`.quiet();
+      repoCwd = await exportGitWorkingTreeSnapshot({
+        sourceRepoDir: params.sourceRepoDir,
+        workspaceDir: params.workspaceDir,
+      });
+      allowedTools = filterGitToolsForSnapshot(params.allowedTools);
+    } else {
+      const preparedRepo = await buildGitRepoTransport({
+        sourceRepoDir: params.sourceRepoDir,
+        workspaceDir: params.workspaceDir,
+      });
+      repoBundlePath = preparedRepo.repoBundlePath;
+      repoTransport = preparedRepo.repoTransport;
     }
-    const preparedRepo = await buildGitRepoTransport({
-      sourceRepoDir: params.sourceRepoDir,
-      workspaceDir: params.workspaceDir,
-    });
-    repoBundlePath = preparedRepo.repoBundlePath;
-    repoTransport = preparedRepo.repoTransport;
   } else {
     repoCwd = join(params.workspaceDir, "repo");
     await mkdir(repoCwd, { recursive: true });
@@ -294,7 +312,7 @@ export async function prepareAgentWorkspace(params: {
       prompt: params.prompt,
       model: params.model,
       maxTurns: params.maxTurns,
-      allowedTools: params.allowedTools,
+      allowedTools,
       taskType: params.taskType,
       ...(repoCwd ? { repoCwd } : {}),
       ...(repoTransport ? { repoTransport } : {}),

--- a/src/execution/mcp/checkpoint-server.test.ts
+++ b/src/execution/mcp/checkpoint-server.test.ts
@@ -106,6 +106,44 @@ describe("createCheckpointServer", () => {
     });
   });
 
+  test("rejects checkpoints where fully reviewed files are missing from inspected files", async () => {
+    const calls: unknown[] = [];
+    const warnings: unknown[] = [];
+    const knowledgeStore = {
+      saveCheckpoint: (data: unknown) => {
+        calls.push(data);
+      },
+    };
+    const logger = {
+      warn: (...args: unknown[]) => warnings.push(args),
+    };
+
+    const server = createCheckpointServer(
+      knowledgeStore as never,
+      "review-key",
+      "acme/repo",
+      42,
+      12,
+      logger as never,
+    );
+    const handler = getToolHandler(server);
+
+    const result = await handler({
+      filesReviewed: ["src/a.ts", "src/b.ts"],
+      filesInspected: ["src/a.ts"],
+      findingCount: 1,
+      summaryDraft: "Partially inconsistent checkpoint",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(calls).toHaveLength(0);
+    expect(JSON.parse(result.content[0]!.text)).toMatchObject({
+      saved: false,
+      reason: "filesInspected must include every filesReviewed path",
+    });
+    expect(warnings).toHaveLength(1);
+  });
+
   test("waits for checkpoint persistence before reporting success", async () => {
     const deferred = createDeferred<void>();
     const knowledgeStore = {

--- a/src/execution/mcp/checkpoint-server.ts
+++ b/src/execution/mcp/checkpoint-server.ts
@@ -37,6 +37,29 @@ export function createCheckpointServer(
         },
         async ({ filesReviewed, filesInspected, findingCount, summaryDraft }) => {
           try {
+            if (filesInspected !== undefined) {
+              const inspectedSet = new Set(filesInspected);
+              const missingReviewedFiles = filesReviewed.filter((filePath) => !inspectedSet.has(filePath));
+              if (missingReviewedFiles.length > 0) {
+                logger?.warn(
+                  { reviewOutputKey, repo, prNumber, missingReviewedFiles },
+                  "Invalid review checkpoint: filesInspected missing reviewed files",
+                );
+                return {
+                  content: [
+                    {
+                      type: "text" as const,
+                      text: JSON.stringify({
+                        saved: false,
+                        reason: "filesInspected must include every filesReviewed path",
+                      }),
+                    },
+                  ],
+                  isError: true,
+                };
+              }
+            }
+
             if (!knowledgeStore.saveCheckpoint) {
               logger?.warn(
                 { reviewOutputKey, repo, prNumber },

--- a/src/execution/prepare-agent-workspace.test.ts
+++ b/src/execution/prepare-agent-workspace.test.ts
@@ -132,13 +132,12 @@ test("prepareAgentWorkspace writes a review bundle transport for repos with trac
   expect((await $`git -C ${cloneCheckDir} diff origin/main...HEAD --stat`.quiet()).text()).toContain("feature.ts");
 });
 
-test("prepareAgentWorkspace unshallows PR workspaces before writing a review bundle transport", async () => {
+test("prepareAgentWorkspace snapshots shallow PR workspaces without unshallowing", async () => {
   const tempRoot = await makeTempDir("kodiai-shallow-bundle-");
   const bareRepoDir = join(tempRoot, "origin.git");
   const seedRepoDir = join(tempRoot, "seed");
   const shallowRepoDir = join(tempRoot, "shallow");
   const workspaceDir = await makeTempDir("kodiai-agent-shallow-workspace-");
-  const cloneCheckDir = await makeTempDir("kodiai-bundle-clone-check-");
 
   await $`git init --bare ${bareRepoDir}`.quiet();
   await $`git clone file://${bareRepoDir} ${seedRepoDir}`.quiet();
@@ -169,33 +168,24 @@ test("prepareAgentWorkspace unshallows PR workspaces before writing a review bun
     prompt: "Review this PR",
     model: "claude-sonnet-4-5-20250929",
     maxTurns: 25,
-    allowedTools: ["Read", "Grep", "Glob"],
+    allowedTools: ["Read", "Grep", "Glob", "Bash(git diff:*)", "Bash(git status:*)"],
     taskType: "review.full",
     mcpServerNames: ["github_comment"],
   }) as unknown as { repoCwd?: string; repoBundlePath?: string };
 
-  expect(result.repoCwd).toBeUndefined();
-  expect(result.repoBundlePath).toBe(join(workspaceDir, "repo.bundle"));
+  expect((await $`git -C ${shallowRepoDir} rev-parse --is-shallow-repository`.quiet().text()).trim()).toBe("true");
+  expect(result.repoBundlePath).toBeUndefined();
+  expect(result.repoCwd).toBe(join(workspaceDir, "repo"));
 
   const rawAgentConfig = await readFile(join(workspaceDir, "agent-config.json"), "utf-8");
   const agentConfig = JSON.parse(rawAgentConfig) as {
-    repoTransport?: {
-      kind?: string;
-      bundlePath?: string;
-      headRef?: string;
-      baseRef?: string;
-      originUrl?: string;
-    };
+    repoCwd?: string;
+    repoTransport?: unknown;
   };
 
-  expect(agentConfig.repoTransport).toEqual({
-    kind: "review-bundle",
-    bundlePath: join(workspaceDir, "repo.bundle"),
-    headRef: "pr-mention",
-    baseRef: "master",
-    originUrl: "file://" + bareRepoDir,
-  });
-
-  await $`git clone -b pr-mention ${join(workspaceDir, "repo.bundle")} ${cloneCheckDir}`.quiet();
-  expect((await $`git -C ${cloneCheckDir} diff origin/master...HEAD --stat`.quiet().text())).toContain("feature.txt");
+  expect(agentConfig.repoTransport).toBeUndefined();
+  expect(agentConfig.repoCwd).toBe(join(workspaceDir, "repo"));
+  expect((agentConfig as { allowedTools?: string[] }).allowedTools).toEqual(["Read", "Grep", "Glob"]);
+  expect(await readFile(join(workspaceDir, "repo", "feature.txt"), "utf-8")).toBe("one\ntwo\npr\n");
+  await expect(stat(join(workspaceDir, "repo", ".git"))).rejects.toThrow();
 });

--- a/src/execution/review-prompt.test.ts
+++ b/src/execution/review-prompt.test.ts
@@ -34,7 +34,7 @@ describe("small-diff review prompt scope", () => {
   test("adds a tiny-diff scope contract when requested", () => {
     const result = buildReviewPromptDetails(baseContext({ smallDiffReview: true }));
 
-    expect(buildSmallDiffScopeSection()).toContain("Inspect `git diff` first.");
+    expect(buildSmallDiffScopeSection()).toContain("Inspect the provided diff context first.");
     expect(result.text).toContain("## Tiny-diff scope contract");
     expect(result.text).toContain("Do not do generalized architecture exploration.");
     expect(result.sections.some((section) => section.sectionName === "review-small-diff-scope")).toBe(true);
@@ -45,6 +45,13 @@ describe("small-diff review prompt scope", () => {
 
     expect(result.text).not.toContain("## Tiny-diff scope contract");
     expect(result.sections.some((section) => section.sectionName === "review-small-diff-scope")).toBe(false);
+  });
+  test("omits git command instructions when the remote workspace has no git metadata", () => {
+    const result = buildReviewPromptDetails(baseContext({ gitDiffInstructionsAvailable: false }));
+
+    expect(result.text).toContain("Git history is not available in this remote workspace");
+    expect(result.text).not.toContain("Bash(git diff origin/main...HEAD)");
+    expect(result.text).not.toContain("Bash(git log origin/main..HEAD --stat)");
   });
 });
 

--- a/src/execution/review-prompt.ts
+++ b/src/execution/review-prompt.ts
@@ -1610,7 +1610,7 @@ export function buildSmallDiffScopeSection(): string {
     "## Tiny-diff scope contract",
     "",
     "This is a small diff (≤2 files, ≤20 lines). Follow these constraints:",
-    "- Inspect `git diff` first.",
+    "- Inspect the provided diff context first.",
     "- Read only the changed file and directly adjacent context.",
     "- Broaden scope only if the diff itself proves an ambiguity that cannot be resolved without wider context.",
     "- Do not do generalized architecture exploration.",
@@ -1708,6 +1708,7 @@ export function buildReviewPromptDetails(context: {
   structuralImpact?: StructuralImpactPayload | null;
   reviewBoundedness?: ReviewBoundednessContract | null;
   publishToolNames?: string[];
+  gitDiffInstructionsAvailable?: boolean;
 }): PromptBuildResult {
   const sectionBlocks: Array<{ sectionName: string; text: string; truncated?: boolean }> = [];
   const scaleNotes: string[] = [];
@@ -1909,11 +1910,18 @@ export function buildReviewPromptDetails(context: {
   }
   pushBudgetedSection("review-knowledge-context", knowledgeContextLines, REVIEW_SECTION_BUDGETS.knowledgeContext);
 
+  const gitDiffInstructionsAvailable = context.gitDiffInstructionsAvailable !== false;
   const instructionLines: string[] = [
     "## Reading the code",
     "",
-    `To see the full diff: Bash(git diff origin/${context.baseBranch}...HEAD)`,
-    `To see changed files with stats: Bash(git log origin/${context.baseBranch}..HEAD --stat)`,
+    ...(gitDiffInstructionsAvailable
+      ? [
+          `To see the full diff: Bash(git diff origin/${context.baseBranch}...HEAD)`,
+          `To see changed files with stats: Bash(git log origin/${context.baseBranch}..HEAD --stat)`,
+        ]
+      : [
+          "Git history is not available in this remote workspace; use the changed-file list, embedded diff context, and Read/Grep/Glob instead of git commands.",
+        ]),
     "Read the diff carefully before posting any comments.",
     "",
     "## First-pass changed-file triage",

--- a/src/handlers/mention.ts
+++ b/src/handlers/mention.ts
@@ -953,6 +953,12 @@ export function createMentionHandler(deps: {
     surface: MentionEvent["surface"];
     token?: string;
     fallbackFileProvider?: () => Promise<string[]>;
+    fallbackDiffProvider?: () => Promise<Array<{
+      filename: string;
+      additions?: number | null;
+      deletions?: number | null;
+      patch?: string | null;
+    }>>;
   }): Promise<{
     changedFiles: string[];
     numstatLines: string[];
@@ -971,6 +977,7 @@ export function createMentionHandler(deps: {
       },
       token: input.token,
       fallbackFileProvider: input.fallbackFileProvider,
+      fallbackDiffProvider: input.fallbackDiffProvider,
     });
 
     return {
@@ -2450,14 +2457,19 @@ export function createMentionHandler(deps: {
                 baseRef: mention.baseRef,
                 surface: mention.surface,
                 token: workspace.token,
-                fallbackFileProvider: async () => {
+                fallbackDiffProvider: async () => {
                   const listFilesResponse = await octokit.rest.pulls.listFiles({
                     owner: mention.owner,
                     repo: mention.repo,
                     pull_number: explicitReviewPrNumber,
                     per_page: 100,
                   });
-                  return listFilesResponse.data.map((file) => file.filename);
+                  return listFilesResponse.data.map((file) => ({
+                    filename: file.filename,
+                    additions: file.additions,
+                    deletions: file.deletions,
+                    patch: file.patch,
+                  }));
                 },
               })
             : { changedFiles: [], numstatLines: [], diffRange: "unknown" };

--- a/src/handlers/mention.ts
+++ b/src/handlers/mention.ts
@@ -63,6 +63,7 @@ import { buildRetrievalVariants } from "../knowledge/multi-query-retrieval.ts";
 import { analyzeDiff, classifyFileLanguage, parseNumstatPerFile } from "../execution/diff-analysis.ts";
 import { computeFileRiskScores, triageFilesByRisk } from "../lib/file-risk-scorer.ts";
 import { computeLanguageComplexity, estimateTimeoutRisk } from "../lib/timeout-estimator.ts";
+import { fetchAllPullRequestFiles } from "../lib/github-pr-files.ts";
 import { buildSearchCacheKey, createSearchCache, type SearchCacheOptions } from "../lib/search-cache.ts";
 import {
   type ErrorCategory,
@@ -955,6 +956,8 @@ export function createMentionHandler(deps: {
     fallbackFileProvider?: () => Promise<string[]>;
     fallbackDiffProvider?: () => Promise<Array<{
       filename: string;
+      status?: string;
+      previousFilename?: string;
       additions?: number | null;
       deletions?: number | null;
       patch?: string | null;
@@ -2457,20 +2460,12 @@ export function createMentionHandler(deps: {
                 baseRef: mention.baseRef,
                 surface: mention.surface,
                 token: workspace.token,
-                fallbackDiffProvider: async () => {
-                  const listFilesResponse = await octokit.rest.pulls.listFiles({
-                    owner: mention.owner,
-                    repo: mention.repo,
-                    pull_number: explicitReviewPrNumber,
-                    per_page: 100,
-                  });
-                  return listFilesResponse.data.map((file) => ({
-                    filename: file.filename,
-                    additions: file.additions,
-                    deletions: file.deletions,
-                    patch: file.patch,
-                  }));
-                },
+                fallbackDiffProvider: async () => await fetchAllPullRequestFiles({
+                  octokit,
+                  owner: mention.owner,
+                  repo: mention.repo,
+                  pullNumber: explicitReviewPrNumber,
+                }),
               })
             : { changedFiles: [], numstatLines: [], diffRange: "unknown" };
           const promptChangedFiles = promptDiffContext.changedFiles;
@@ -2596,6 +2591,7 @@ export function createMentionHandler(deps: {
               mentionOnlyCount: tieredFiles.mentionOnly.length,
               totalFiles: tieredFiles.totalFiles,
             } : null,
+            gitDiffInstructionsAvailable: false,
             publishToolNames: [
               "mcp__github_comment__create_comment",
               "mcp__github_inline_comment__create_inline_comment",

--- a/src/handlers/review.test.ts
+++ b/src/handlers/review.test.ts
@@ -4996,6 +4996,54 @@ describe("createReviewHandler diff collection resilience", () => {
     }
   });
 
+  test("uses GitHub PR file metadata when merge-base recovery times out", async () => {
+    const workspaceFixture = await createNoMergeBaseFixture({ includePhase27Fields: true });
+    const { logger } = createCaptureLogger();
+
+    try {
+      const result = await collectDiffContext({
+        workspaceDir: workspaceFixture.dir,
+        baseRef: "main",
+        maxFilesForFullDiff: 200,
+        logger,
+        baseLog: { deliveryId: "delivery-123", prNumber: 101 },
+        runGitCommand: async () => ({
+          exitCode: 124,
+          stdout: "",
+          stderr: "timed out",
+          timedOut: true,
+        }),
+        fallbackDiffProvider: async () => [
+          {
+            filename: "src/api/phase27-uat-example.ts",
+            additions: 7,
+            deletions: 2,
+            patch: "@@ -1 +1 @@\n-old\n+new",
+          },
+          {
+            filename: "docs/phase27-note.md",
+            additions: 1,
+            deletions: 0,
+          },
+        ],
+      });
+
+      expect(result.strategy).toBe("github-pr-files-fallback");
+      expect(result.changedFiles).toEqual([
+        "src/api/phase27-uat-example.ts",
+        "docs/phase27-note.md",
+      ]);
+      expect(result.numstatLines).toEqual([
+        "7\t2\tsrc/api/phase27-uat-example.ts",
+        "1\t0\tdocs/phase27-note.md",
+      ]);
+      expect(result.diffContent).toContain("diff --git a/src/api/phase27-uat-example.ts b/src/api/phase27-uat-example.ts");
+      expect(result.diffContent).toContain("@@ -1 +1 @@");
+    } finally {
+      await workspaceFixture.cleanup();
+    }
+  });
+
   test("continues review flow when diff collection degrades to file-list fallback", async () => {
     const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
     const workspaceFixture = await createWorkspaceFixture();

--- a/src/handlers/review.test.ts
+++ b/src/handlers/review.test.ts
@@ -5016,12 +5016,15 @@ describe("createReviewHandler diff collection resilience", () => {
         fallbackDiffProvider: async () => [
           {
             filename: "src/api/phase27-uat-example.ts",
+            status: "renamed",
+            previousFilename: "src/api/old-phase27-uat-example.ts",
             additions: 7,
             deletions: 2,
             patch: "@@ -1 +1 @@\n-old\n+new",
           },
           {
             filename: "docs/phase27-note.md",
+            status: "added",
             additions: 1,
             deletions: 0,
           },
@@ -5037,7 +5040,9 @@ describe("createReviewHandler diff collection resilience", () => {
         "7\t2\tsrc/api/phase27-uat-example.ts",
         "1\t0\tdocs/phase27-note.md",
       ]);
-      expect(result.diffContent).toContain("diff --git a/src/api/phase27-uat-example.ts b/src/api/phase27-uat-example.ts");
+      expect(result.diffContent).toContain("diff --git a/src/api/old-phase27-uat-example.ts b/src/api/phase27-uat-example.ts");
+      expect(result.diffContent).toContain("--- a/src/api/old-phase27-uat-example.ts");
+      expect(result.diffContent).toContain("+++ b/src/api/phase27-uat-example.ts");
       expect(result.diffContent).toContain("@@ -1 +1 @@");
     } finally {
       await workspaceFixture.cleanup();

--- a/src/handlers/review.ts
+++ b/src/handlers/review.ts
@@ -76,6 +76,7 @@ import { evaluateFeedbackSuppressions, adjustConfidenceForFeedback } from "../fe
 import type { SuggestionClusterStore } from "../knowledge/suggestion-cluster-store.ts";
 import { applyClusterScoringWithDegradation } from "../knowledge/suggestion-cluster-degradation.ts";
 import { classifyError, formatErrorComment, postOrUpdateErrorComment } from "../lib/errors.ts";
+import { fetchAllPullRequestFiles, type PullRequestFileMetadata } from "../lib/github-pr-files.ts";
 import { estimateTimeoutRisk, computeLanguageComplexity } from "../lib/timeout-estimator.ts";
 import {
   ensureReviewBoundednessDisclosureInSummary,
@@ -1233,12 +1234,7 @@ type DiffCommandResult = {
 
 type DiffCommandRunner = (args: string[], timeoutMs: number) => Promise<DiffCommandResult>;
 
-type DiffFallbackFile = {
-  filename: string;
-  additions?: number | null;
-  deletions?: number | null;
-  patch?: string | null;
-};
+type DiffFallbackFile = PullRequestFileMetadata;
 
 const DIFF_DEEPEN_STEPS = [50, 150, 300];
 const DIFF_COMMAND_TIMEOUT_MS = 15_000;
@@ -1300,12 +1296,16 @@ async function runDiffCommandWithTimeout(params: {
 function buildFallbackPatchDiff(files: DiffFallbackFile[]): string | undefined {
   const chunks = files
     .filter((file) => typeof file.patch === "string" && file.patch.trim().length > 0)
-    .map((file) => [
-      `diff --git a/${file.filename} b/${file.filename}`,
-      `--- a/${file.filename}`,
-      `+++ b/${file.filename}`,
-      file.patch!.trimEnd(),
-    ].join("\n"));
+    .map((file) => {
+      const oldPath = file.status === "added" ? "/dev/null" : `a/${file.previousFilename ?? file.filename}`;
+      const newPath = file.status === "removed" ? "/dev/null" : `b/${file.filename}`;
+      return [
+        `diff --git a/${file.previousFilename ?? file.filename} b/${file.filename}`,
+        `--- ${oldPath}`,
+        `+++ ${newPath}`,
+        file.patch!.trimEnd(),
+      ].join("\n");
+    });
 
   return chunks.length > 0 ? chunks.join("\n") + "\n" : undefined;
 }
@@ -2829,20 +2829,12 @@ export function createReviewHandler(deps: {
           logger,
           baseLog,
           token: workspace.token,
-          fallbackDiffProvider: async () => {
-            const listFilesResponse = await idempotencyOctokit.rest.pulls.listFiles({
-              owner: apiOwner,
-              repo: apiRepo,
-              pull_number: pr.number,
-              per_page: 100,
-            });
-            return listFilesResponse.data.map((file) => ({
-              filename: file.filename,
-              additions: file.additions,
-              deletions: file.deletions,
-              patch: file.patch,
-            }));
-          },
+          fallbackDiffProvider: async () => await fetchAllPullRequestFiles({
+            octokit: idempotencyOctokit,
+            owner: apiOwner,
+            repo: apiRepo,
+            pullNumber: pr.number,
+          }),
         });
         const allChangedFiles = diffContext.changedFiles;
 
@@ -2869,16 +2861,15 @@ export function createReviewHandler(deps: {
         if (dependsBumpInfo) {
           try {
             // 1. Fetch PR files with status/patch from GitHub API
-            const prFilesResponse = await idempotencyOctokit.rest.pulls.listFiles({
+            const prFilesForDepends = (await fetchAllPullRequestFiles({
+              octokit: idempotencyOctokit,
               owner: apiOwner,
               repo: apiRepo,
-              pull_number: pr.number,
-              per_page: 100,
-            });
-            const prFilesForDepends = prFilesResponse.data.map(f => ({
-              filename: f.filename,
-              status: f.status,
-              patch: f.patch,
+              pullNumber: pr.number,
+            })).map((file) => ({
+              filename: file.filename,
+              status: file.status,
+              patch: file.patch ?? undefined,
             }));
 
             // 2. Parse VERSION file diffs from PR files
@@ -4005,6 +3996,7 @@ export function createReviewHandler(deps: {
             mentionOnlyCount: tieredFiles.mentionOnly.length,
             totalFiles: tieredFiles.totalFiles,
           } : null,
+          gitDiffInstructionsAvailable: false,
           publishToolNames: [
             "mcp__github_comment__create_comment",
             "mcp__github_inline_comment__create_inline_comment",
@@ -5795,6 +5787,7 @@ export function createReviewHandler(deps: {
                           }
                         : null,
                       largePRContext: null,
+                      gitDiffInstructionsAvailable: false,
                       publishToolNames: [
                         "mcp__github_comment__create_comment",
                         "mcp__github_inline_comment__create_inline_comment",

--- a/src/handlers/review.ts
+++ b/src/handlers/review.ts
@@ -1210,7 +1210,8 @@ type DiffCollectionStrategy =
   | "triple-dot"
   | "deepened-triple-dot"
   | "fallback-two-dot"
-  | "github-file-list-fallback";
+  | "github-file-list-fallback"
+  | "github-pr-files-fallback";
 
 type DiffCollectionResult = {
   changedFiles: string[];
@@ -1231,6 +1232,13 @@ type DiffCommandResult = {
 };
 
 type DiffCommandRunner = (args: string[], timeoutMs: number) => Promise<DiffCommandResult>;
+
+type DiffFallbackFile = {
+  filename: string;
+  additions?: number | null;
+  deletions?: number | null;
+  patch?: string | null;
+};
 
 const DIFF_DEEPEN_STEPS = [50, 150, 300];
 const DIFF_COMMAND_TIMEOUT_MS = 15_000;
@@ -1289,8 +1297,30 @@ async function runDiffCommandWithTimeout(params: {
   }
 }
 
+function buildFallbackPatchDiff(files: DiffFallbackFile[]): string | undefined {
+  const chunks = files
+    .filter((file) => typeof file.patch === "string" && file.patch.trim().length > 0)
+    .map((file) => [
+      `diff --git a/${file.filename} b/${file.filename}`,
+      `--- a/${file.filename}`,
+      `+++ b/${file.filename}`,
+      file.patch!.trimEnd(),
+    ].join("\n"));
+
+  return chunks.length > 0 ? chunks.join("\n") + "\n" : undefined;
+}
+
+function buildFallbackNumstatLines(files: DiffFallbackFile[]): string[] {
+  return files.map((file) => {
+    const additions = typeof file.additions === "number" && Number.isFinite(file.additions) ? String(file.additions) : "-";
+    const deletions = typeof file.deletions === "number" && Number.isFinite(file.deletions) ? String(file.deletions) : "-";
+    return `${additions}\t${deletions}\t${file.filename}`;
+  });
+}
+
 async function buildDiffCollectionFallback(params: {
   fallbackFileProvider?: () => Promise<string[]>;
+  fallbackDiffProvider?: () => Promise<DiffFallbackFile[]>;
   logger: Logger;
   baseLog: Record<string, unknown>;
   stage: string;
@@ -1302,6 +1332,7 @@ async function buildDiffCollectionFallback(params: {
 }): Promise<DiffCollectionResult> {
   const {
     fallbackFileProvider,
+    fallbackDiffProvider,
     logger,
     baseLog,
     stage,
@@ -1311,6 +1342,42 @@ async function buildDiffCollectionFallback(params: {
     mergeBaseRecovered,
     diffRange,
   } = params;
+
+  if (fallbackDiffProvider) {
+    const fallbackFiles = await fallbackDiffProvider();
+    const uniqueFiles = Array.from(new Map(fallbackFiles.map((file) => [file.filename, file])).values());
+    const changedFiles = uniqueFiles.map((file) => file.filename);
+    const numstatLines = buildFallbackNumstatLines(uniqueFiles);
+    const diffContent = buildFallbackPatchDiff(uniqueFiles);
+
+    logger.warn(
+      {
+        ...baseLog,
+        gate: "diff-collection",
+        stage,
+        reason,
+        strategy: "github-pr-files-fallback",
+        deepenAttempts,
+        unshallowAttempted,
+        mergeBaseRecovered,
+        diffRange,
+        changedFilesCount: changedFiles.length,
+        patchFilesCount: uniqueFiles.filter((file) => typeof file.patch === "string" && file.patch.trim().length > 0).length,
+      },
+      "Diff collection degraded to GitHub PR files fallback",
+    );
+
+    return {
+      changedFiles,
+      numstatLines,
+      diffContent,
+      strategy: "github-pr-files-fallback",
+      mergeBaseRecovered,
+      deepenAttempts,
+      unshallowAttempted,
+      diffRange: "github-api:pr-files",
+    };
+  }
 
   if (!fallbackFileProvider) {
     throw new Error(`Diff collection timed out during ${stage} (${reason}) and no fallback provider was configured`);
@@ -1355,6 +1422,7 @@ export async function collectDiffContext(params: {
   token?: string;
   runGitCommand?: DiffCommandRunner;
   fallbackFileProvider?: () => Promise<string[]>;
+  fallbackDiffProvider?: () => Promise<DiffFallbackFile[]>;
   commandTimeoutMs?: number;
 }): Promise<DiffCollectionResult> {
   const {
@@ -1366,6 +1434,7 @@ export async function collectDiffContext(params: {
     token,
     runGitCommand,
     fallbackFileProvider,
+    fallbackDiffProvider,
     commandTimeoutMs = DIFF_COMMAND_TIMEOUT_MS,
   } = params;
 
@@ -1415,6 +1484,7 @@ export async function collectDiffContext(params: {
       if (deepenResult.timedOut) {
         return await buildDiffCollectionFallback({
           fallbackFileProvider,
+          fallbackDiffProvider,
           logger,
           baseLog,
           stage: "merge-base-recovery",
@@ -1455,6 +1525,7 @@ export async function collectDiffContext(params: {
       if (unshallowResult.timedOut) {
         return await buildDiffCollectionFallback({
           fallbackFileProvider,
+          fallbackDiffProvider,
           logger,
           baseLog,
           stage: "merge-base-recovery",
@@ -1483,6 +1554,7 @@ export async function collectDiffContext(params: {
   if (nameOnlyResult.timedOut) {
     return await buildDiffCollectionFallback({
       fallbackFileProvider,
+      fallbackDiffProvider,
       logger,
       baseLog,
       stage: "name-only",
@@ -1510,6 +1582,7 @@ export async function collectDiffContext(params: {
     if (nameOnlyResult.timedOut) {
       return await buildDiffCollectionFallback({
         fallbackFileProvider,
+        fallbackDiffProvider,
         logger,
         baseLog,
         stage: "name-only",
@@ -2756,14 +2829,19 @@ export function createReviewHandler(deps: {
           logger,
           baseLog,
           token: workspace.token,
-          fallbackFileProvider: async () => {
+          fallbackDiffProvider: async () => {
             const listFilesResponse = await idempotencyOctokit.rest.pulls.listFiles({
               owner: apiOwner,
               repo: apiRepo,
               pull_number: pr.number,
               per_page: 100,
             });
-            return listFilesResponse.data.map((file) => file.filename);
+            return listFilesResponse.data.map((file) => ({
+              filename: file.filename,
+              additions: file.additions,
+              deletions: file.deletions,
+              patch: file.patch,
+            }));
           },
         });
         const allChangedFiles = diffContext.changedFiles;

--- a/src/knowledge/store.test.ts
+++ b/src/knowledge/store.test.ts
@@ -853,6 +853,7 @@ describe.skipIf(!TEST_DB_URL)("KnowledgeStore", () => {
         },
       } as unknown as import("pino").Logger;
       const loggingStore = createKnowledgeStore({ sql, logger });
+      debugCalls.length = 0;
 
       await loggingStore.upsertContinuationFamilyState?.({
         familyKey,
@@ -876,10 +877,7 @@ describe.skipIf(!TEST_DB_URL)("KnowledgeStore", () => {
         supersededByAttemptId: null,
       });
 
-      const conflictDebugCalls = debugCalls.filter((call) =>
-        call.message === "Continuation family state update skipped due to ordinal conflict"
-      );
-      expect(conflictDebugCalls).toEqual([
+      expect(debugCalls).toEqual([
         {
           bindings: expect.objectContaining({
             familyKey,

--- a/src/lib/github-pr-files.test.ts
+++ b/src/lib/github-pr-files.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { Octokit } from "@octokit/rest";
+import { fetchAllPullRequestFiles } from "./github-pr-files.ts";
+
+describe("fetchAllPullRequestFiles", () => {
+  test("collects every paginated pull request file", async () => {
+    const firstPage = Array.from({ length: 100 }, (_, index) => ({
+      filename: `src/page-one-${index}.ts`,
+      status: "modified",
+      additions: 1,
+      deletions: 0,
+      patch: "@@ -1 +1 @@",
+    }));
+    const listFiles = mock((params: { owner: string; repo: string; pull_number: number; per_page: number; page: number }) => Promise.resolve({
+      data: params.page === 1
+        ? firstPage
+        : [
+            {
+              filename: "src/two.ts",
+              status: "renamed",
+              previous_filename: "src/old-two.ts",
+              additions: 2,
+              deletions: 1,
+              patch: "@@ -2 +2 @@",
+            },
+          ],
+    }));
+    const octokit = {
+      rest: {
+        pulls: {
+          listFiles,
+        },
+      },
+    } as unknown as Octokit;
+
+    const files = await fetchAllPullRequestFiles({
+      octokit,
+      owner: "xbmc",
+      repo: "kodiai",
+      pullNumber: 130,
+    });
+
+    expect(files).toHaveLength(101);
+    expect(files.at(-1)).toEqual({
+      filename: "src/two.ts",
+      status: "renamed",
+      previousFilename: "src/old-two.ts",
+      additions: 2,
+      deletions: 1,
+      patch: "@@ -2 +2 @@",
+    });
+    expect(listFiles).toHaveBeenCalledTimes(2);
+    expect(listFiles.mock.calls[0]?.[0]).toEqual({
+      owner: "xbmc",
+      repo: "kodiai",
+      pull_number: 130,
+      per_page: 100,
+      page: 1,
+    });
+    expect(listFiles.mock.calls[1]?.[0]).toEqual({
+      owner: "xbmc",
+      repo: "kodiai",
+      pull_number: 130,
+      per_page: 100,
+      page: 2,
+    });
+  });
+});

--- a/src/lib/github-pr-files.ts
+++ b/src/lib/github-pr-files.ts
@@ -1,0 +1,47 @@
+import type { Octokit } from "@octokit/rest";
+
+export type PullRequestFileMetadata = {
+  filename: string;
+  status?: string;
+  previousFilename?: string;
+  additions?: number | null;
+  deletions?: number | null;
+  patch?: string | null;
+};
+
+export async function fetchAllPullRequestFiles(params: {
+  octokit: Octokit;
+  owner: string;
+  repo: string;
+  pullNumber: number;
+}): Promise<PullRequestFileMetadata[]> {
+  const { octokit, owner, repo, pullNumber } = params;
+  const files: PullRequestFileMetadata[] = [];
+  let page = 1;
+
+  while (true) {
+    const response = await octokit.rest.pulls.listFiles({
+      owner,
+      repo,
+      pull_number: pullNumber,
+      per_page: 100,
+      page,
+    });
+
+    for (const file of response.data) {
+      files.push({
+        filename: file.filename,
+        status: file.status,
+        previousFilename: file.previous_filename,
+        additions: file.additions,
+        deletions: file.deletions,
+        patch: file.patch,
+      });
+    }
+
+    if (response.data.length < 100) {
+      return files;
+    }
+    page += 1;
+  }
+}

--- a/src/lib/partial-review-formatter.test.ts
+++ b/src/lib/partial-review-formatter.test.ts
@@ -303,6 +303,15 @@ describe("formatPartialReviewComment", () => {
       reason: "workspace-prep-terminated",
     });
   });
+
+  test("classifies string exit code 143 as retry infrastructure failure", () => {
+    const err = Object.assign(new Error("process exited"), { exitCode: "143" });
+
+    expect(classifyRetryFailure(err)).toEqual({
+      category: "retry-infra-failure",
+      reason: "workspace-prep-terminated",
+    });
+  });
 });
 
 describe("formatContinuationRevisionSummary", () => {

--- a/src/lib/review-routing.test.ts
+++ b/src/lib/review-routing.test.ts
@@ -99,6 +99,19 @@ describe("review-routing", () => {
     })).toBe(SEMANTIC_FANOUT_REVIEW_MAX_TURNS);
   });
 
+  test("does not raise turn budget for unrelated event or message paths", () => {
+    expect(resolveReviewMaxTurnsOverride({
+      taskType: TASK_TYPES.REVIEW_FULL,
+      timeoutRiskLevel: "low",
+      baseMaxTurns: 25,
+      changedFiles: [
+        "src/handlers/message-handler.ts",
+        "src/lib/event-emitter.ts",
+        "src/execution/dispatcher.ts",
+      ],
+    })).toBeUndefined();
+  });
+
   test("does not lower an explicitly higher repo maxTurns setting", () => {
     expect(resolveReviewMaxTurnsOverride({
       taskType: TASK_TYPES.REVIEW_FULL,

--- a/src/lib/review-routing.ts
+++ b/src/lib/review-routing.ts
@@ -81,16 +81,20 @@ export function hasSemanticReviewFanout(changedFiles: readonly string[] | undefi
   }
 
   return changedFiles.some((filePath) => {
-    const normalized = filePath.toLowerCase();
-    return normalized.includes("guilib/")
+    const normalized = filePath.toLowerCase().replace(/\\/g, "/");
+    const isGuiPath = normalized.includes("/guilib/") || normalized.startsWith("guilib/");
+
+    return isGuiPath
       || normalized.includes("guiwindow")
       || normalized.includes("guicontrol")
       || normalized.includes("buttoncontrol")
       || normalized.includes("windowmanager")
       || normalized.includes("playercorefactory")
-      || normalized.includes("event")
-      || normalized.includes("message")
-      || normalized.includes("dispatcher");
+      || (isGuiPath && (
+        normalized.includes("event")
+        || normalized.includes("message")
+        || normalized.includes("dispatcher")
+      ));
   });
 }
 

--- a/src/lib/review-routing.ts
+++ b/src/lib/review-routing.ts
@@ -89,12 +89,7 @@ export function hasSemanticReviewFanout(changedFiles: readonly string[] | undefi
       || normalized.includes("guicontrol")
       || normalized.includes("buttoncontrol")
       || normalized.includes("windowmanager")
-      || normalized.includes("playercorefactory")
-      || (isGuiPath && (
-        normalized.includes("event")
-        || normalized.includes("message")
-        || normalized.includes("dispatcher")
-      ));
+      || normalized.includes("playercorefactory");
   });
 }
 

--- a/src/lib/review-utils.ts
+++ b/src/lib/review-utils.ts
@@ -140,7 +140,7 @@ export function classifyRetryFailure(err: unknown): ReviewRetryFailureClassifica
     : undefined;
   const message = err instanceof Error ? err.message : String(err);
 
-  if (exitCode === 143 || /exit code 143|sigterm/i.test(message)) {
+  if (exitCode === 143 || exitCode === "143" || /exit code 143|sigterm/i.test(message)) {
     return { category: "retry-infra-failure", reason: "workspace-prep-terminated" };
   }
 


### PR DESCRIPTION
## Summary
- address Kodiai PR #129 follow-up findings around semantic fan-out, checkpoint validation, and retry exit-code classification
- avoid unbounded `git fetch --unshallow` during review handoff by snapshotting shallow PR worktrees for the remote agent
- upgrade degraded diff fallback from filename-only to GitHub PR file metadata with numstat and patch context when local merge-base recovery times out

## Production evidence
- audited 144h of Container Apps logs from workspace `fb0d671a-6537-4c68-9f32-bef49c3d41d8`
- found 21 `fetch-timeout-deepen-50` diff degradations across 12 PRs
- current revision still showed degraded reviews and slow handoff on PRs including 28247, 28255, and 28068

## Verification
- `bun test ./src/execution/prepare-agent-workspace.test.ts ./src/execution/executor.test.ts ./src/handlers/review.test.ts ./src/handlers/mention.test.ts ./src/lib/review-routing.test.ts ./src/lib/partial-review-formatter.test.ts ./src/execution/mcp/checkpoint-server.test.ts` — 368 pass, 0 fail
- `bun run tsc --noEmit && bun run lint` — pass
