### PR TITLE
Harden production review operations

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -709,6 +709,7 @@ ${BOT_USER_ENV_YAML}
             httpGet:
               path: /healthz
               port: 3000
+            timeoutSeconds: 3
             initialDelaySeconds: 5
             periodSeconds: 30
             failureThreshold: 3
@@ -716,6 +717,7 @@ ${BOT_USER_ENV_YAML}
             httpGet:
               path: /readiness
               port: 3000
+            timeoutSeconds: 5
             initialDelaySeconds: 10
             periodSeconds: 10
             failureThreshold: 3
@@ -723,6 +725,7 @@ ${BOT_USER_ENV_YAML}
             httpGet:
               path: /healthz
               port: 3000
+            timeoutSeconds: 3
             initialDelaySeconds: 3
             periodSeconds: 5
             failureThreshold: 40
@@ -826,6 +829,7 @@ ${BOT_USER_ENV_YAML}
             httpGet:
               path: /healthz
               port: 3000
+            timeoutSeconds: 3
             initialDelaySeconds: 5
             periodSeconds: 30
             failureThreshold: 3
@@ -833,6 +837,7 @@ ${BOT_USER_ENV_YAML}
             httpGet:
               path: /readiness
               port: 3000
+            timeoutSeconds: 5
             initialDelaySeconds: 10
             periodSeconds: 10
             failureThreshold: 3
@@ -840,6 +845,7 @@ ${BOT_USER_ENV_YAML}
             httpGet:
               path: /healthz
               port: 3000
+            timeoutSeconds: 3
             initialDelaySeconds: 3
             periodSeconds: 5
             failureThreshold: 40

--- a/docs/GRACEFUL-RESTART-RUNBOOK.md
+++ b/docs/GRACEFUL-RESTART-RUNBOOK.md
@@ -63,7 +63,15 @@ Webhooks arriving during the drain period are queued to PostgreSQL and replayed 
 
 ```bash
 curl -s https://<FQDN>/healthz | jq .
-# Expected: { "status": "ok", "db": "connected" }
+# Expected: { "status": "ok" }
+```
+
+Optional dependency sample:
+
+```bash
+curl -s https://<FQDN>/readiness | jq .
+# Expected when dependencies are healthy: { "status": "ready" }
+# GitHub transients may return: { "status": "ready", "github": "degraded", "reason": "..." }
 ```
 
 2. Check container logs for the startup summary:
@@ -107,15 +115,25 @@ UPDATE webhook_queue SET status = 'pending' WHERE status = 'processing';
 
 ### Health check failing after deploy
 
-**Symptom:** `/healthz` returns 503 with `{ "status": "unhealthy", "db": "unreachable" }`.
+**Symptom:** `/healthz` fails to return HTTP 200 with `{ "status": "ok" }`.
 
-**Cause:** PostgreSQL connection is not working.
+**Cause:** The app process is not accepting HTTP requests. `/healthz` is intentionally process-only; PostgreSQL and GitHub dependency latency should not make ACA restart a healthy process.
 
 **Resolution:**
-- Verify the production `DATABASE_URL` secret ref resolves correctly for the running app revision
-- Check PostgreSQL server is running and accessible from the container network
-- Check connection pool limits (max 10 connections configured)
-- Review container logs for PostgreSQL connection errors at startup
+- Check the active revision and replica status in Azure Container Apps
+- Review container logs for startup crashes, port binding failures, or process exits
+- If `/healthz` is healthy but review processing fails, inspect runtime logs and dependency-specific errors instead of treating liveness as a database probe
+
+### Readiness dependency degradation
+
+**Symptom:** `/readiness` returns HTTP 200 with `{ "status": "ready", "github": "degraded", ... }`.
+
+**Cause:** The process is ready to receive traffic, but the bounded GitHub connectivity sample failed or timed out.
+
+**Resolution:**
+- Treat this as an operational warning, not an ACA replica-fatal readiness failure
+- Check GitHub API reachability and app-auth logs if review handling also reports GitHub errors
+- Re-check `/readiness`; transient dependency degradation should clear without restarting the process
 
 ### Rollback to previous revision
 
@@ -157,7 +175,8 @@ See the deployment guide for the full production secret contract and the app sec
 | `Webhook queued to PostgreSQL for drain-time replay` | Webhook saved during shutdown |
 | `Dequeued pending webhooks for replay` | Startup found queued webhooks |
 | `Startup webhook queue replay complete` | All queued webhooks processed |
-| `Health check failed: PostgreSQL unreachable` | DB connection issue on liveness probe |
+| `Readiness dependency degraded: GitHub API unreachable` | GitHub connectivity sample failed but readiness stayed fail-open |
+| `Readiness dependency degraded: GitHub API connectivity check timed out` | GitHub connectivity sample exceeded the readiness dependency timeout |
 
 ### Exit Codes
 
@@ -170,6 +189,6 @@ See the deployment guide for the full production secret contract and the app sec
 
 | Endpoint | Type | What it checks |
 |----------|------|----------------|
-| `/healthz` | Liveness | Process up + PostgreSQL `SELECT 1` |
-| `/readiness` | Readiness | GitHub API connectivity |
+| `/healthz` | Liveness | Process is accepting HTTP requests |
+| `/readiness` | Readiness | Process is ready; bounded GitHub sample may be reported as degraded without failing readiness |
 | `/health` | Alias | Same as `/healthz` (backward compatibility) |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -231,6 +231,6 @@ On the next startup, queued webhooks are replayed from the database, ensuring no
 | `POST /webhooks/github` | GitHub webhook receiver |
 | `POST /webhooks/slack/events` | Slack event receiver |
 | `POST /webhooks/slack/commands/*` | Slack slash command handlers |
-| `GET /healthz` | Health check (verifies DB connectivity) |
+| `GET /healthz` | Process-only liveness probe |
 | `GET /health` | Alias for `/healthz` |
-| `GET /readiness` | Readiness probe (verifies GitHub API access) |
+| `GET /readiness` | Readiness probe; GitHub connectivity is bounded and reported as degraded, not replica-fatal |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -152,12 +152,14 @@ This avoids webhook timeouts from cold starts and reduces concurrency surprises.
 
 Configured in the container app template:
 
-- Liveness: `GET /healthz`
-- Readiness: `GET /readiness`
-- Startup: `GET /healthz`
+- Liveness: `GET /healthz` (process-only)
+- Readiness: `GET /readiness` (fail-open degraded GitHub connectivity sample)
+- Startup: `GET /healthz` (process-only)
 
 Important:
 
+- Do not make liveness depend on PostgreSQL, GitHub, or any other external service. ACA uses liveness failures to restart replicas.
+- Readiness may report `github: "degraded"` while still returning HTTP 200; treat that as an operator warning, not an instruction to remove the replica from service.
 - Existing app updates must render the full container app template in one YAML payload.
 - Partial YAML updates that only add a volume mount can wipe env vars or probes from the next revision.
 - In single-revision mode, a stripped revision can become active immediately and fail startup with missing env vars.

--- a/scripts/verify-m064-s02.ts
+++ b/scripts/verify-m064-s02.ts
@@ -280,6 +280,45 @@ function createCanonicalStateStore() {
   };
 }
 
+function createCheckpointBackedStore(
+  canonical: ReturnType<typeof createCanonicalStateStore>,
+  overrides: Record<string, unknown> = {},
+): KnowledgeStore {
+  const checkpoints = new Map<string, Record<string, unknown>>();
+  const defaultCheckpoint = (key: string) => ({
+    reviewOutputKey: key,
+    repo: `${FIXTURE_OWNER}/${FIXTURE_REPO}`,
+    prNumber: FIXTURE_PR_NUMBER,
+    filesReviewed: ["README.md"],
+    inspectedFiles: ["README.md"],
+    findingCount: 1,
+    summaryDraft: "Found one issue before timeout.",
+    totalFiles: 2,
+  });
+
+  return createKnowledgeStoreStub({
+    ...canonical.store,
+    getCheckpoint: async (key: string) => checkpoints.get(key) ?? defaultCheckpoint(key),
+    saveCheckpoint: async (checkpoint: Record<string, unknown>) => {
+      const key = String(checkpoint.reviewOutputKey ?? "");
+      if (key) {
+        checkpoints.set(key, { ...checkpoint });
+      }
+    },
+    updateCheckpointCommentId: async (key: string, partialCommentId: number) => {
+      checkpoints.set(key, {
+        ...defaultCheckpoint(key),
+        ...(checkpoints.get(key) ?? {}),
+        partialCommentId,
+      });
+    },
+    deleteCheckpoint: async (key: string) => {
+      checkpoints.delete(key);
+    },
+    ...overrides,
+  }) as KnowledgeStore;
+}
+
 function createDiffContext() {
   return {
     changedFiles: ["README.md", "src/a.ts"],
@@ -399,7 +438,7 @@ async function runRetryEnqueueFailureScenario(): Promise<ScenarioHarnessResult> 
       handlers,
       jobQueue,
       workspaceDir: workspaceFixture.dir,
-      knowledgeStore: canonical.store,
+      knowledgeStore: createCheckpointBackedStore(canonical),
       executor: {
         execute: async () => ({
           conclusion: "error",
@@ -466,7 +505,7 @@ async function runRetryExecutionFailureScenario(): Promise<ScenarioHarnessResult
       handlers,
       jobQueue,
       workspaceDir: workspaceFixture.dir,
-      knowledgeStore: canonical.store,
+      knowledgeStore: createCheckpointBackedStore(canonical),
       executor: {
         execute: async (context) => {
           if (context.eventType === "pull_request.review-retry") {
@@ -624,7 +663,7 @@ async function runSupersededStaleRetryScenario(): Promise<ScenarioHarnessResult>
       handlers,
       jobQueue,
       workspaceDir: workspaceFixture.dir,
-      knowledgeStore: canonical.store,
+      knowledgeStore: createCheckpointBackedStore(canonical),
       reviewWorkCoordinator: coordinator,
       executor: {
         execute: async (context) => {

--- a/src/handlers/mention.test.ts
+++ b/src/handlers/mention.test.ts
@@ -10669,7 +10669,7 @@ describe("createMentionHandler review command", () => {
     expect(capturedPrompt).toContain("If NO issues found: do nothing -- no summary, no comments. The calling code handles silent approval.");
     expect(capturedPrompt).toContain("## Tiny-diff scope contract");
     expect(capturedPrompt).not.toContain("You MUST post a reply when you are mentioned.");
-    expect(capturedMaxTurnsOverride).toBe(8);
+    expect(capturedMaxTurnsOverride).toBeUndefined();
     expect(capturedEnableInlineTools).toBe(true);
 
     await workspaceFixture.cleanup();
@@ -11054,7 +11054,7 @@ describe("createMentionHandler review command", () => {
     expect(capturedReviewOutputKey).toBeDefined();
     expect(capturedReviewOutputKey).toContain("kodiai-review-output:v1:");
     expect(capturedTriggerBody).toBe("please retry review");
-    expect(capturedMaxTurnsOverride).toBe(8);
+    expect(capturedMaxTurnsOverride).toBeUndefined();
 
     await workspaceFixture.cleanup();
   });

--- a/src/handlers/review.test.ts
+++ b/src/handlers/review.test.ts
@@ -10770,6 +10770,213 @@ describe("createReviewHandler timeout resilience", () => {
     await workspaceFixture.cleanup();
   });
 
+  test("max-turns continuation publishes one final completed review instead of a bounded first-pass", async () => {
+    const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
+    const workspaceFixture = await createWorkspaceFixture();
+
+    const checkpointState = new Map<string, {
+      partialCommentId?: number;
+      findingCount?: number;
+      filesReviewed?: string[];
+      summaryDraft?: string;
+      totalFiles?: number;
+    }>();
+
+    const reviewOutputKey = buildReviewOutputKey({
+      installationId: 42,
+      owner: "acme",
+      repo: "repo",
+      prNumber: 101,
+      action: "review_requested",
+      deliveryId: "delivery-123",
+      headSha: "abcdef1234567890",
+    });
+    const retryReviewOutputKey = `${reviewOutputKey}-retry-1`;
+    checkpointState.set(reviewOutputKey, {
+      findingCount: 0,
+      filesReviewed: ["README.md"],
+      summaryDraft: "Reviewed README before max-turns.",
+      totalFiles: 3,
+    });
+    checkpointState.set(retryReviewOutputKey, {
+      findingCount: 0,
+      filesReviewed: ["src/a.ts", "src/b.ts"],
+      summaryDraft: "Completed the remaining files without findings.",
+      totalFiles: 3,
+    });
+
+    let queuedRetryJob: ((metadata: JobQueueRunMetadata) => Promise<unknown>) | undefined;
+    let nextCommentId = 610;
+    const issueComments = new Map<number, string>();
+    const { logger, entries } = createCaptureLogger();
+
+    createReviewHandler({
+      eventRouter: {
+        register: (eventKey, handler) => {
+          handlers.set(eventKey, handler);
+        },
+        dispatch: async () => undefined,
+      },
+      jobQueue: {
+        enqueue: async <T>(
+          _installationId: number,
+          fn: (metadata: JobQueueRunMetadata) => Promise<T>,
+          context?: { action?: string },
+        ) => {
+          if (context?.action === "review-retry") {
+            queuedRetryJob = fn as (metadata: JobQueueRunMetadata) => Promise<unknown>;
+            return undefined as T;
+          }
+          return fn(createQueueRunMetadata());
+        },
+        getQueueSize: () => 0,
+        getPendingCount: () => 0,
+        getActiveJobs: getEmptyActiveJobs,
+      } as unknown as JobQueue,
+      workspaceManager: {
+        create: async () => ({
+          dir: workspaceFixture.dir,
+          cleanup: async () => undefined,
+        }),
+        cleanupStale: async () => 0,
+      } as WorkspaceManager,
+      githubApp: {
+        getAppSlug: () => "kodiai",
+        getInstallationOctokit: async () => ({
+          rest: {
+            pulls: {
+              listReviewComments: async () => ({ data: [] }),
+              listReviews: async () => ({ data: [] }),
+              listCommits: async () => ({ data: [] }),
+            },
+            issues: {
+              listComments: async () => ({
+                data: Array.from(issueComments.entries()).map(([id, body]) => ({ id, body })),
+              }),
+              createComment: async (params: { body: string }) => {
+                const id = nextCommentId++;
+                issueComments.set(id, params.body);
+                return { data: { id } };
+              },
+              updateComment: async (params: { comment_id: number; body: string }) => {
+                issueComments.set(params.comment_id, params.body);
+                return { data: {} };
+              },
+            },
+            reactions: {
+              createForIssue: async () => ({ data: {} }),
+            },
+          },
+        }) as never,
+      } as unknown as GitHubApp,
+      executor: {
+        execute: async (context: { eventType: string }) => {
+          if (context.eventType === "pull_request.review-retry") {
+            return {
+              conclusion: "success",
+              published: false,
+              costUsd: 0,
+              numTurns: 1,
+              durationMs: 1,
+              sessionId: "session-max-turns-retry-complete",
+              model: "test-model",
+              inputTokens: 0,
+              outputTokens: 0,
+              cacheReadTokens: 0,
+              cacheCreationTokens: 0,
+              stopReason: "end_turn",
+            };
+          }
+          return {
+            conclusion: "failure",
+            published: false,
+            stopReason: "max_turns",
+            failureSubtype: "error_max_turns",
+            costUsd: 0,
+            numTurns: 25,
+            durationMs: 1,
+            sessionId: "session-max-turns-root-complete",
+            model: "test-model",
+            inputTokens: 0,
+            outputTokens: 0,
+            cacheReadTokens: 0,
+            cacheCreationTokens: 0,
+          };
+        },
+      } as never,
+      telemetryStore: noopTelemetryStore,
+      knowledgeStore: createKnowledgeStoreStub({
+        getCheckpoint: async (key: string) => {
+          const checkpoint = checkpointState.get(key);
+          if (!checkpoint || !checkpoint.filesReviewed || !checkpoint.summaryDraft || !checkpoint.totalFiles) {
+            return null;
+          }
+          return {
+            reviewOutputKey: key,
+            repo: "acme/repo",
+            prNumber: 101,
+            filesReviewed: checkpoint.filesReviewed,
+            findingCount: checkpoint.findingCount ?? 0,
+            summaryDraft: checkpoint.summaryDraft,
+            totalFiles: checkpoint.totalFiles,
+            partialCommentId: checkpoint.partialCommentId,
+          };
+        },
+        saveCheckpoint: async (checkpoint: {
+          reviewOutputKey: string;
+          partialCommentId?: number;
+          findingCount?: number;
+          filesReviewed?: string[];
+          summaryDraft?: string;
+          totalFiles?: number;
+        }) => {
+          checkpointState.set(checkpoint.reviewOutputKey, {
+            partialCommentId: checkpoint.partialCommentId,
+            findingCount: checkpoint.findingCount,
+            filesReviewed: checkpoint.filesReviewed,
+            summaryDraft: checkpoint.summaryDraft,
+            totalFiles: checkpoint.totalFiles,
+          });
+        },
+        deleteCheckpoint: (key: string) => {
+          checkpointState.delete(key);
+        },
+      }) as never,
+      diffContextCollector: async () => ({
+        changedFiles: ["README.md", "src/a.ts", "src/b.ts"],
+        numstatLines: [],
+        diffContent: undefined,
+        strategy: "github-file-list-fallback",
+        mergeBaseRecovered: false,
+        deepenAttempts: 0,
+        unshallowAttempted: false,
+        diffRange: "github-api:file-list",
+      }),
+      logger,
+    });
+
+    await handlers.get("pull_request.review_requested")!(
+      buildReviewRequestedEvent({ requested_reviewer: { login: "kodiai[bot]" } }),
+    );
+
+    expect(queuedRetryJob).toBeDefined();
+    expect(Array.from(issueComments.values()).join("\n")).not.toContain("Bounded first-pass review");
+    expect(Array.from(issueComments.values()).join("\n")).not.toContain("follow-up review is pending");
+
+    await queuedRetryJob!(createQueueRunMetadata());
+
+    expect(entries.some((entry) => entry.message === "Retry complete -- published final review comment with merged results")).toBeTrue();
+    const finalComment = Array.from(issueComments.values()).join("\n");
+    expect(finalComment).toContain("**Review complete**");
+    expect(finalComment).toContain("Coverage: 3 of 3 changed files reviewed.");
+    expect(finalComment).not.toContain("Bounded first-pass review");
+    expect(finalComment).not.toContain("follow-up review is pending");
+    expect(finalComment).not.toContain("- Bounded first-pass:");
+    expect(finalComment).toContain(buildReviewOutputMarker(reviewOutputKey));
+
+    await workspaceFixture.cleanup();
+  });
+
   test("retry merge updates the bounded comment and Review Details with merged coverage", async () => {
     const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
     const workspaceFixture = await createWorkspaceFixture();
@@ -16272,7 +16479,7 @@ describe("createReviewHandler bounded review disclosure", () => {
 
 
 describe("createReviewHandler failure fallback publication", () => {
-  test("publishes bounded first-pass output for max-turns when checkpoint evidence exists", async () => {
+  test("defers max-turns checkpoint evidence publicly while continuation is scheduled", async () => {
     const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
     const workspaceFixture = await createWorkspaceFixture();
 
@@ -16377,10 +16584,10 @@ describe("createReviewHandler failure fallback publication", () => {
       }),
     );
 
-    const boundedComment = createdCommentBodies.find((body) => body.includes("**Bounded first-pass review**"));
-    expect(boundedComment).toBeDefined();
-    expect(boundedComment).toContain("stopped at max-turns after covering 1 of 3 files from checkpoint evidence");
-    expect(boundedComment).toContain("Found two issues before max-turns.");
+    const combinedBodies = createdCommentBodies.join("\n");
+    expect(combinedBodies).not.toContain("**Bounded first-pass review**");
+    expect(combinedBodies).not.toContain("stopped at max-turns");
+    expect(combinedBodies).not.toContain("follow-up review is pending");
 
     await workspaceFixture.cleanup();
   });
@@ -16596,9 +16803,9 @@ describe("createReviewHandler failure fallback publication", () => {
       }),
     );
 
-    const boundedComment = createdCommentBodies.find((body) => body.includes("**Bounded first-pass review**"));
-    expect(boundedComment).toBeDefined();
-    expect(boundedComment).toContain("Scheduling a reduced-scope retry.");
+    const combinedBodies = createdCommentBodies.join("\n");
+    expect(combinedBodies).not.toContain("**Bounded first-pass review**");
+    expect(combinedBodies).not.toContain("Scheduling a reduced-scope retry.");
     expect(queuedRetryJob).toBeDefined();
 
     const retryLog = entries.find((entry) => entry.message === "Enqueueing retry with reduced scope");
@@ -16608,7 +16815,7 @@ describe("createReviewHandler failure fallback publication", () => {
     await workspaceFixture.cleanup();
   });
 
-  test("merges bounded first-pass Review Details into the max-turns fallback comment when checkpoint evidence exists", async () => {
+  test("does not publish bounded Review Details for max-turns while continuation is scheduled", async () => {
     const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
     const workspaceFixture = await createWorkspaceFixture();
 
@@ -16717,24 +16924,16 @@ describe("createReviewHandler failure fallback publication", () => {
       }),
     );
 
-    const boundedComment = Array.from(issueComments.values()).find((body) => body.includes("**Bounded first-pass review**"));
-    const standaloneReviewDetails = Array.from(issueComments.values()).find((body) =>
-      body.includes("<summary>Review Details</summary>") && body !== boundedComment
-    );
-
-    expect(boundedComment).toBeDefined();
-    expect(boundedComment).toContain("stopped at max-turns after covering 1 of 3 files from checkpoint evidence");
-    expect(boundedComment).toContain("<summary>Review Details</summary>");
-    expect(boundedComment).toContain("- Bounded first-pass: max-turns via checkpoint evidence");
-    expect(boundedComment).toContain("- Covered scope: 1/3 changed files");
-    expect(boundedComment).toContain("- Remaining scope: 2/3 changed files");
-    expect(boundedComment).toContain("- Continuation state: follow-up review pending for remaining scope");
-    expect(standaloneReviewDetails).toBeUndefined();
+    const combinedBodies = Array.from(issueComments.values()).join("\n");
+    expect(combinedBodies).not.toContain("**Bounded first-pass review**");
+    expect(combinedBodies).not.toContain("stopped at max-turns");
+    expect(combinedBodies).not.toContain("<summary>Review Details</summary>");
+    expect(combinedBodies).not.toContain("- Bounded first-pass:");
 
     await workspaceFixture.cleanup();
   });
 
-  test("falls back to standalone Review Details when max-turns canonical comment rebuild fails", async () => {
+  test("does not fall back to standalone bounded Review Details while max-turns continuation is scheduled", async () => {
     const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
     const workspaceFixture = await createWorkspaceFixture();
     const { logger, entries } = createCaptureLogger();
@@ -16849,18 +17048,12 @@ describe("createReviewHandler failure fallback publication", () => {
       }),
     );
 
-    const boundedComment = Array.from(issueComments.values()).find((body) => body.includes("**Bounded first-pass review**"));
-    const standaloneReviewDetails = Array.from(issueComments.values()).find((body) =>
-      body.includes("<summary>Review Details</summary>") && body !== boundedComment
-    );
-
-    expect(boundedComment).toBeDefined();
-    expect(boundedComment).not.toContain("<summary>Review Details</summary>");
-    expect(standaloneReviewDetails).toBeDefined();
-    expect(standaloneReviewDetails).toContain("<summary>Review Details</summary>");
+    const combinedBodies = Array.from(issueComments.values()).join("\n");
+    expect(combinedBodies).not.toContain("**Bounded first-pass review**");
+    expect(combinedBodies).not.toContain("<summary>Review Details</summary>");
     expect(
       entries.some((entry) => entry.data?.gate === "review-details-output" && entry.data?.gateResult === "degraded-fallback"),
-    ).toBeTrue();
+    ).toBeFalse();
 
     await workspaceFixture.cleanup();
   });

--- a/src/handlers/review.test.ts
+++ b/src/handlers/review.test.ts
@@ -17209,6 +17209,7 @@ describe("createReviewHandler canonical continuation-family state", () => {
       } as never,
       telemetryStore: noopTelemetryStore,
       knowledgeStore: createKnowledgeStoreStub({
+        saveCheckpoint: async () => undefined,
         upsertContinuationFamilyState: async (record: Record<string, unknown>) => {
           canonicalWrites.push(record);
         },
@@ -17246,7 +17247,7 @@ describe("createReviewHandler canonical continuation-family state", () => {
     await workspaceFixture.cleanup();
   });
 
-  test("settles retry canonical state when the base checkpoint is missing during retry completion", async () => {
+  test("does not enqueue a retry when the base run has no checkpoint or evidence", async () => {
     const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
     const workspaceFixture = await createWorkspaceFixture();
     const canonicalWrites: Array<Record<string, unknown>> = [];
@@ -17368,15 +17369,14 @@ describe("createReviewHandler canonical continuation-family state", () => {
       }),
     );
 
-    expect(queuedRetryJob).toBeDefined();
-    await queuedRetryJob!(createQueueRunMetadata());
+    expect(queuedRetryJob).toBeUndefined();
 
     expect(canonicalWrites.at(-1)).toMatchObject({
       familyKey: buildReviewFamilyKey("acme", "repo", 101),
-      authoritativeAttemptId: "review-work-2",
-      authoritativeAttemptOrdinal: 2,
-      authoritativeOutcome: "quiet-settled",
-      finalStopReason: "settled-without-update",
+      authoritativeAttemptId: "review-work-1",
+      authoritativeAttemptOrdinal: 1,
+      authoritativeOutcome: "blocked",
+      finalStopReason: "no-follow-up",
       projectionStatus: "canonical",
       supersededByAttemptId: null,
     });
@@ -17958,6 +17958,7 @@ describe("createReviewHandler canonical continuation-family state", () => {
       } as never,
       telemetryStore: noopTelemetryStore,
       knowledgeStore: createKnowledgeStoreStub({
+        saveCheckpoint: async () => undefined,
         upsertContinuationFamilyState: async (record: Record<string, unknown>) => {
           canonicalWrites.push(record);
         },
@@ -18212,6 +18213,7 @@ describe("createReviewHandler canonical continuation-family state", () => {
       } as never,
       telemetryStore: noopTelemetryStore,
       knowledgeStore: createKnowledgeStoreStub({
+        saveCheckpoint: async () => undefined,
         upsertContinuationFamilyState: async (record: Record<string, unknown>) => {
           canonicalWrites.push(record);
         },

--- a/src/handlers/review.test.ts
+++ b/src/handlers/review.test.ts
@@ -4954,6 +4954,36 @@ describe("createReviewHandler diff collection resilience", () => {
     await workspaceFixture.cleanup();
   });
 
+  test("uses a production-safe default timeout for merge-base recovery fetches", async () => {
+    const workspaceFixture = await createNoMergeBaseFixture({ includePhase27Fields: true });
+    const { logger } = createCaptureLogger();
+    const observedTimeouts: number[] = [];
+
+    try {
+      await collectDiffContext({
+        workspaceDir: workspaceFixture.dir,
+        baseRef: "main",
+        maxFilesForFullDiff: 200,
+        logger,
+        baseLog: { deliveryId: "delivery-123", prNumber: 101 },
+        runGitCommand: async (_args, timeoutMs) => {
+          observedTimeouts.push(timeoutMs);
+          return {
+            exitCode: 124,
+            stdout: "",
+            stderr: "timed out",
+            timedOut: true,
+          };
+        },
+        fallbackFileProvider: async () => ["src/api/phase27-uat-example.ts"],
+      });
+
+      expect(observedTimeouts.at(0)).toBe(30_000);
+    } finally {
+      await workspaceFixture.cleanup();
+    }
+  });
+
   test("degrades to GitHub file list when merge-base recovery times out", async () => {
     const workspaceFixture = await createNoMergeBaseFixture({ includePhase27Fields: true });
     const { logger, entries } = createCaptureLogger();

--- a/src/handlers/review.ts
+++ b/src/handlers/review.ts
@@ -2484,6 +2484,8 @@ export function createReviewHandler(deps: {
             prNumber: pr.number,
             localBranch: "pr-review",
             token: workspace.token,
+            fallbackRemoteUrl: pr.head.repo ? `https://github.com/${pr.head.repo.full_name}.git` : undefined,
+            fallbackRef: pr.head.ref,
           });
         }
 
@@ -5349,6 +5351,11 @@ export function createReviewHandler(deps: {
                       break;
                     case "zero-evidence-failure": {
                       retryState = "not scheduled (zero-evidence timeout)";
+                      if (knowledgeStore?.upsertContinuationFamilyState && !knowledgeStore.saveCheckpoint) {
+                        retrySummaryNote = "Retry not scheduled because the first pass produced no trustworthy evidence and checkpoint persistence is unavailable.";
+                        break;
+                      }
+
                       const retryRemoteRuntimeBudgetSeconds = Math.max(30, Math.floor(timeoutDuration / 2));
                       const retryScope = computeRetryScope({
                         allFiles: riskScores,
@@ -5679,6 +5686,20 @@ export function createReviewHandler(deps: {
                 "Enqueueing retry with reduced scope",
               );
 
+              if (timeoutFirstPass?.zeroEvidenceFailure && knowledgeStore?.saveCheckpoint) {
+                await knowledgeStore.saveCheckpoint({
+                  reviewOutputKey,
+                  repo: `${apiOwner}/${apiRepo}`,
+                  prNumber: pr.number,
+                  filesReviewed: timeoutReviewedFiles,
+                  filesInspected: timeoutInspectedFiles,
+                  findingCount: timeoutFindingCount,
+                  summaryDraft,
+                  totalFiles: timeoutTotalFiles,
+                  partialCommentId,
+                });
+              }
+
               await persistContinuationFamilyState({
                 authoritativeAttemptId: retryReviewWorkAttempt.attemptId,
                 authoritativeOutcome: "continuation-pending",
@@ -5708,6 +5729,8 @@ export function createReviewHandler(deps: {
                         prNumber: pr.number,
                         localBranch: "pr-review-retry-1",
                         token: retryWorkspace.token,
+                        fallbackRemoteUrl: pr.head.repo ? `https://github.com/${pr.head.repo.full_name}.git` : undefined,
+                        fallbackRef: pr.head.ref,
                       });
                     }
 

--- a/src/handlers/review.ts
+++ b/src/handlers/review.ts
@@ -83,7 +83,7 @@ import {
   resolveReviewBoundedness,
   type ReviewBoundednessContract,
 } from "../lib/review-boundedness.ts";
-import { formatPartialReviewComment } from "../lib/partial-review-formatter.ts";
+import { formatPartialReviewComment, formatCompletedContinuationReviewComment } from "../lib/partial-review-formatter.ts";
 import {
   normalizeReviewFirstPass,
   type ReviewFirstPassPayload,
@@ -5236,6 +5236,7 @@ export function createReviewHandler(deps: {
           let publishedPartialReview = false;
           let partialCommentId: number | undefined;
           let fallbackRetryState: string | undefined;
+          let deferredPublicOutputForContinuation = false;
 
           if (result.isTimeout || exhaustedTurnBudget) {
             // Step 1: Read checkpoint/progress data
@@ -5421,7 +5422,14 @@ export function createReviewHandler(deps: {
             };
 
             const octokit = extractionOctokit;
-            if (timeoutFirstPass?.state === "bounded-first-pass" && canPublishVisibleOutput("bounded first-pass review")) {
+            deferredPublicOutputForContinuation = exhaustedTurnBudget
+              && retryPlan?.decision === "schedule-continuation"
+              && !hasPublishedInlines;
+            if (
+              timeoutFirstPass?.state === "bounded-first-pass"
+              && !deferredPublicOutputForContinuation
+              && canPublishVisibleOutput("bounded first-pass review")
+            ) {
               setReviewWorkPhase("publish");
               const partialBody = formatPartialReviewComment({
                 summaryDraft,
@@ -6060,34 +6068,36 @@ export function createReviewHandler(deps: {
                           return;
                         }
 
-                        const mergedBody = formatPartialReviewComment({
-                          summaryDraft:
-                            settlementDecision.mergedCheckpoint.summaryDraft ||
-                            retryCheckpoint?.summaryDraft ||
-                            checkpoint?.summaryDraft ||
-                            "Review completed with reduced scope.",
-                          firstPass: mergedFirstPass,
-                          reviewOutputKey,
-                          timedOutAfterSeconds: timeoutDuration,
-                          isRetryResult: true,
-                          retryFilesReviewed,
-                          continuationRevisionCounts,
-                        });
+                        const summaryDraftForMerge =
+                          settlementDecision.mergedCheckpoint.summaryDraft ||
+                          retryCheckpoint?.summaryDraft ||
+                          checkpoint?.summaryDraft ||
+                          "Review completed with reduced scope.";
+                        const mergedReviewedFiles = settlementDecision.mergedCheckpoint.filesReviewed.length;
+                        const mergedTotalFiles = settlementDecision.mergedCheckpoint.totalFiles;
+                        const maxTurnsContinuationCompleted = timeoutFirstPass?.boundedReason === "max-turns"
+                          && mergedTotalFiles > 0
+                          && mergedReviewedFiles >= mergedTotalFiles;
+                        const mergedBody = maxTurnsContinuationCompleted
+                          ? formatCompletedContinuationReviewComment({
+                              summaryDraft: summaryDraftForMerge,
+                              reviewOutputKey,
+                              totalFiles: mergedTotalFiles,
+                              continuationRevisionCounts,
+                            })
+                          : formatPartialReviewComment({
+                              summaryDraft: summaryDraftForMerge,
+                              firstPass: mergedFirstPass,
+                              reviewOutputKey,
+                              timedOutAfterSeconds: timeoutDuration,
+                              isRetryResult: true,
+                              retryFilesReviewed,
+                              continuationRevisionCounts,
+                            });
 
                         const retryOctokit = await githubApp.getInstallationOctokit(event.installationId);
                         const storedCheckpoint = (await knowledgeStore?.getCheckpoint?.(reviewOutputKey)) ?? null;
                         const commentIdToUpdate = storedCheckpoint?.partialCommentId ?? partialCommentId;
-
-                        if (!commentIdToUpdate) {
-                          await settleRetryWithoutCanonicalUpdate({
-                            attemptId: retryReviewWorkAttempt.attemptId,
-                            reviewOutputKey: retryReviewOutputKey,
-                            deliveryId: retryDeliveryId,
-                            reason: "missing-partial-comment-id",
-                            logMessage: "Retry settlement skipped because no partial comment ID was available",
-                          });
-                          return;
-                        }
 
                         if (canPublishReviewWorkOutput(
                           retryReviewWorkAttempt.attemptId,
@@ -6097,7 +6107,9 @@ export function createReviewHandler(deps: {
                           setReviewWorkPhaseForAttempt(retryReviewWorkAttempt.attemptId, "publish");
 
                           let retryMergeProjectionStatus: ContinuationFamilyProjectionStatus = "canonical";
-                          let retryMergeLogMessage = "Retry complete -- updated partial review comment with merged results";
+                          let retryMergeLogMessage = commentIdToUpdate
+                            ? "Retry complete -- updated partial review comment with merged results"
+                            : "Retry complete -- published final review comment with merged results";
 
                           try {
                             const mergedBodyWithDetails = await upsertCanonicalReviewSurface({
@@ -6107,14 +6119,16 @@ export function createReviewHandler(deps: {
                               prNumber: pr.number,
                               reviewOutputKey,
                               preferredKind: "issue_comment",
-                              canonicalSurface: {
-                                kind: "issue_comment",
-                                commentId: commentIdToUpdate,
-                                body: mergedBody,
-                              },
+                              canonicalSurface: commentIdToUpdate
+                                ? {
+                                    kind: "issue_comment",
+                                    commentId: commentIdToUpdate,
+                                    body: mergedBody,
+                                  }
+                                : undefined,
                               summaryBody: mergedBody,
                               reviewDetailsBlock: buildReviewDetailsBody({
-                                reviewFirstPass: mergedFirstPass,
+                                reviewFirstPass: maxTurnsContinuationCompleted ? null : mergedFirstPass,
                               }),
                               botHandles: [githubApp.getAppSlug(), "claude"],
                               requireDegradationDisclosure: authorClassification.searchEnrichment.degraded,
@@ -6150,7 +6164,9 @@ export function createReviewHandler(deps: {
                             );
 
                             retryMergeProjectionStatus = "degraded";
-                            retryMergeLogMessage = "Retry complete -- updated partial review comment with merged results; Review Details published via degraded fallback comment";
+                            retryMergeLogMessage = commentIdToUpdate
+                              ? "Retry complete -- updated partial review comment with merged results; Review Details published via degraded fallback comment"
+                              : "Retry complete -- published final review comment with merged results; Review Details published via degraded fallback comment";
 
                             if (
                               canPublishReviewWorkOutput(
@@ -6167,7 +6183,7 @@ export function createReviewHandler(deps: {
                                   prNumber: pr.number,
                                   reviewOutputKey,
                                   body: buildReviewDetailsBody({
-                                    reviewFirstPass: mergedFirstPass,
+                                    reviewFirstPass: maxTurnsContinuationCompleted ? null : mergedFirstPass,
                                   }),
                                   botHandles: [githubApp.getAppSlug(), "claude"],
                                   recheckCanPublish: () =>
@@ -6348,7 +6364,7 @@ export function createReviewHandler(deps: {
           }
 
           let errorBody: string;
-          if (!publishedPartialReview) {
+          if (!publishedPartialReview && !deferredPublicOutputForContinuation) {
             if (exhaustedTurnBudget) {
               errorBody = [
                 "> **Kodiai ran out of steps while reviewing this PR**",

--- a/src/handlers/review.ts
+++ b/src/handlers/review.ts
@@ -1237,7 +1237,7 @@ type DiffCommandRunner = (args: string[], timeoutMs: number) => Promise<DiffComm
 type DiffFallbackFile = PullRequestFileMetadata;
 
 const DIFF_DEEPEN_STEPS = [50, 150, 300];
-const DIFF_COMMAND_TIMEOUT_MS = 15_000;
+const DIFF_COMMAND_TIMEOUT_MS = 30_000;
 const AUTHOR_PR_COUNT_SEARCH_CACHE_TTL_MS = 10 * 60 * 1000;
 
 async function hasMergeBase(workspaceDir: string, baseRef: string): Promise<boolean> {

--- a/src/jobs/aca-launcher.test.ts
+++ b/src/jobs/aca-launcher.test.ts
@@ -241,6 +241,64 @@ describe("launchAcaJob", () => {
       }
     }
   });
+
+  test("retries a transient managed identity HTTP failure before starting the job", async () => {
+    const originalFetch = globalThis.fetch;
+    const originalIdentityEndpoint = process.env["IDENTITY_ENDPOINT"];
+    const originalIdentityHeader = process.env["IDENTITY_HEADER"];
+    const originalSleep = Bun.sleep;
+
+    const calls: string[] = [];
+    const logger = makeLogger();
+
+    process.env["IDENTITY_ENDPOINT"] = "https://identity.example/token";
+    process.env["IDENTITY_HEADER"] = "identity-header";
+    Bun.sleep = (async () => undefined) as typeof Bun.sleep;
+
+    globalThis.fetch = (async (input) => {
+      const url = input instanceof Request ? input.url : String(input);
+      calls.push(url);
+      if (url.startsWith("https://identity.example/token")) {
+        if (calls.filter((call) => call.startsWith("https://identity.example/token")).length === 1) {
+          return jsonResponse({ error: "transient identity failure" }, 503);
+        }
+        return jsonResponse({ access_token: "test-access-token" });
+      }
+      return jsonResponse({ name: "caj-kodiai-agent-abc123" });
+    }) as typeof fetch;
+
+    try {
+      const result = await launchAcaJob({
+        resourceGroup: "rg-kodiai",
+        jobName: "caj-kodiai-agent",
+        spec: buildAcaJobSpec({
+          jobName: "caj-kodiai-agent",
+          image: "kodiairegistry.azurecr.io/kodiai-agent:latest",
+          workspaceDir: "/mnt/kodiai-workspaces/test-job",
+          mcpBearerToken: "test-token",
+          mcpBaseUrl: "http://ca-kodiai",
+        }),
+        logger: logger as unknown as Logger,
+      });
+
+      expect(result).toEqual({ executionName: "caj-kodiai-agent-abc123" });
+      expect(calls.filter((call) => call.startsWith("https://identity.example/token")).length).toBe(2);
+      expect(calls.some((call) => call.includes("/jobs/caj-kodiai-agent/start"))).toBe(true);
+    } finally {
+      globalThis.fetch = originalFetch;
+      Bun.sleep = originalSleep;
+      if (originalIdentityEndpoint === undefined) {
+        delete process.env["IDENTITY_ENDPOINT"];
+      } else {
+        process.env["IDENTITY_ENDPOINT"] = originalIdentityEndpoint;
+      }
+      if (originalIdentityHeader === undefined) {
+        delete process.env["IDENTITY_HEADER"];
+      } else {
+        process.env["IDENTITY_HEADER"] = originalIdentityHeader;
+      }
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/jobs/aca-launcher.test.ts
+++ b/src/jobs/aca-launcher.test.ts
@@ -9,6 +9,7 @@ import {
   readJobResult,
   cancelAcaJob,
   pollUntilComplete,
+  launchAcaJob,
 } from "./aca-launcher.ts";
 
 // ---------------------------------------------------------------------------
@@ -159,6 +160,86 @@ describe("buildAcaJobSpec", () => {
     // trigger the guard — the current implementation prevents this via the allowed
     // name set, so we confirm no standard call throws.
     expect(() => buildAcaJobSpec(BASE_OPTS)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// launchAcaJob
+// ---------------------------------------------------------------------------
+
+describe("launchAcaJob", () => {
+  function jsonResponse(body: unknown, status = 200) {
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "content-type": "application/json" },
+    });
+  }
+
+  function makeLogger() {
+    return {
+      debug: mock(() => undefined),
+      info: mock(() => undefined),
+      warn: mock(() => undefined),
+      error: mock(() => undefined),
+    } satisfies Pick<Logger, "debug" | "info" | "warn" | "error">;
+  }
+
+  test("retries a transient managed identity fetch failure before starting the job", async () => {
+    const originalFetch = globalThis.fetch;
+    const originalIdentityEndpoint = process.env["IDENTITY_ENDPOINT"];
+    const originalIdentityHeader = process.env["IDENTITY_HEADER"];
+    const originalSleep = Bun.sleep;
+
+    const calls: string[] = [];
+    const logger = makeLogger();
+
+    process.env["IDENTITY_ENDPOINT"] = "https://identity.example/token";
+    process.env["IDENTITY_HEADER"] = "identity-header";
+    Bun.sleep = (async () => undefined) as typeof Bun.sleep;
+
+    globalThis.fetch = (async (input) => {
+      const url = input instanceof Request ? input.url : String(input);
+      calls.push(url);
+      if (url.startsWith("https://identity.example/token")) {
+        if (calls.filter((call) => call.startsWith("https://identity.example/token")).length === 1) {
+          throw new Error("identity sidecar connection refused");
+        }
+        return jsonResponse({ access_token: "test-access-token" });
+      }
+      return jsonResponse({ name: "caj-kodiai-agent-abc123" });
+    }) as typeof fetch;
+
+    try {
+      const result = await launchAcaJob({
+        resourceGroup: "rg-kodiai",
+        jobName: "caj-kodiai-agent",
+        spec: buildAcaJobSpec({
+          jobName: "caj-kodiai-agent",
+          image: "kodiairegistry.azurecr.io/kodiai-agent:latest",
+          workspaceDir: "/mnt/kodiai-workspaces/test-job",
+          mcpBearerToken: "test-token",
+          mcpBaseUrl: "http://ca-kodiai",
+        }),
+        logger: logger as unknown as Logger,
+      });
+
+      expect(result).toEqual({ executionName: "caj-kodiai-agent-abc123" });
+      expect(calls.filter((call) => call.startsWith("https://identity.example/token")).length).toBe(2);
+      expect(calls.some((call) => call.includes("/jobs/caj-kodiai-agent/start"))).toBe(true);
+    } finally {
+      globalThis.fetch = originalFetch;
+      Bun.sleep = originalSleep;
+      if (originalIdentityEndpoint === undefined) {
+        delete process.env["IDENTITY_ENDPOINT"];
+      } else {
+        process.env["IDENTITY_ENDPOINT"] = originalIdentityEndpoint;
+      }
+      if (originalIdentityHeader === undefined) {
+        delete process.env["IDENTITY_HEADER"];
+      } else {
+        process.env["IDENTITY_HEADER"] = originalIdentityHeader;
+      }
+    }
   });
 });
 

--- a/src/jobs/aca-launcher.ts
+++ b/src/jobs/aca-launcher.ts
@@ -110,6 +110,23 @@ export function buildAcaJobSpec(opts: BuildAcaJobSpecOpts): AcaJobSpec {
 // Job dispatch
 // ---------------------------------------------------------------------------
 
+async function fetchManagedIdentityToken(url: string, identityHeader: string): Promise<Response> {
+  const maxAttempts = 3;
+  let lastErr: unknown;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await fetch(url, { headers: { "X-IDENTITY-HEADER": identityHeader } });
+    } catch (err) {
+      lastErr = err;
+      if (attempt === maxAttempts) break;
+      await Bun.sleep(100 * attempt);
+    }
+  }
+
+  throw lastErr instanceof Error ? lastErr : new Error(String(lastErr));
+}
+
 /**
  * Get an Azure management API access token.
  *
@@ -129,7 +146,7 @@ async function getAzureAccessToken(): Promise<{ token: string; subscriptionId: s
 
   if (identityEndpoint && identityHeader) {
     const url = `${identityEndpoint}?resource=https://management.azure.com/&api-version=2019-08-01&client_id=${clientId}`;
-    const resp = await fetch(url, { headers: { "X-IDENTITY-HEADER": identityHeader } });
+    const resp = await fetchManagedIdentityToken(url, identityHeader);
     const body = await resp.text();
     if (!resp.ok) {
       throw new Error(`getAzureAccessToken: MSI endpoint returned ${resp.status}: ${body.slice(0, 300)}`);

--- a/src/jobs/aca-launcher.ts
+++ b/src/jobs/aca-launcher.ts
@@ -116,12 +116,19 @@ async function fetchManagedIdentityToken(url: string, identityHeader: string): P
 
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
-      return await fetch(url, { headers: { "X-IDENTITY-HEADER": identityHeader } });
+      const response = await fetch(url, { headers: { "X-IDENTITY-HEADER": identityHeader } });
+      if (response.ok || response.status < 500 || response.status >= 600) {
+        return response;
+      }
+
+      const body = await response.text();
+      lastErr = new Error(`getAzureAccessToken: MSI endpoint returned ${response.status}: ${body.slice(0, 300)}`);
     } catch (err) {
       lastErr = err;
-      if (attempt === maxAttempts) break;
-      await Bun.sleep(100 * attempt);
     }
+
+    if (attempt === maxAttempts) break;
+    await Bun.sleep(100 * attempt);
   }
 
   throw lastErr instanceof Error ? lastErr : new Error(String(lastErr));

--- a/src/jobs/queue.test.ts
+++ b/src/jobs/queue.test.ts
@@ -28,11 +28,15 @@ test("createJobQueue passes structured run metadata to queued review callbacks",
   const releaseFirst = Promise.withResolvers<void>();
   let secondJobMetadata: JobQueueRunMetadata | undefined;
 
-  const firstJob = queue.enqueue(42, async () => {
-    firstStarted.resolve();
-    await releaseFirst.promise;
-    return "first";
-  });
+  const firstJob = queue.enqueue(
+    42,
+    async () => {
+      firstStarted.resolve();
+      await releaseFirst.promise;
+      return "first";
+    },
+    { lane: "review", key: "pr-42" },
+  );
 
   await firstStarted.promise;
 
@@ -96,6 +100,78 @@ test("createJobQueue lets interactive-review start while a review lane job is st
   await Promise.all([reviewJob, interactiveJob]);
 
   expect(interactiveStartedWhileReviewWasRunning).toBeTrue();
+});
+
+test("createJobQueue lets interactive-review jobs for different PR keys run concurrently", async () => {
+  const queue = createJobQueue(createNoopLogger());
+  const firstStarted = Promise.withResolvers<void>();
+  const releaseFirst = Promise.withResolvers<void>();
+  let secondStartedBeforeFirstRelease = false;
+
+  const firstJob = queue.enqueue(
+    42,
+    async () => {
+      firstStarted.resolve();
+      await releaseFirst.promise;
+      return "first";
+    },
+    { lane: "interactive-review", key: "acme/repo#1" },
+  );
+
+  await firstStarted.promise;
+
+  const secondJob = queue.enqueue(
+    42,
+    async () => {
+      secondStartedBeforeFirstRelease = true;
+      return "second";
+    },
+    { lane: "interactive-review", key: "acme/repo#2" },
+  );
+
+  await Bun.sleep(20);
+  const secondStartedWhileFirstWasRunning = secondStartedBeforeFirstRelease;
+  releaseFirst.resolve();
+
+  await Promise.all([firstJob, secondJob]);
+
+  expect(secondStartedWhileFirstWasRunning).toBeTrue();
+});
+
+test("createJobQueue still serializes interactive-review jobs for the same PR key", async () => {
+  const queue = createJobQueue(createNoopLogger());
+  const firstStarted = Promise.withResolvers<void>();
+  const releaseFirst = Promise.withResolvers<void>();
+  let secondStartedBeforeFirstRelease = false;
+
+  const firstJob = queue.enqueue(
+    42,
+    async () => {
+      firstStarted.resolve();
+      await releaseFirst.promise;
+      return "first";
+    },
+    { lane: "interactive-review", key: "acme/repo#1" },
+  );
+
+  await firstStarted.promise;
+
+  const secondJob = queue.enqueue(
+    42,
+    async () => {
+      secondStartedBeforeFirstRelease = true;
+      return "second";
+    },
+    { lane: "interactive-review", key: "acme/repo#1" },
+  );
+
+  await Bun.sleep(20);
+  const secondStartedWhileFirstWasRunning = secondStartedBeforeFirstRelease;
+  releaseFirst.resolve();
+
+  await Promise.all([firstJob, secondJob]);
+
+  expect(secondStartedWhileFirstWasRunning).toBeFalse();
 });
 
 test("createJobQueue updates active job snapshots when setPhase is called", async () => {

--- a/src/jobs/queue.ts
+++ b/src/jobs/queue.ts
@@ -12,7 +12,7 @@ const DEFAULT_JOB_LANE: JobLane = "review";
 const QUEUED_PHASE = "queued";
 const RUNNING_PHASE = "running";
 
-type InstallationLaneQueues = Map<JobLane, PQueue>;
+type InstallationQueueScopes = Map<string, PQueue>;
 type InstallationActiveJobs = Map<string, JobSnapshot>;
 
 /**
@@ -24,28 +24,33 @@ type InstallationActiveJobs = Map<string, JobSnapshot>;
  * through completion so callers can inspect machine-readable queue state.
  */
 export function createJobQueue(logger: Logger): JobQueue {
-  const laneQueues = new Map<number, InstallationLaneQueues>();
+  const queueScopes = new Map<number, InstallationQueueScopes>();
   const activeJobs = new Map<number, InstallationActiveJobs>();
   let nextJobId = 1;
 
-  function getOrCreateInstallationQueues(installationId: number): InstallationLaneQueues {
-    let queues = laneQueues.get(installationId);
+  function getQueueScopeKey(lane: JobLane, key: string): string {
+    return `${lane}::${key}`;
+  }
+
+  function getOrCreateInstallationQueues(installationId: number): InstallationQueueScopes {
+    let queues = queueScopes.get(installationId);
     if (!queues) {
-      queues = new Map<JobLane, PQueue>();
-      laneQueues.set(installationId, queues);
+      queues = new Map<string, PQueue>();
+      queueScopes.set(installationId, queues);
     }
     return queues;
   }
 
-  function getOrCreateQueue(installationId: number, lane: JobLane): PQueue {
+  function getOrCreateQueue(installationId: number, lane: JobLane, key: string): PQueue {
     const queues = getOrCreateInstallationQueues(installationId);
-    let queue = queues.get(lane);
+    const queueScopeKey = getQueueScopeKey(lane, key);
+    let queue = queues.get(queueScopeKey);
     if (!queue) {
       queue = new PQueue({ concurrency: 1 });
-      queues.set(lane, queue);
+      queues.set(queueScopeKey, queue);
       logger.debug(
-        { installationId, lane },
-        "Created new job queue lane for installation",
+        { installationId, lane, key, queueScopeKey },
+        "Created new job queue scope for installation",
       );
     }
     return queue;
@@ -64,7 +69,7 @@ export function createJobQueue(logger: Logger): JobQueue {
     installationId: number,
     selector: (queue: PQueue) => number,
   ): number {
-    const queues = laneQueues.get(installationId);
+    const queues = queueScopes.get(installationId);
     if (!queues) {
       return 0;
     }
@@ -76,23 +81,24 @@ export function createJobQueue(logger: Logger): JobQueue {
     return total;
   }
 
-  function pruneLaneQueue(installationId: number, lane: JobLane): void {
-    const queues = laneQueues.get(installationId);
-    const queue = queues?.get(lane);
+  function pruneQueueScope(installationId: number, lane: JobLane, key: string): void {
+    const queues = queueScopes.get(installationId);
+    const queueScopeKey = getQueueScopeKey(lane, key);
+    const queue = queues?.get(queueScopeKey);
     if (!queues || !queue) {
       return;
     }
 
     if (queue.size === 0 && queue.pending === 0) {
-      queues.delete(lane);
+      queues.delete(queueScopeKey);
       logger.debug(
-        { installationId, lane },
-        "Pruned idle job queue lane for installation",
+        { installationId, lane, key, queueScopeKey },
+        "Pruned idle job queue scope for installation",
       );
     }
 
     if (queues.size === 0) {
-      laneQueues.delete(installationId);
+      queueScopes.delete(installationId);
     }
   }
 
@@ -137,9 +143,9 @@ export function createJobQueue(logger: Logger): JobQueue {
       context?: JobQueueContext,
     ): Promise<T> {
       const lane = context?.lane ?? DEFAULT_JOB_LANE;
-      const queue = getOrCreateQueue(installationId, lane);
       const jobId = `${installationId}-${nextJobId++}`;
       const key = context?.key ?? jobId;
+      const queue = getOrCreateQueue(installationId, lane, key);
       const queuedAtMs = Date.now();
       const snapshot = createSnapshot(
         installationId,
@@ -267,7 +273,7 @@ export function createJobQueue(logger: Logger): JobQueue {
         });
       } finally {
         deleteActiveJob(installationId, jobId);
-        pruneLaneQueue(installationId, lane);
+        pruneQueueScope(installationId, lane, key);
       }
     },
 

--- a/src/jobs/workspace.test.ts
+++ b/src/jobs/workspace.test.ts
@@ -10,6 +10,7 @@ import {
   buildAuthFetchUrl,
   createWorkspaceManager,
   fetchRemoteTrackingBranch,
+  fetchAndCheckoutPullRequestHeadRef,
 } from "./workspace.ts";
 import type { GitHubApp } from "../auth/github-app.ts";
 
@@ -212,6 +213,46 @@ async function setupBareAndClone(bareDir: string, cloneDir: string): Promise<str
     await rm(srcDir, { recursive: true, force: true });
   }
 }
+
+describe("fetchAndCheckoutPullRequestHeadRef", () => {
+  test("falls back to the PR head repository ref when the base pull ref is missing", async () => {
+    const tmpBase = await mkdtemp(join(tmpdir(), "kodiai-workspace-test-"));
+    const baseBareDir = join(tmpBase, "base.git");
+    const headBareDir = join(tmpBase, "head.git");
+    const cloneDir = join(tmpBase, "clone");
+
+    try {
+      await setupBareAndClone(baseBareDir, cloneDir);
+      await $`git init --bare ${headBareDir}`.quiet();
+
+      const headWorkDir = join(tmpBase, "head-work");
+      await $`git clone file://${baseBareDir} ${headWorkDir}`.quiet();
+      await $`git -C ${headWorkDir} checkout -B feature`.quiet();
+      await $`git -C ${headWorkDir} config user.email "test@example.com"`.quiet();
+      await $`git -C ${headWorkDir} config user.name "Test"`.quiet();
+      await writeFile(join(headWorkDir, "README.md"), "fallback head ref\n");
+      await $`git -C ${headWorkDir} add README.md`.quiet();
+      await $`git -C ${headWorkDir} commit -m "feature"`.quiet();
+      const featureSha = (await $`git -C ${headWorkDir} rev-parse HEAD`.quiet()).text().trim();
+      await $`git -C ${headWorkDir} remote add head file://${headBareDir}`.quiet();
+      await $`git -C ${headWorkDir} push head feature:feature`.quiet();
+
+      const result = await fetchAndCheckoutPullRequestHeadRef({
+        dir: cloneDir,
+        prNumber: 28271,
+        localBranch: "pr-review",
+        fallbackRemoteUrl: `file://${headBareDir}`,
+        fallbackRef: "feature",
+      });
+
+      expect(result).toEqual({ localBranch: "pr-review", source: "head-ref-fallback" });
+      const checkedOutSha = (await $`git -C ${cloneDir} rev-parse HEAD`.quiet()).text().trim();
+      expect(checkedOutSha).toBe(featureSha);
+    } finally {
+      await rm(tmpBase, { recursive: true, force: true });
+    }
+  });
+});
 
 // ---------------------------------------------------------------------------
 // buildAuthFetchUrl tests

--- a/src/jobs/workspace.test.ts
+++ b/src/jobs/workspace.test.ts
@@ -236,12 +236,14 @@ describe("fetchAndCheckoutPullRequestHeadRef", () => {
       const featureSha = (await $`git -C ${headWorkDir} rev-parse HEAD`.quiet()).text().trim();
       await $`git -C ${headWorkDir} remote add head file://${headBareDir}`.quiet();
       await $`git -C ${headWorkDir} push head feature:feature`.quiet();
+      await $`git -C ${cloneDir} config url.file://${headBareDir}.insteadOf https://x-access-token:test-token@github.com/acme/head.git`.quiet();
 
       const result = await fetchAndCheckoutPullRequestHeadRef({
         dir: cloneDir,
         prNumber: 28271,
         localBranch: "pr-review",
-        fallbackRemoteUrl: `file://${headBareDir}`,
+        token: "test-token",
+        fallbackRemoteUrl: "https://github.com/acme/head.git",
         fallbackRef: "feature",
       });
 

--- a/src/jobs/workspace.ts
+++ b/src/jobs/workspace.ts
@@ -560,24 +560,41 @@ export async function fetchAndCheckoutPullRequestHeadRef(options: {
   remote?: string;
   localBranch?: string;
   token?: string;
-}): Promise<{ localBranch: string }> {
-  const { dir, prNumber, remote = "origin", localBranch = "pr-review", token } = options;
+  fallbackRemoteUrl?: string;
+  fallbackRef?: string;
+}): Promise<{ localBranch: string; source: "pull-ref" | "head-ref-fallback" }> {
+  const { dir, prNumber, remote = "origin", localBranch = "pr-review", token, fallbackRemoteUrl, fallbackRef } = options;
 
   validatePullRequestNumber(prNumber);
   validateBranchName(localBranch);
+  if (fallbackRef) validateBranchName(fallbackRef);
 
   try {
     // Construct the auth URL inline; never stored — used for this fetch only.
     const strippedUrl = (await $`git -C ${dir} remote get-url ${remote}`.quiet()).text().trim();
     const fetchUrl = makeAuthUrl(strippedUrl, token);
-    await $`git -C ${dir} fetch ${fetchUrl} pull/${prNumber}/head:${localBranch}`.quiet();
+    const primaryFetch = await $`git -C ${dir} fetch ${fetchUrl} pull/${prNumber}/head:${localBranch}`.quiet().nothrow();
+    if (primaryFetch.exitCode === 0) {
+      await $`git -C ${dir} checkout ${localBranch}`.quiet();
+      return { localBranch, source: "pull-ref" };
+    }
+
+    const stderr = primaryFetch.stderr.toString();
+    const missingPullRef = stderr.includes(`couldn't find remote ref pull/${prNumber}/head`)
+      || stderr.includes(`couldn't find remote ref refs/pull/${prNumber}/head`);
+    if (!missingPullRef || !fallbackRemoteUrl || !fallbackRef) {
+      const err = new Error(`git fetch pull/${prNumber}/head failed: ${stderr.trim()}`);
+      redactTokenFromError(err, token);
+      throw err;
+    }
+
+    await $`git -C ${dir} fetch ${fallbackRemoteUrl} ${fallbackRef}:${localBranch}`.quiet();
     await $`git -C ${dir} checkout ${localBranch}`.quiet();
+    return { localBranch, source: "head-ref-fallback" };
   } catch (err) {
     redactTokenFromError(err, token);
     throw err;
   }
-
-  return { localBranch };
 }
 
 const STALE_THRESHOLD_MS = 60 * 60 * 1000; // 1 hour

--- a/src/jobs/workspace.ts
+++ b/src/jobs/workspace.ts
@@ -588,7 +588,8 @@ export async function fetchAndCheckoutPullRequestHeadRef(options: {
       throw err;
     }
 
-    await $`git -C ${dir} fetch ${fallbackRemoteUrl} ${fallbackRef}:${localBranch}`.quiet();
+    const fallbackFetchUrl = makeAuthUrl(fallbackRemoteUrl, token);
+    await $`git -C ${dir} fetch ${fallbackFetchUrl} ${fallbackRef}:${localBranch}`.quiet();
     await $`git -C ${dir} checkout ${localBranch}`.quiet();
     return { localBranch, source: "head-ref-fallback" };
   } catch (err) {

--- a/src/knowledge/wiki-sync.test.ts
+++ b/src/knowledge/wiki-sync.test.ts
@@ -141,6 +141,43 @@ describe("createWikiSyncScheduler", () => {
     expect(store.updateSyncState).toHaveBeenCalled();
   });
 
+  test("skips malformed successful parse payloads without treating them as updated pages", async () => {
+    const store = createMockStore();
+    const logger = createMockLogger();
+
+    const fetchFn = mockFetch(async (url: string) => {
+      if (url.includes("list=recentchanges")) {
+        return new Response(JSON.stringify(buildRCResponse([
+          { pageid: 0, title: "BadPage", revid: 200 },
+        ])));
+      }
+      if (url.includes("action=parse")) {
+        return new Response(JSON.stringify({ error: { code: "missingtitle", info: "Bad title" } }));
+      }
+      return new Response("", { status: 404 });
+    }) as typeof globalThis.fetch;
+
+    const scheduler = createWikiSyncScheduler({
+      store,
+      embeddingProvider: createMockEmbeddingProvider(),
+      source: "kodi.wiki",
+      delayMs: 0,
+      logger,
+      fetchFn,
+    });
+
+    const result = await scheduler.syncNow();
+
+    expect(result.pagesChecked).toBe(1);
+    expect(result.pagesUpdated).toBe(0);
+    expect(result.pagesDeleted).toBe(0);
+    expect(store.replacePageChunks).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ pageId: 0, reason: "malformed-parse-response" }),
+      "Wiki sync parse response malformed, skipping page",
+    );
+  });
+
   test("soft-deletes pages that become redirects", async () => {
     const store = createMockStore();
     // Page existed before (has a revision)

--- a/src/knowledge/wiki-sync.ts
+++ b/src/knowledge/wiki-sync.ts
@@ -46,13 +46,17 @@ type RecentChangesResponse = {
 };
 
 type ParseResponse = {
-  parse: {
-    title: string;
-    pageid: number;
-    revid: number;
-    text: {
-      "*": string;
+  parse?: {
+    title?: string;
+    pageid?: number;
+    revid?: number;
+    text?: {
+      "*"?: string;
     };
+  };
+  error?: {
+    code?: string;
+    info?: string;
   };
 };
 
@@ -186,6 +190,24 @@ async function runSync(opts: {
           parseData = (await parseResponse.json()) as ParseResponse;
         } catch (err) {
           logger.warn({ pageId: change.pageid, err }, "Wiki sync parse network error, skipping page");
+          await sleep(delayMs);
+          continue;
+        }
+
+        if (
+          typeof parseData.parse?.title !== "string"
+          || typeof parseData.parse?.revid !== "number"
+          || typeof parseData.parse?.text?.["*"] !== "string"
+        ) {
+          logger.warn(
+            {
+              pageId: change.pageid,
+              reason: "malformed-parse-response",
+              errorCode: parseData.error?.code,
+              errorInfo: parseData.error?.info,
+            },
+            "Wiki sync parse response malformed, skipping page",
+          );
           await sleep(delayMs);
           continue;
         }

--- a/src/lib/partial-review-formatter.ts
+++ b/src/lib/partial-review-formatter.ts
@@ -39,6 +39,37 @@ export function formatContinuationRevisionSummary(params: {
   return `Continuation revisions: ${formatFindingCount(counts.new, "new finding")}, ${formatFindingCount(counts.stillOpen, "still-open finding")}, and ${formatFindingCount(counts.resolved, "resolved or revised finding")}.`;
 }
 
+export function formatCompletedContinuationReviewComment(params: {
+  summaryDraft: string;
+  reviewOutputKey?: string;
+  totalFiles: number;
+  continuationRevisionCounts?: ContinuationRevisionCounts | null;
+}): string {
+  const lines: string[] = [];
+
+  lines.push(`> **Review complete** -- initial review reached the turn limit, then Kodiai automatically completed the remaining scope before publishing this summary.`);
+  lines.push("> ");
+  lines.push(`> Coverage: ${params.totalFiles} of ${params.totalFiles} changed files reviewed.`);
+
+  const continuationRevisionSummary = params.continuationRevisionCounts
+    ? formatContinuationRevisionSummary({ counts: params.continuationRevisionCounts })
+    : null;
+  if (continuationRevisionSummary) {
+    lines.push("> ");
+    lines.push(`> ${continuationRevisionSummary}`);
+  }
+
+  lines.push("");
+  lines.push(params.summaryDraft);
+
+  if (params.reviewOutputKey) {
+    lines.push("");
+    lines.push(buildReviewOutputMarker(params.reviewOutputKey));
+  }
+
+  return lines.join("\n");
+}
+
 export function formatPartialReviewComment(params: PartialReviewParams): string {
   const {
     summaryDraft,

--- a/src/lib/review-routing.test.ts
+++ b/src/lib/review-routing.test.ts
@@ -7,7 +7,6 @@ import {
   resolveReviewTaskRouting,
   resolveReviewMaxTurnsOverride,
   SEMANTIC_FANOUT_REVIEW_MAX_TURNS,
-  SMALL_DIFF_MAX_TURNS,
   HIGH_RISK_REVIEW_MAX_TURNS,
   MEDIUM_RISK_REVIEW_MAX_TURNS,
 } from "./review-routing.ts";
@@ -47,11 +46,10 @@ describe("review-routing", () => {
     })).toBe(false);
   });
 
-  test("resolves tiny diffs to review.small-diff with an eight-turn override", () => {
+  test("resolves tiny diffs to review.small-diff without lowering the repo turn budget", () => {
     expect(resolveReviewTaskRouting({ changedFileCount: 1, linesChanged: 2 })).toEqual({
       taskType: TASK_TYPES.REVIEW_SMALL_DIFF,
       routingReason: "tiny-diff",
-      maxTurnsOverride: SMALL_DIFF_MAX_TURNS,
     });
   });
 
@@ -62,13 +60,12 @@ describe("review-routing", () => {
     });
   });
 
-  test("keeps small-diff turn override ahead of risk scaling", () => {
+  test("does not apply risk scaling to small-diff reviews without an explicit routing override", () => {
     expect(resolveReviewMaxTurnsOverride({
       taskType: TASK_TYPES.REVIEW_SMALL_DIFF,
-      routingMaxTurnsOverride: SMALL_DIFF_MAX_TURNS,
       timeoutRiskLevel: "high",
       baseMaxTurns: 25,
-    })).toBe(SMALL_DIFF_MAX_TURNS);
+    })).toBeUndefined();
   });
 
   test("raises standard full-review turn budget for medium and high timeout risk", () => {

--- a/src/lib/review-routing.ts
+++ b/src/lib/review-routing.ts
@@ -2,7 +2,6 @@ import { TASK_TYPES } from "../llm/task-types.ts";
 
 export const SMALL_DIFF_MAX_FILES = 2;
 export const SMALL_DIFF_MAX_LINES = 20;
-export const SMALL_DIFF_MAX_TURNS = 8;
 export const MEDIUM_RISK_REVIEW_MAX_TURNS = 50;
 export const HIGH_RISK_REVIEW_MAX_TURNS = 75;
 export const SEMANTIC_FANOUT_REVIEW_MAX_TURNS = MEDIUM_RISK_REVIEW_MAX_TURNS;
@@ -65,7 +64,6 @@ export function resolveReviewTaskRouting(params: {
     return {
       taskType: TASK_TYPES.REVIEW_SMALL_DIFF,
       routingReason: "tiny-diff",
-      maxTurnsOverride: SMALL_DIFF_MAX_TURNS,
     };
   }
 

--- a/src/routes/health.test.ts
+++ b/src/routes/health.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, mock, test } from "bun:test";
+import { createHealthRoutes } from "./health.ts";
+import type { GitHubApp } from "../auth/github-app.ts";
+import type { Sql } from "../db/client.ts";
+import type { Logger } from "pino";
+
+function createMockLogger(): Logger {
+  return {
+    debug: mock(() => undefined),
+    info: mock(() => undefined),
+    warn: mock(() => undefined),
+    error: mock(() => undefined),
+    child: mock(() => createMockLogger()),
+  } as unknown as Logger;
+}
+
+describe("createHealthRoutes", () => {
+  test("/healthz is process-only and does not wait on PostgreSQL or GitHub", async () => {
+    const sql = mock(async () => {
+      throw new Error("db should not be called by liveness");
+    }) as unknown as Sql;
+    const githubApp = {
+      checkConnectivity: mock(async () => {
+        throw new Error("github should not be called by liveness");
+      }),
+    } as unknown as GitHubApp;
+
+    const app = createHealthRoutes({ sql, githubApp, logger: createMockLogger() });
+    const response = await app.request("/healthz");
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ status: "ok" });
+    expect(sql).not.toHaveBeenCalled();
+    expect((githubApp.checkConnectivity as ReturnType<typeof mock>)).not.toHaveBeenCalled();
+  });
+});

--- a/src/routes/health.test.ts
+++ b/src/routes/health.test.ts
@@ -33,4 +33,53 @@ describe("createHealthRoutes", () => {
     expect(sql).not.toHaveBeenCalled();
     expect((githubApp.checkConnectivity as ReturnType<typeof mock>)).not.toHaveBeenCalled();
   });
+
+  test("/readiness stays ready when GitHub connectivity is transiently unavailable", async () => {
+    const logger = createMockLogger();
+    const sql = mock(async () => []) as unknown as Sql;
+    const githubApp = {
+      checkConnectivity: mock(async () => false),
+    } as unknown as GitHubApp;
+
+    const app = createHealthRoutes({ sql, githubApp, logger });
+    const response = await app.request("/readiness");
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      status: "ready",
+      github: "degraded",
+      reason: "GitHub API unreachable",
+    });
+    expect(logger.warn).toHaveBeenCalledWith(
+      { githubConnectivity: "degraded" },
+      "Readiness dependency degraded: GitHub API unreachable",
+    );
+  });
+
+  test("/readiness has a bounded GitHub connectivity check", async () => {
+    const logger = createMockLogger();
+    const sql = mock(async () => []) as unknown as Sql;
+    const githubApp = {
+      checkConnectivity: mock(() => new Promise<boolean>(() => undefined)),
+    } as unknown as GitHubApp;
+
+    const app = createHealthRoutes({
+      sql,
+      githubApp,
+      logger,
+      readinessDependencyTimeoutMs: 1,
+    });
+    const response = await app.request("/readiness");
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      status: "ready",
+      github: "degraded",
+      reason: "GitHub API connectivity check timed out",
+    });
+    expect(logger.warn).toHaveBeenCalledWith(
+      { githubConnectivity: "timeout", timeoutMs: 1 },
+      "Readiness dependency degraded: GitHub API connectivity check timed out",
+    );
+  });
 });

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -7,10 +7,36 @@ interface HealthRouteDeps {
   githubApp: GitHubApp;
   logger: Logger;
   sql: Sql;
+  readinessDependencyTimeoutMs?: number;
+}
+
+type GitHubConnectivityResult =
+  | { kind: "connected" }
+  | { kind: "unreachable" }
+  | { kind: "timeout" }
+  | { kind: "error"; err: unknown };
+
+async function checkGitHubConnectivityWithTimeout(
+  githubApp: GitHubApp,
+  timeoutMs: number,
+): Promise<GitHubConnectivityResult> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      githubApp.checkConnectivity()
+        .then((connected) => connected ? { kind: "connected" as const } : { kind: "unreachable" as const })
+        .catch((err) => ({ kind: "error" as const, err })),
+      new Promise<GitHubConnectivityResult>((resolve) => {
+        timeout = setTimeout(() => resolve({ kind: "timeout" }), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
 }
 
 export function createHealthRoutes(deps: HealthRouteDeps): Hono {
-  const { githubApp, logger } = deps;
+  const { githubApp, logger, readinessDependencyTimeoutMs = 1_000 } = deps;
   const app = new Hono();
 
   // Liveness probe: process-only. Dependency checks belong in readiness/deep health
@@ -20,18 +46,49 @@ export function createHealthRoutes(deps: HealthRouteDeps): Hono {
   // Backward-compatible alias for /healthz during deploy transition.
   app.get("/health", (c) => c.json({ status: "ok" }));
 
-  // Readiness probe: checks GitHub API connectivity
+  // Readiness probe: process is ready to receive traffic. External dependency
+  // checks are bounded and fail open as degraded so transient GitHub latency does
+  // not remove healthy replicas from service.
   app.get("/readiness", async (c) => {
-    const connected = await githubApp.checkConnectivity();
-    if (connected) {
-      return c.json({ status: "ready" });
-    }
-
-    logger.warn("Readiness check failed: GitHub API unreachable");
-    return c.json(
-      { status: "not ready", reason: "GitHub API unreachable" },
-      503,
+    const githubConnectivity = await checkGitHubConnectivityWithTimeout(
+      githubApp,
+      readinessDependencyTimeoutMs,
     );
+
+    switch (githubConnectivity.kind) {
+      case "connected":
+        return c.json({ status: "ready" });
+      case "unreachable":
+        logger.warn(
+          { githubConnectivity: "degraded" },
+          "Readiness dependency degraded: GitHub API unreachable",
+        );
+        return c.json({
+          status: "ready",
+          github: "degraded",
+          reason: "GitHub API unreachable",
+        });
+      case "timeout":
+        logger.warn(
+          { githubConnectivity: "timeout", timeoutMs: readinessDependencyTimeoutMs },
+          "Readiness dependency degraded: GitHub API connectivity check timed out",
+        );
+        return c.json({
+          status: "ready",
+          github: "degraded",
+          reason: "GitHub API connectivity check timed out",
+        });
+      case "error":
+        logger.warn(
+          { err: githubConnectivity.err, githubConnectivity: "error" },
+          "Readiness dependency degraded: GitHub API connectivity check failed",
+        );
+        return c.json({
+          status: "ready",
+          github: "degraded",
+          reason: "GitHub API connectivity check failed",
+        });
+    }
   });
 
   return app;

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -10,30 +10,15 @@ interface HealthRouteDeps {
 }
 
 export function createHealthRoutes(deps: HealthRouteDeps): Hono {
-  const { githubApp, logger, sql } = deps;
+  const { githubApp, logger } = deps;
   const app = new Hono();
 
-  // Liveness probe: checks process is up AND PostgreSQL connection pool is healthy
-  app.get("/healthz", async (c) => {
-    try {
-      await sql`SELECT 1`;
-      return c.json({ status: "ok", db: "connected" });
-    } catch (err) {
-      logger.warn({ err }, "Health check failed: PostgreSQL unreachable");
-      return c.json({ status: "unhealthy", db: "unreachable" }, 503);
-    }
-  });
+  // Liveness probe: process-only. Dependency checks belong in readiness/deep health
+  // so transient PostgreSQL or GitHub latency does not make ACA restart a healthy process.
+  app.get("/healthz", (c) => c.json({ status: "ok" }));
 
-  // Backward-compatible alias for /healthz during deploy transition
-  app.get("/health", async (c) => {
-    try {
-      await sql`SELECT 1`;
-      return c.json({ status: "ok", db: "connected" });
-    } catch (err) {
-      logger.warn({ err }, "Health check failed: PostgreSQL unreachable");
-      return c.json({ status: "unhealthy", db: "unreachable" }, 503);
-    }
-  });
+  // Backward-compatible alias for /healthz during deploy transition.
+  app.get("/health", (c) => c.json({ status: "ok" }));
 
   // Readiness probe: checks GitHub API connectivity
   app.get("/readiness", async (c) => {


### PR DESCRIPTION
## Summary
- make health liveness process-only and readiness fail-open with bounded GitHub dependency sampling
- remove the small-diff 8-turn cap and reduce zero-evidence retry settlement noise
- add fork PR head-ref fallback, MSI token retry, wiki parse guards, and a longer diff recovery timeout

## Verification
- `bun test ./src/routes/health.test.ts ./src/lib/review-routing.test.ts ./src/handlers/review.test.ts ./src/jobs/aca-launcher.test.ts ./src/jobs/workspace.test.ts ./src/knowledge/wiki-sync.test.ts --timeout 30000` — 234 pass / 0 fail
- `bun run tsc --noEmit` — exit 0
