### PR TITLE
Fix shallow symlink archive handoff

### DIFF
--- a/src/execution/agent-entrypoint.test.ts
+++ b/src/execution/agent-entrypoint.test.ts
@@ -723,6 +723,69 @@ describe("happy path", () => {
     expect(diagnostics.join("")).toContain("materialized review bundle");
   });
 
+  test("materializes working-tree archive transport without git metadata", async () => {
+    const workspaceDir = await makeTempDir("agent-entrypoint-archive-workspace-");
+    const sourceRepoDir = await makeTempDir("agent-entrypoint-archive-source-");
+    const archivePath = join(workspaceDir, "repo.tar");
+    const diagnostics: string[] = [];
+
+    await mkdir(join(sourceRepoDir, "system", "settings"), { recursive: true });
+    await writeFile(join(sourceRepoDir, "system", "settings", "linux.xml"), "<settings />\n");
+    await symlink("linux.xml", join(sourceRepoDir, "system", "settings", "freebsd.xml"));
+    await $`git -C ${sourceRepoDir} init`.quiet();
+    await $`git -C ${sourceRepoDir} config user.email t@example.com`.quiet();
+    await $`git -C ${sourceRepoDir} config user.name T`.quiet();
+    await $`git -C ${sourceRepoDir} add .`.quiet();
+    await $`git -C ${sourceRepoDir} commit -m init`.quiet();
+    await $`git -C ${sourceRepoDir} archive --format=tar -o ${archivePath} HEAD`.quiet();
+
+    const agentConfig = {
+      prompt: "Review this PR",
+      model: "claude-sonnet-4-5-20250929",
+      maxTurns: 20,
+      allowedTools: ["Read", "Grep"],
+      repoTransport: {
+        kind: "working-tree-archive",
+        archivePath,
+      },
+    };
+    await writeFile(join(workspaceDir, "agent-config.json"), JSON.stringify(agentConfig));
+
+    setEnv({
+      WORKSPACE_DIR: workspaceDir,
+      MCP_BASE_URL: "https://api.example.com",
+      MCP_BEARER_TOKEN: "bearer-tok",
+      ANTHROPIC_API_KEY: "sk-ant-test",
+    });
+
+    let capturedParams: { prompt: string; options?: Record<string, unknown> } | undefined;
+    const written: Record<string, string> = {};
+    const deps: Partial<EntrypointDeps> = {
+      appendFileFn: async (_path, content) => {
+        diagnostics.push(content);
+      },
+      writeFileFn: async (path, content) => {
+        written[path] = content;
+        await writeFile(path, content);
+      },
+      queryFn: (params) => {
+        capturedParams = params as { prompt: string; options?: Record<string, unknown> };
+        return makeAsyncIterable([makeResultSuccess()]);
+      },
+    };
+
+    await main(deps);
+
+    expect(capturedParams, written[join(workspaceDir, "result.json")]).toBeDefined();
+    const cwd = capturedParams!.options!.cwd as string;
+    expect(cwd).not.toBe(workspaceDir);
+    expect(cwd).not.toBe(archivePath);
+    expect(await $`git -C ${cwd} rev-parse --is-inside-work-tree`.quiet().nothrow().then((r) => r.exitCode)).not.toBe(0);
+    expect((await lstat(join(cwd, "system", "settings", "freebsd.xml"))).isSymbolicLink()).toBe(true);
+    expect(diagnostics.join("")).toContain("repo transport kind=working-tree-archive");
+    expect(diagnostics.join("")).toContain("materialized repo archive kind=working-tree-archive");
+  });
+
   test("writes an error result when repoTransport metadata is malformed", async () => {
     const written: Record<string, string> = {};
     let queryCalled = false;

--- a/src/execution/agent-entrypoint.ts
+++ b/src/execution/agent-entrypoint.ts
@@ -13,7 +13,7 @@
 
 import { query as sdkQuery } from "@anthropic-ai/claude-agent-sdk";
 import type { SDKResultMessage, McpHttpServerConfig, Query, SDKRateLimitEvent } from "@anthropic-ai/claude-agent-sdk";
-import { readFile, writeFile as fsWriteFile, appendFile as fsAppendFile, mkdtemp } from "node:fs/promises";
+import { readFile, writeFile as fsWriteFile, appendFile as fsAppendFile, mkdtemp, mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { $ } from "bun";
@@ -168,6 +168,12 @@ async function materializeRepoTransport(transport: RepoTransport): Promise<strin
     return repoDir;
   }
 
+  if (transport.kind === "working-tree-archive") {
+    await mkdir(repoDir, { recursive: true });
+    await $`tar -xf ${transport.archivePath} -C ${repoDir}`.quiet();
+    return repoDir;
+  }
+
   await $`git clone ${transport.bundlePath} ${repoDir}`.quiet();
   if (transport.originUrl) {
     await $`git -C ${repoDir} remote set-url origin ${transport.originUrl}`.quiet();
@@ -266,7 +272,9 @@ export async function main(deps?: Partial<EntrypointDeps>): Promise<void> {
       await appendDiagnostic(
         repoTransport.kind === "review-bundle"
           ? `repo transport kind=${repoTransport.kind} headRef=${repoTransport.headRef} baseRef=${repoTransport.baseRef} originConfigured=${repoTransport.originUrl ? "yes" : "no"}`
-          : `repo transport kind=${repoTransport.kind} originConfigured=${repoTransport.originUrl ? "yes" : "no"}`,
+          : repoTransport.kind === "working-tree-archive"
+            ? `repo transport kind=${repoTransport.kind}`
+            : `repo transport kind=${repoTransport.kind} originConfigured=${repoTransport.originUrl ? "yes" : "no"}`,
       );
     }
 
@@ -278,7 +286,9 @@ export async function main(deps?: Partial<EntrypointDeps>): Promise<void> {
       await appendDiagnostic(
         repoTransport.kind === "review-bundle"
           ? `materialized review bundle headRef=${repoTransport.headRef} baseRef=${repoTransport.baseRef}`
-          : "materialized repo bundle kind=bundle-all",
+          : repoTransport.kind === "working-tree-archive"
+            ? "materialized repo archive kind=working-tree-archive"
+            : "materialized repo bundle kind=bundle-all",
       );
     }
 

--- a/src/execution/executor.ts
+++ b/src/execution/executor.ts
@@ -246,6 +246,21 @@ async function buildGitRepoTransport(params: {
   };
 }
 
+async function buildGitArchiveTransport(params: {
+  sourceRepoDir: string;
+  workspaceDir: string;
+}): Promise<{ archivePath: string; repoTransport: RepoTransport }> {
+  const archivePath = join(params.workspaceDir, "repo.tar");
+  await $`git -C ${params.sourceRepoDir} archive --format=tar -o ${archivePath} HEAD`.quiet();
+  return {
+    archivePath,
+    repoTransport: {
+      kind: "working-tree-archive",
+      archivePath,
+    },
+  };
+}
+
 async function hasTrackedSymlinks(repoDir: string): Promise<boolean> {
   const result = await $`git -C ${repoDir} ls-files -s`.quiet().nothrow();
   if (result.exitCode !== 0) {
@@ -296,12 +311,12 @@ export async function prepareAgentWorkspace(params: {
     if (sourceIsShallow) {
       const sourceHasTrackedSymlinks = await hasTrackedSymlinks(params.sourceRepoDir);
       if (sourceHasTrackedSymlinks) {
-        const preparedRepo = await buildGitRepoTransport({
+        const preparedRepo = await buildGitArchiveTransport({
           sourceRepoDir: params.sourceRepoDir,
           workspaceDir: params.workspaceDir,
         });
-        repoBundlePath = preparedRepo.repoBundlePath;
         repoTransport = preparedRepo.repoTransport;
+        allowedTools = filterGitToolsForSnapshot(params.allowedTools);
       } else {
         repoCwd = await exportGitWorkingTreeSnapshot({
           sourceRepoDir: params.sourceRepoDir,

--- a/src/execution/prepare-agent-workspace.test.ts
+++ b/src/execution/prepare-agent-workspace.test.ts
@@ -132,7 +132,7 @@ test("prepareAgentWorkspace writes a review bundle transport for repos with trac
   expect((await $`git -C ${cloneCheckDir} diff origin/main...HEAD --stat`.quiet()).text()).toContain("feature.ts");
 });
 
-test("prepareAgentWorkspace uses bundle transport for shallow repos with tracked symlinks", async () => {
+test("prepareAgentWorkspace uses archive transport for shallow repos with tracked symlinks", async () => {
   const tempRoot = await makeTempDir("kodiai-shallow-symlink-bundle-");
   const bareRepoDir = join(tempRoot, "origin.git");
   const seedRepoDir = join(tempRoot, "seed");
@@ -175,24 +175,21 @@ test("prepareAgentWorkspace uses bundle transport for shallow repos with tracked
 
   expect((await $`git -C ${shallowRepoDir} rev-parse --is-shallow-repository`.quiet().text()).trim()).toBe("true");
   expect(result.repoCwd).toBeUndefined();
-  expect(result.repoBundlePath).toBe(join(workspaceDir, "repo.bundle"));
+  expect(result.repoBundlePath).toBeUndefined();
 
   const rawAgentConfig = await readFile(join(workspaceDir, "agent-config.json"), "utf-8");
   const agentConfig = JSON.parse(rawAgentConfig) as {
     repoCwd?: string;
-    repoTransport?: { kind?: string; bundlePath?: string; headRef?: string; baseRef?: string; originUrl?: string };
+    repoTransport?: { kind?: string; bundlePath?: string; headRef?: string; baseRef?: string; originUrl?: string; archivePath?: string };
     allowedTools?: string[];
   };
 
   expect(agentConfig.repoCwd).toBeUndefined();
   expect(agentConfig.repoTransport).toEqual({
-    kind: "review-bundle",
-    bundlePath: join(workspaceDir, "repo.bundle"),
-    headRef: "pr-mention",
-    baseRef: "master",
-    originUrl: `file://${bareRepoDir}`,
+    kind: "working-tree-archive",
+    archivePath: join(workspaceDir, "repo.tar"),
   });
-  expect(agentConfig.allowedTools).toContain("Bash(git diff:*)");
+  expect(agentConfig.allowedTools).toEqual(["Read", "Grep", "Glob"]);
   await expect(stat(join(workspaceDir, "repo"))).rejects.toThrow();
 });
 

--- a/src/execution/repo-transport.ts
+++ b/src/execution/repo-transport.ts
@@ -12,7 +12,12 @@ export type ReviewBundleRepoTransport = {
   originUrl?: string;
 };
 
-export type RepoTransport = BundleAllRepoTransport | ReviewBundleRepoTransport;
+export type WorkingTreeArchiveRepoTransport = {
+  kind: "working-tree-archive";
+  archivePath: string;
+};
+
+export type RepoTransport = BundleAllRepoTransport | ReviewBundleRepoTransport | WorkingTreeArchiveRepoTransport;
 
 function readRequiredString(
   value: unknown,
@@ -71,6 +76,13 @@ export function resolveRepoTransport(config: {
       headRef: readRequiredString(raw.headRef, "headRef", kind),
       baseRef: readRequiredString(raw.baseRef, "baseRef", kind),
       ...(readOptionalString(raw.originUrl) ? { originUrl: readOptionalString(raw.originUrl) } : {}),
+    };
+  }
+
+  if (kind === "working-tree-archive") {
+    return {
+      kind,
+      archivePath: readRequiredString(raw.archivePath, "archivePath", kind),
     };
   }
 


### PR DESCRIPTION
## Summary

Follow-up to PR #132. The first live validation on `xbmc/xbmc#28172` got past Azure Files symlink creation, but the agent then failed materializing the shallow review bundle:

```text
fatal: remote did not send all necessary objects
```

Root cause: a shallow repo with tracked symlinks cannot safely use the non-git snapshot path, but creating a git review bundle from shallow history can be incomplete for the agent-side clone.

This change introduces a `working-tree-archive` repo transport for shallow symlink workspaces:

- orchestrator writes `git archive --format=tar -o repo.tar HEAD` into Azure Files;
- Azure Files stores the tar as a regular file, so it never creates symlinks;
- agent extracts the tar into its local `/tmp` checkout directory, where symlinks are allowed;
- git tools remain stripped because this transport is a non-git working-tree snapshot.

Shallow repos without tracked symlinks keep the faster `checkout-index` snapshot path.

## Verification

- RED first: changed the shallow symlink regression test to expect `working-tree-archive`; it failed because code still emitted `review-bundle`.
- GREEN targeted: `bun test ./src/execution/prepare-agent-workspace.test.ts -t "shallow repos with tracked symlinks"` passed.
- Agent materialization: `bun test ./src/execution/agent-entrypoint.test.ts -t "working-tree archive"` passed.
- Affected suite: `bun test ./src/execution/prepare-agent-workspace.test.ts ./src/execution/agent-entrypoint.test.ts ./src/execution/executor.test.ts` — 68 pass, 0 fail.
- Type/lint: `bun run tsc --noEmit && bun run lint` passed.

## Live evidence

`xbmc/xbmc#28172` after PR #132 deploy:

- review reached ACA job dispatch (`caj-kodiai-agent-lv639sg`), proving the original Azure Files symlink handoff failure was bypassed;
- agent result failed in 3.5s with `Failed with exit code 128`;
- downloaded `repo.bundle` reproduced locally:

```text
fatal: remote did not send all necessary objects
```
