### PR TITLE
Fix shallow symlink review handoff

### DIFF
--- a/src/execution/executor.ts
+++ b/src/execution/executor.ts
@@ -246,6 +246,14 @@ async function buildGitRepoTransport(params: {
   };
 }
 
+async function hasTrackedSymlinks(repoDir: string): Promise<boolean> {
+  const result = await $`git -C ${repoDir} ls-files -s`.quiet().nothrow();
+  if (result.exitCode !== 0) {
+    return false;
+  }
+  return result.stdout.toString().split(/\r?\n/).some((line) => line.startsWith("120000 "));
+}
+
 async function exportGitWorkingTreeSnapshot(params: {
   sourceRepoDir: string;
   workspaceDir: string;
@@ -286,11 +294,21 @@ export async function prepareAgentWorkspace(params: {
       .then((value) => value.trim() === "true")
       .catch(() => false);
     if (sourceIsShallow) {
-      repoCwd = await exportGitWorkingTreeSnapshot({
-        sourceRepoDir: params.sourceRepoDir,
-        workspaceDir: params.workspaceDir,
-      });
-      allowedTools = filterGitToolsForSnapshot(params.allowedTools);
+      const sourceHasTrackedSymlinks = await hasTrackedSymlinks(params.sourceRepoDir);
+      if (sourceHasTrackedSymlinks) {
+        const preparedRepo = await buildGitRepoTransport({
+          sourceRepoDir: params.sourceRepoDir,
+          workspaceDir: params.workspaceDir,
+        });
+        repoBundlePath = preparedRepo.repoBundlePath;
+        repoTransport = preparedRepo.repoTransport;
+      } else {
+        repoCwd = await exportGitWorkingTreeSnapshot({
+          sourceRepoDir: params.sourceRepoDir,
+          workspaceDir: params.workspaceDir,
+        });
+        allowedTools = filterGitToolsForSnapshot(params.allowedTools);
+      }
     } else {
       const preparedRepo = await buildGitRepoTransport({
         sourceRepoDir: params.sourceRepoDir,

--- a/src/execution/prepare-agent-workspace.test.ts
+++ b/src/execution/prepare-agent-workspace.test.ts
@@ -132,6 +132,70 @@ test("prepareAgentWorkspace writes a review bundle transport for repos with trac
   expect((await $`git -C ${cloneCheckDir} diff origin/main...HEAD --stat`.quiet()).text()).toContain("feature.ts");
 });
 
+test("prepareAgentWorkspace uses bundle transport for shallow repos with tracked symlinks", async () => {
+  const tempRoot = await makeTempDir("kodiai-shallow-symlink-bundle-");
+  const bareRepoDir = join(tempRoot, "origin.git");
+  const seedRepoDir = join(tempRoot, "seed");
+  const shallowRepoDir = join(tempRoot, "shallow");
+  const workspaceDir = await makeTempDir("kodiai-agent-shallow-symlink-workspace-");
+
+  await $`git init --bare ${bareRepoDir}`.quiet();
+  await $`git clone file://${bareRepoDir} ${seedRepoDir}`.quiet();
+  await $`git -C ${seedRepoDir} config user.email t@example.com`.quiet();
+  await $`git -C ${seedRepoDir} config user.name T`.quiet();
+  await mkdir(join(seedRepoDir, "system", "settings"), { recursive: true });
+  await writeFile(join(seedRepoDir, "system", "settings", "linux.xml"), "<settings />\n");
+  await symlink("linux.xml", join(seedRepoDir, "system", "settings", "freebsd.xml"));
+  await $`git -C ${seedRepoDir} add .`.quiet();
+  await $`git -C ${seedRepoDir} commit -m init`.quiet();
+  await $`git -C ${seedRepoDir} branch -M master`.quiet();
+  await $`git -C ${seedRepoDir} push origin master`.quiet();
+  await $`git -C ${seedRepoDir} checkout -b pr-mention`.quiet();
+  await writeFile(join(seedRepoDir, "feature.txt"), "pr\n");
+  await $`git -C ${seedRepoDir} add feature.txt`.quiet();
+  await $`git -C ${seedRepoDir} commit -m pr`.quiet();
+  await $`git -C ${seedRepoDir} push origin pr-mention`.quiet();
+
+  await $`git clone --depth=1 --single-branch --branch master file://${bareRepoDir} ${shallowRepoDir}`.quiet();
+  await $`git -C ${shallowRepoDir} fetch file://${bareRepoDir} pr-mention:pr-mention`.quiet();
+  await $`git -C ${shallowRepoDir} checkout pr-mention`.quiet();
+  await $`git -C ${shallowRepoDir} fetch origin master:refs/remotes/origin/master --depth=1`.quiet();
+  expect((await $`git -C ${shallowRepoDir} rev-parse --is-shallow-repository`.quiet().text()).trim()).toBe("true");
+
+  const result = await prepareAgentWorkspace({
+    sourceRepoDir: shallowRepoDir,
+    workspaceDir,
+    prompt: "Review this PR",
+    model: "claude-sonnet-4-5-20250929",
+    maxTurns: 25,
+    allowedTools: ["Read", "Grep", "Glob", "Bash(git diff:*)", "Bash(git status:*)"],
+    taskType: "review.full",
+    mcpServerNames: ["github_comment"],
+  }) as unknown as { repoCwd?: string; repoBundlePath?: string };
+
+  expect((await $`git -C ${shallowRepoDir} rev-parse --is-shallow-repository`.quiet().text()).trim()).toBe("true");
+  expect(result.repoCwd).toBeUndefined();
+  expect(result.repoBundlePath).toBe(join(workspaceDir, "repo.bundle"));
+
+  const rawAgentConfig = await readFile(join(workspaceDir, "agent-config.json"), "utf-8");
+  const agentConfig = JSON.parse(rawAgentConfig) as {
+    repoCwd?: string;
+    repoTransport?: { kind?: string; bundlePath?: string; headRef?: string; baseRef?: string; originUrl?: string };
+    allowedTools?: string[];
+  };
+
+  expect(agentConfig.repoCwd).toBeUndefined();
+  expect(agentConfig.repoTransport).toEqual({
+    kind: "review-bundle",
+    bundlePath: join(workspaceDir, "repo.bundle"),
+    headRef: "pr-mention",
+    baseRef: "master",
+    originUrl: `file://${bareRepoDir}`,
+  });
+  expect(agentConfig.allowedTools).toContain("Bash(git diff:*)");
+  await expect(stat(join(workspaceDir, "repo"))).rejects.toThrow();
+});
+
 test("prepareAgentWorkspace snapshots shallow PR workspaces without unshallowing", async () => {
   const tempRoot = await makeTempDir("kodiai-shallow-bundle-");
   const bareRepoDir = join(tempRoot, "origin.git");


### PR DESCRIPTION
## Summary

Fixes the PR #130 regression where shallow PR workspaces containing tracked symlinks fail before remote runtime starts.

`xbmc/xbmc#28259` failed in `exportGitWorkingTreeSnapshot()` because `git checkout-index` tried to materialize tracked symlinks into the Azure Files workspace mount and Azure Files returned `Permission denied`.

This change keeps the shallow non-symlink fast path, but routes shallow repos with tracked symlinks through the existing review-bundle transport instead of exporting a non-git working tree snapshot.

## Verification

- RED first: `bun test ./src/execution/prepare-agent-workspace.test.ts -t "shallow repos with tracked symlinks"` failed because `repoCwd` was set to a snapshot path.
- GREEN: `bun test ./src/execution/prepare-agent-workspace.test.ts -t "shallow repos with tracked symlinks"` passed.
- Affected tests: `bun test ./src/execution/prepare-agent-workspace.test.ts ./src/execution/executor.test.ts` — 39 pass, 0 fail.
- Type/lint: `bun run tsc --noEmit && bun run lint` passed.

## Production evidence

Failing PR: https://github.com/xbmc/xbmc/pull/28259

Observed production error on revision `ca-kodiai--deploy-20260504-003802`:

```text
ShellError: Failed with exit code 1
error: unable to create symlink .../repo/system/settings/freebsd.xml: Permission denied
error: unable to create symlink .../repo/xbmc/platform/darwin/tvos/.../applaunch_screen.png: Permission denied
```
