### PR TITLE
M066 formatter suggestions smoke gate

### DIFF
--- a/.kodiai.yml
+++ b/.kodiai.yml
@@ -3,6 +3,10 @@ timeoutSeconds: 1800
 review:
   profile: strict
   minConfidence: 70
+  formatterSuggestions:
+    automatic: false
+    command: "python3 scripts/m066-formatter-smoke.py"
+    maxSuggestions: 1
   triggers:
     onSynchronize: true
   suppressions:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kodiai
 
-Kodiai is an installable GitHub App that delivers AI-powered code review, conversational assistance, issue intelligence, and Slack integration. One installation replaces per-repo workflow YAML — configure behavior with an optional `.kodiai.yml` file.
+Kodiai  is an installable GitHub App that delivers AI-powered code review, conversational assistance, issue intelligence, and Slack integration. One installation replaces per-repo workflow YAML — configure behavior with an optional `.kodiai.yml` file.
 
 Service-level runtime features like Slack webhook relay are configured through environment variables, not `.kodiai.yml`.
 

--- a/scripts/m066-formatter-smoke.py
+++ b/scripts/m066-formatter-smoke.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+"""M066 controlled smoke formatter: fixes the intentional README double-space and emits a bounded diff."""
+from pathlib import Path
+import subprocess
+
+path = Path("README.md")
+text = path.read_text()
+formatted = text.replace("Kodiai  is", "Kodiai is", 1)
+if formatted != text:
+    path.write_text(formatted)
+subprocess.run(["git", "diff", "--", "README.md"], check=False)


### PR DESCRIPTION
M066 controlled formatter-suggestions smoke gate.

This PR intentionally contains one README whitespace-only hunk (`Kodiai  is` -> `Kodiai is`) plus the minimum PR-head smoke formatter configuration needed for `@kodiai format suggestions` to emit a same-PR suggestion.

Do not merge; use only for M066 formatter-suggestions acceptance proof.

Non-secret prerequisites captured by T02:
- repo: `xbmc/kodiai`
- branch: `smoke/m066-formatter-suggestions-1777950652`
- head SHA: `df017da6b6959038a288f8eae070b7a384ef0fa4`
- formatter command: `python3 scripts/m066-formatter-smoke.py`
- controlled diff: README double-space correction
