### PR TITLE
Harden review diff fallback and checkpoints

### DIFF
--- a/src/execution/executor.ts
+++ b/src/execution/executor.ts
@@ -479,6 +479,7 @@ export function createExecutor(deps: {
           knowledgeStore: context.knowledgeStore,
           totalFiles: context.totalFiles,
           enableCheckpointTool: context.enableCheckpointTool,
+          prDiffForCommentValidation: context.prDiffForCommentValidation,
           enableIssueTools,
           triageConfig,
         };

--- a/src/execution/mcp/checkpoint-server.test.ts
+++ b/src/execution/mcp/checkpoint-server.test.ts
@@ -106,7 +106,7 @@ describe("createCheckpointServer", () => {
     });
   });
 
-  test("rejects checkpoints where fully reviewed files are missing from inspected files", async () => {
+  test("normalizes inspected files to include fully reviewed files", async () => {
     const calls: unknown[] = [];
     const warnings: unknown[] = [];
     const knowledgeStore = {
@@ -135,13 +135,20 @@ describe("createCheckpointServer", () => {
       summaryDraft: "Partially inconsistent checkpoint",
     });
 
-    expect(result.isError).toBe(true);
-    expect(calls).toHaveLength(0);
-    expect(JSON.parse(result.content[0]!.text)).toMatchObject({
-      saved: false,
-      reason: "filesInspected must include every filesReviewed path",
+    expect(result.isError).toBeUndefined();
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      filesReviewed: ["src/a.ts", "src/b.ts"],
+      filesInspected: ["src/a.ts", "src/b.ts"],
+      findingCount: 1,
+      totalFiles: 12,
     });
-    expect(warnings).toHaveLength(1);
+    expect(JSON.parse(result.content[0]!.text)).toMatchObject({
+      saved: true,
+      filesReviewed: 2,
+      totalFiles: 12,
+    });
+    expect(warnings).toHaveLength(0);
   });
 
   test("waits for checkpoint persistence before reporting success", async () => {

--- a/src/execution/mcp/checkpoint-server.ts
+++ b/src/execution/mcp/checkpoint-server.ts
@@ -37,28 +37,9 @@ export function createCheckpointServer(
         },
         async ({ filesReviewed, filesInspected, findingCount, summaryDraft }) => {
           try {
-            if (filesInspected !== undefined) {
-              const inspectedSet = new Set(filesInspected);
-              const missingReviewedFiles = filesReviewed.filter((filePath) => !inspectedSet.has(filePath));
-              if (missingReviewedFiles.length > 0) {
-                logger?.warn(
-                  { reviewOutputKey, repo, prNumber, missingReviewedFiles },
-                  "Invalid review checkpoint: filesInspected missing reviewed files",
-                );
-                return {
-                  content: [
-                    {
-                      type: "text" as const,
-                      text: JSON.stringify({
-                        saved: false,
-                        reason: "filesInspected must include every filesReviewed path",
-                      }),
-                    },
-                  ],
-                  isError: true,
-                };
-              }
-            }
+            const normalizedFilesInspected = filesInspected === undefined
+              ? undefined
+              : Array.from(new Set([...filesInspected, ...filesReviewed]));
 
             if (!knowledgeStore.saveCheckpoint) {
               logger?.warn(
@@ -83,13 +64,13 @@ export function createCheckpointServer(
               repo,
               prNumber,
               filesReviewed,
-              filesInspected,
+              filesInspected: normalizedFilesInspected,
               findingCount,
               summaryDraft,
               totalFiles,
             });
 
-            logger?.debug(
+            logger?.debug?.(
               {
                 reviewOutputKey,
                 repo,

--- a/src/execution/mcp/index.ts
+++ b/src/execution/mcp/index.ts
@@ -43,6 +43,7 @@ export function buildMcpServers(deps: {
   knowledgeStore?: KnowledgeStore;
   totalFiles?: number;
   enableCheckpointTool?: boolean;
+  prDiffForCommentValidation?: string;
   enableIssueTools?: boolean;
   triageConfig?: TriageConfig;
 }): Record<string, McpServerConfig> {
@@ -97,6 +98,7 @@ export function buildMcpServers(deps: {
       deps.logger,
       deps.onPublish,
       reviewOutputPublicationGate,
+      deps.prDiffForCommentValidation,
     );
     servers.github_ci = createCIStatusServer(
       deps.getOctokit,
@@ -256,6 +258,7 @@ export function buildMcpServerFactories(deps: Parameters<typeof buildMcpServers>
         deps.logger,
         deps.onPublish,
         reviewOutputPublicationGate,
+        deps.prDiffForCommentValidation,
       ) as McpSdkServerConfigWithInstance;
 
     factories.github_ci = () =>

--- a/src/execution/mcp/inline-review-server.test.ts
+++ b/src/execution/mcp/inline-review-server.test.ts
@@ -211,6 +211,73 @@ describe("createInlineReviewServer validation diagnostics", () => {
     });
   });
 
+  test("rejects RIGHT-side lines that are not commentable in the PR diff before calling GitHub", async () => {
+    let createReviewCommentCalls = 0;
+    const octokit = {
+      rest: {
+        pulls: {
+          listReviewComments: async () => ({ data: [] }),
+          listReviews: async () => ({ data: [] }),
+          get: async () => ({ data: { head: { sha: "abcdef1234" } } }),
+          createReviewComment: async () => {
+            createReviewCommentCalls++;
+            return { data: { id: 1, html_url: "https://example.test/comment", path: "src/file.ts", line: 10 } };
+          },
+        },
+        issues: { listComments: async () => ({ data: [] }) },
+      },
+    };
+    const prDiffForCommentValidation = [
+      "diff --git a/src/file.ts b/src/file.ts",
+      "--- a/src/file.ts",
+      "+++ b/src/file.ts",
+      "@@ -700,18 +789,12 @@ void f()",
+      " context",
+      "+added",
+      " context",
+    ].join("\n");
+
+    const { logger, warnCalls } = createMockLogger();
+    const server = createInlineReviewServer(
+      async () => octokit as never,
+      "acme",
+      "repo",
+      101,
+      [],
+      "review-key",
+      "delivery-123",
+      logger as never,
+      undefined,
+      undefined,
+      prDiffForCommentValidation,
+    );
+    const handler = getToolHandler(server);
+
+    const result = await handler({
+      path: "src/file.ts",
+      body: "line comment",
+      line: 810,
+      side: "RIGHT",
+    });
+
+    expect(createReviewCommentCalls).toBe(0);
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain("src/file.ts");
+    expect(result.content[0]?.text).toContain("RIGHT line 810 is not commentable");
+    expect(warnCalls).toHaveLength(1);
+    expect(warnCalls[0]?.[0]).toMatchObject({
+      deliveryId: "delivery-123",
+      reviewOutputKey: "review-key",
+      owner: "acme",
+      repo: "repo",
+      prNumber: 101,
+      path: "src/file.ts",
+      line: 810,
+      side: "RIGHT",
+      reason: "line-not-commentable-in-pr-diff",
+    });
+  });
+
   test("returns and logs structured GitHub validation details", async () => {
     const githubError = Object.assign(new Error("Validation Failed"), {
       status: 422,

--- a/src/execution/mcp/inline-review-server.ts
+++ b/src/execution/mcp/inline-review-server.ts
@@ -4,6 +4,7 @@ import type { Octokit } from "@octokit/rest";
 import type { Logger } from "pino";
 import { buildReviewOutputMarker } from "../../handlers/review-idempotency.ts";
 import { sanitizeOutgoingMentions, scanOutgoingForSecrets } from "../../lib/sanitizer.ts";
+import { buildPrDiffCommentabilityIndex } from "../formatter-suggestions.ts";
 import {
   createReviewOutputPublicationGate,
   type ReviewOutputPublicationGate,
@@ -78,7 +79,11 @@ export function createInlineReviewServer(
   logger?: Logger,
   onPublish?: () => void,
   publicationGate?: ReviewOutputPublicationGate,
+  prDiffForCommentValidation?: string,
 ) {
+  const rightCommentableLines = prDiffForCommentValidation
+    ? buildPrDiffCommentabilityIndex(prDiffForCommentValidation)
+    : undefined;
   const reviewOutputPublicationGate = publicationGate
     ?? (
       reviewOutputKey
@@ -170,6 +175,16 @@ export function createInlineReviewServer(
             }
             if (startLine !== undefined && line !== undefined && startLine > line) {
               throw new Error("Inline comment 'startLine' must be less than or equal to 'line'");
+            }
+            if (rightCommentableLines && (side ?? "RIGHT") === "RIGHT") {
+              const commentableLinesForPath = rightCommentableLines.get(path);
+              const targetLines = startLine !== undefined && line !== undefined
+                ? Array.from({ length: line - startLine + 1 }, (_, index) => startLine + index)
+                : [line].filter((value): value is number => value !== undefined);
+              const missingLine = targetLines.find((targetLine) => !commentableLinesForPath?.has(targetLine));
+              if (missingLine !== undefined) {
+                throw new Error(`RIGHT line ${missingLine} is not commentable in the PR diff for ${path}`);
+              }
             }
 
             const octokit = await getOctokit();
@@ -290,6 +305,9 @@ export function createInlineReviewServer(
                 githubRequestId: githubErrorDetails.requestId,
                 githubResponseMessage: githubErrorDetails.responseMessage,
                 githubResponseErrors: githubErrorDetails.responseErrors,
+                reason: errorMessage.includes("is not commentable in the PR diff")
+                  ? "line-not-commentable-in-pr-diff"
+                  : undefined,
               },
               "Inline review comment publication failed",
             );

--- a/src/execution/review-prompt.test.ts
+++ b/src/execution/review-prompt.test.ts
@@ -53,6 +53,26 @@ describe("small-diff review prompt scope", () => {
     expect(result.text).not.toContain("Bash(git diff origin/main...HEAD)");
     expect(result.text).not.toContain("Bash(git log origin/main..HEAD --stat)");
   });
+  test("embeds PR diff context and warns against full-file line numbers when supplied", () => {
+    const result = buildReviewPromptDetails(baseContext({
+      gitDiffInstructionsAvailable: false,
+      diffContent: [
+        "diff --git a/src/index.ts b/src/index.ts",
+        "--- a/src/index.ts",
+        "+++ b/src/index.ts",
+        "@@ -10,3 +10,4 @@ function f()",
+        " context",
+        "+changed",
+        " context",
+      ].join("\n"),
+    }));
+
+    expect(result.text).toContain("## PR Diff Context");
+    expect(result.text).toContain("@@ -10,3 +10,4 @@ function f()");
+    expect(result.text).toContain("Only call `mcp__github_inline_comment__create_inline_comment` on lines visible in these diff hunks");
+    expect(result.text).toContain("Do not use full-file `Read` line numbers for inline comments unless that line is also visible in the diff context");
+    expect(result.sections.some((section) => section.sectionName === "review-diff-context")).toBe(true);
+  });
 });
 
 function baseContext(overrides: Record<string, unknown> = {}) {

--- a/src/execution/review-prompt.ts
+++ b/src/execution/review-prompt.ts
@@ -1709,6 +1709,7 @@ export function buildReviewPromptDetails(context: {
   reviewBoundedness?: ReviewBoundednessContract | null;
   publishToolNames?: string[];
   gitDiffInstructionsAvailable?: boolean;
+  diffContent?: string;
 }): PromptBuildResult {
   const sectionBlocks: Array<{ sectionName: string; text: string; truncated?: boolean }> = [];
   const scaleNotes: string[] = [];
@@ -1718,6 +1719,7 @@ export function buildReviewPromptDetails(context: {
     sizeContext: 3_200,
     graphContext: 4_000,
     knowledgeContext: 3_600,
+    diffContext: 12_000,
     instructions: 16_000,
   } as const;
 
@@ -1801,6 +1803,25 @@ export function buildReviewPromptDetails(context: {
     changeContextLines.push("", diffAnalysisSection);
   }
   pushBudgetedSection("review-change-context", changeContextLines, REVIEW_SECTION_BUDGETS.changeContext);
+
+  const diffContentSanitized = sanitizeContent((context.diffContent ?? "").trim());
+  if (diffContentSanitized.length > 0) {
+    pushBudgetedSection(
+      "review-diff-context",
+      [
+        "## PR Diff Context",
+        "",
+        "Only call `mcp__github_inline_comment__create_inline_comment` on lines visible in these diff hunks.",
+        "Do not use full-file `Read` line numbers for inline comments unless that line is also visible in the diff context.",
+        "If a finding concerns unchanged code outside the shown hunk, comment on the nearest visible changed/context line and mention the exact full-file line in the body.",
+        "",
+        "```diff",
+        diffContentSanitized,
+        "```",
+      ],
+      REVIEW_SECTION_BUDGETS.diffContext,
+    );
+  }
 
   const sizeContextLines: string[] = [];
   if (context.largePRContext) {
@@ -2406,6 +2427,7 @@ export function buildReviewPrompt(context: {
   graphContextOptions?: GraphContextOptions;
   structuralImpact?: StructuralImpactPayload | null;
   reviewBoundedness?: ReviewBoundednessContract | null;
+  diffContent?: string;
   publishToolNames?: string[];
 }): string {
   return buildReviewPromptDetails(context).text;

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -83,6 +83,9 @@ export type ExecutionContext = {
   enableInlineTools?: boolean;
   enableCommentTools?: boolean;
 
+  /** Optional PR diff used by MCP inline-comment tools to reject non-commentable full-file line numbers before GitHub does. */
+  prDiffForCommentValidation?: string;
+
   /** Task type for LLM routing and cost tracking (e.g., "review.full", "mention.response"). */
   taskType?: string;
 

--- a/src/handlers/mention.ts
+++ b/src/handlers/mention.ts
@@ -1011,6 +1011,7 @@ export function createMentionHandler(deps: {
     changedFiles: string[];
     numstatLines: string[];
     diffRange: string;
+    diffContent?: string;
   }> {
     const diffContext = await collectDiffContext({
       workspaceDir: input.workspaceDir,
@@ -1032,6 +1033,7 @@ export function createMentionHandler(deps: {
       changedFiles: diffContext.changedFiles,
       numstatLines: diffContext.numstatLines,
       diffRange: diffContext.diffRange,
+      diffContent: diffContext.diffContent,
     };
   }
 
@@ -2633,6 +2635,7 @@ export function createMentionHandler(deps: {
         let explicitReviewPromptFileCount: number | undefined;
         let explicitReviewDynamicTimeoutSeconds: number | undefined;
         let explicitReviewMaxTurnsOverride: number | undefined;
+        let explicitReviewPrDiffForCommentValidation: string | undefined;
         let explicitReviewRouting: ReviewTaskRouting = {
           taskType: TASK_TYPES.REVIEW_FULL,
           routingReason: "standard",
@@ -2663,6 +2666,7 @@ export function createMentionHandler(deps: {
               })
             : { changedFiles: [], numstatLines: [], diffRange: "unknown" };
           const promptChangedFiles = promptDiffContext.changedFiles;
+          explicitReviewPrDiffForCommentValidation = promptDiffContext.diffContent;
           explicitReviewPromptFileCount = promptChangedFiles.length;
 
           const diffAnalysis = analyzeDiff({
@@ -2768,6 +2772,7 @@ export function createMentionHandler(deps: {
             suppressions: config.review.suppressions,
             minConfidence: config.review.minConfidence,
             diffAnalysis,
+            diffContent: promptDiffContext.diffContent,
             matchedPathInstructions,
             retrievalContext,
             reviewPrecedents: reviewPrecedentsForPrompt.length > 0 ? reviewPrecedentsForPrompt : undefined,
@@ -2892,6 +2897,7 @@ export function createMentionHandler(deps: {
             formatterSuggestionRequest,
             totalFiles: explicitReviewPromptFileCount,
             enableInlineTools: explicitReviewRequest ? true : undefined,
+            prDiffForCommentValidation: explicitReviewRequest ? explicitReviewPrDiffForCommentValidation : undefined,
           });
         } catch (err) {
           if (isCombinedFormatterSuggestionRequest) {

--- a/src/handlers/mention.ts
+++ b/src/handlers/mention.ts
@@ -1668,6 +1668,7 @@ export function createMentionHandler(deps: {
             prNumber: mention.prNumber,
             localBranch: "pr-mention",
             token: workspace.token,
+            depth: cloneDepth,
           });
 
           // Ensure base branch exists as a remote-tracking ref so git diff tools can compare
@@ -1677,7 +1678,7 @@ export function createMentionHandler(deps: {
               dir: workspace.dir,
               branch: mention.baseRef,
               token: workspace.token,
-              depth: 1,
+              depth: cloneDepth,
             });
           }
         }

--- a/src/handlers/review.ts
+++ b/src/handlers/review.ts
@@ -3959,6 +3959,7 @@ export function createReviewHandler(deps: {
           suppressions: config.review.suppressions,
           minConfidence: config.review.minConfidence,
           diffAnalysis,
+          diffContent,
           matchedPathInstructions,
           // Incremental re-review context (REV-01)
           incrementalContext: incrementalResult?.mode === "incremental" ? {
@@ -4090,6 +4091,7 @@ export function createReviewHandler(deps: {
           knowledgeStore,
           totalFiles: changedFiles.length,
           enableCheckpointTool: checkpointEnabled,
+          prDiffForCommentValidation: diffContext.diffContent,
           // TMO-04: total timeout = infra overhead cushion + complexity-scaled remote runtime budget
           dynamicTimeoutSeconds: appliedTimeoutBudget
             ? appliedTimeoutBudget.totalTimeoutSeconds
@@ -5793,6 +5795,7 @@ export function createReviewHandler(deps: {
                       suppressions: config.review.suppressions,
                       minConfidence: config.review.minConfidence,
                       diffAnalysis,
+                      diffContent: diffContext.diffContent,
                       matchedPathInstructions,
                       incrementalContext: incrementalResult?.mode === "incremental" ? {
                         lastReviewedHeadSha: incrementalResult.lastReviewedHeadSha!,
@@ -5901,6 +5904,7 @@ export function createReviewHandler(deps: {
                       knowledgeStore,
                       totalFiles: timeoutTotalFiles,
                       enableCheckpointTool: retryCheckpointEnabled,
+                      prDiffForCommentValidation: diffContext.diffContent,
                       enableCommentTools: false,
                     });
 

--- a/src/handlers/review.ts
+++ b/src/handlers/review.ts
@@ -2490,6 +2490,7 @@ export function createReviewHandler(deps: {
             token: workspace.token,
             fallbackRemoteUrl: pr.head.repo ? `https://github.com/${pr.head.repo.full_name}.git` : undefined,
             fallbackRef: pr.head.ref,
+            depth: REVIEW_WORKSPACE_FETCH_DEPTH,
           });
         }
 
@@ -5745,6 +5746,7 @@ export function createReviewHandler(deps: {
                         token: retryWorkspace.token,
                         fallbackRemoteUrl: pr.head.repo ? `https://github.com/${pr.head.repo.full_name}.git` : undefined,
                         fallbackRef: pr.head.ref,
+                        depth: REVIEW_WORKSPACE_FETCH_DEPTH,
                       });
                     }
 

--- a/src/jobs/workspace.test.ts
+++ b/src/jobs/workspace.test.ts
@@ -246,11 +246,14 @@ describe("fetchAndCheckoutPullRequestHeadRef", () => {
         token: "test-token",
         fallbackRemoteUrl: "https://github.com/acme/head.git",
         fallbackRef,
+        depth: 1,
       });
 
       expect(result).toEqual({ localBranch: "pr-review", source: "head-ref-fallback" });
       const checkedOutSha = (await $`git -C ${cloneDir} rev-parse HEAD`.quiet()).text().trim();
       expect(checkedOutSha).toBe(featureSha);
+      const fetchedCommitCount = Number((await $`git -C ${cloneDir} rev-list --count HEAD`.quiet()).text().trim());
+      expect(fetchedCommitCount).toBe(1);
     } finally {
       await rm(tmpBase, { recursive: true, force: true });
     }

--- a/src/jobs/workspace.ts
+++ b/src/jobs/workspace.ts
@@ -564,8 +564,9 @@ export async function fetchAndCheckoutPullRequestHeadRef(options: {
   token?: string;
   fallbackRemoteUrl?: string;
   fallbackRef?: string;
+  depth?: number;
 }): Promise<{ localBranch: string; source: "pull-ref" | "head-ref-fallback" }> {
-  const { dir, prNumber, remote = "origin", localBranch = "pr-review", token, fallbackRemoteUrl, fallbackRef } = options;
+  const { dir, prNumber, remote = "origin", localBranch = "pr-review", token, fallbackRemoteUrl, fallbackRef, depth } = options;
 
   validatePullRequestNumber(prNumber);
   validateBranchName(localBranch);
@@ -575,7 +576,10 @@ export async function fetchAndCheckoutPullRequestHeadRef(options: {
     // Construct the auth URL inline; never stored — used for this fetch only.
     const strippedUrl = (await $`git -C ${dir} remote get-url ${remote}`.quiet()).text().trim();
     const fetchUrl = makeAuthUrl(strippedUrl, token);
-    const primaryFetch = await $`git -C ${dir} fetch ${fetchUrl} pull/${prNumber}/head:${localBranch}`.quiet().nothrow();
+    const primaryFetchArgs = depth === undefined
+      ? ["fetch", fetchUrl, `pull/${prNumber}/head:${localBranch}`]
+      : ["fetch", fetchUrl, `pull/${prNumber}/head:${localBranch}`, `--depth=${depth}`];
+    const primaryFetch = await $`git -C ${dir} ${primaryFetchArgs}`.quiet().nothrow();
     if (primaryFetch.exitCode === 0) {
       await $`git -C ${dir} checkout ${localBranch}`.quiet();
       return { localBranch, source: "pull-ref" };
@@ -591,7 +595,10 @@ export async function fetchAndCheckoutPullRequestHeadRef(options: {
     }
 
     const fallbackFetchUrl = makeAuthUrl(fallbackRemoteUrl, token);
-    await $`git -C ${dir} fetch ${fallbackFetchUrl} ${fallbackRef}:${localBranch}`.quiet();
+    const fallbackFetchArgs = depth === undefined
+      ? ["fetch", fallbackFetchUrl, `${fallbackRef}:${localBranch}`]
+      : ["fetch", fallbackFetchUrl, `${fallbackRef}:${localBranch}`, `--depth=${depth}`];
+    await $`git -C ${dir} ${fallbackFetchArgs}`.quiet();
     await $`git -C ${dir} checkout ${localBranch}`.quiet();
     return { localBranch, source: "head-ref-fallback" };
   } catch (err) {


### PR DESCRIPTION
## Summary

Fixes the production anomalies found on:

- `xbmc/xbmc#28276`: diff fallback plus inline GitHub `422`
- `xbmc/xbmc#28279`: checkpoint mismatch (`filesInspected missing reviewed files`)

Changes:

- Pass fallback PR diff context into review prompts so agents can see actual diff hunks when git history is unavailable.
- Pass the same diff context into the inline-comment MCP server and reject non-commentable RIGHT-side line numbers locally before GitHub returns `422`.
- Normalize checkpoint `filesInspected` to include every `filesReviewed` path, since fully reviewed files are necessarily inspected.
- Make checkpoint debug logging optional-safe.
- Add depth support to PR-head fetches and thread review/mention workspace depth through PR-head and base fetches, reducing shallow merge-base recovery fallbacks.

## Verification

- `bun test ./src/execution/mcp/inline-review-server.test.ts ./src/execution/mcp/checkpoint-server.test.ts ./src/execution/review-prompt.test.ts ./src/handlers/review.test.ts ./src/handlers/mention.test.ts ./src/execution/executor.test.ts ./src/jobs/workspace.test.ts --timeout 30000`
  - `601 pass`
  - `0 fail`
- `bun run tsc --noEmit`
  - exit 0
- `git diff --check`
  - exit 0
