### PR TITLE
Fix production review failure paths

### DIFF
--- a/src/execution/executor.test.ts
+++ b/src/execution/executor.test.ts
@@ -1643,7 +1643,7 @@ test("prepareAgentWorkspace writes a review bundle transport for repos with trac
   }
 });
 
-test("prepareAgentWorkspace snapshots shallow PR workspaces without unshallowing", async () => {
+test("prepareAgentWorkspace uses archive transport for shallow PR workspaces without unshallowing", async () => {
   const tempRoot = await mkdtemp(join(tmpdir(), "kodiai-shallow-bundle-"));
   const bareRepoDir = join(tempRoot, "origin.git");
   const seedRepoDir = join(tempRoot, "seed");
@@ -1688,19 +1688,23 @@ test("prepareAgentWorkspace snapshots shallow PR workspaces without unshallowing
 
     expect((await $`git -C ${shallowRepoDir} rev-parse --is-shallow-repository`.quiet().text()).trim()).toBe("true");
     expect(result.repoBundlePath).toBeUndefined();
-    expect(result.repoCwd).toBe(join(workspaceDir, "repo"));
+    expect(result.repoCwd).toBeUndefined();
 
     const rawAgentConfig = await readFile(join(workspaceDir, "agent-config.json"), "utf-8");
     const agentConfig = JSON.parse(rawAgentConfig) as {
       repoCwd?: string;
-      repoTransport?: unknown;
+      repoTransport?: { kind?: string; archivePath?: string };
+      allowedTools?: string[];
     };
 
-    expect(agentConfig.repoTransport).toBeUndefined();
-    expect(agentConfig.repoCwd).toBe(join(workspaceDir, "repo"));
-    expect((agentConfig as { allowedTools?: string[] }).allowedTools).toEqual(["Read", "Grep", "Glob"]);
-    expect(await readFile(join(workspaceDir, "repo", "feature.txt"), "utf-8")).toBe("one\ntwo\npr\n");
-    await expect(stat(join(workspaceDir, "repo", ".git"))).rejects.toThrow();
+    expect(agentConfig.repoCwd).toBeUndefined();
+    expect(agentConfig.repoTransport).toEqual({
+      kind: "working-tree-archive",
+      archivePath: join(workspaceDir, "repo.tar"),
+    });
+    expect(agentConfig.allowedTools).toEqual(["Read", "Grep", "Glob"]);
+    expect((await lstat(join(workspaceDir, "repo.tar"))).isFile()).toBe(true);
+    await expect(stat(join(workspaceDir, "repo"))).rejects.toThrow();
   } finally {
     await Promise.all(cleanupDirs.map((dir) => rm(dir, { recursive: true, force: true })));
   }

--- a/src/execution/executor.ts
+++ b/src/execution/executor.ts
@@ -261,24 +261,6 @@ async function buildGitArchiveTransport(params: {
   };
 }
 
-async function hasTrackedSymlinks(repoDir: string): Promise<boolean> {
-  const result = await $`git -C ${repoDir} ls-files -s`.quiet().nothrow();
-  if (result.exitCode !== 0) {
-    return false;
-  }
-  return result.stdout.toString().split(/\r?\n/).some((line) => line.startsWith("120000 "));
-}
-
-async function exportGitWorkingTreeSnapshot(params: {
-  sourceRepoDir: string;
-  workspaceDir: string;
-}): Promise<string> {
-  const repoCwd = join(params.workspaceDir, "repo");
-  await mkdir(repoCwd, { recursive: true });
-  await $`git -C ${params.sourceRepoDir} checkout-index -a -f --prefix=${repoCwd + "/"}`.quiet();
-  return repoCwd;
-}
-
 function filterGitToolsForSnapshot(allowedTools: string[]): string[] {
   return allowedTools.filter((tool) => !tool.startsWith("Bash(git "));
 }
@@ -309,21 +291,12 @@ export async function prepareAgentWorkspace(params: {
       .then((value) => value.trim() === "true")
       .catch(() => false);
     if (sourceIsShallow) {
-      const sourceHasTrackedSymlinks = await hasTrackedSymlinks(params.sourceRepoDir);
-      if (sourceHasTrackedSymlinks) {
-        const preparedRepo = await buildGitArchiveTransport({
-          sourceRepoDir: params.sourceRepoDir,
-          workspaceDir: params.workspaceDir,
-        });
-        repoTransport = preparedRepo.repoTransport;
-        allowedTools = filterGitToolsForSnapshot(params.allowedTools);
-      } else {
-        repoCwd = await exportGitWorkingTreeSnapshot({
-          sourceRepoDir: params.sourceRepoDir,
-          workspaceDir: params.workspaceDir,
-        });
-        allowedTools = filterGitToolsForSnapshot(params.allowedTools);
-      }
+      const preparedRepo = await buildGitArchiveTransport({
+        sourceRepoDir: params.sourceRepoDir,
+        workspaceDir: params.workspaceDir,
+      });
+      repoTransport = preparedRepo.repoTransport;
+      allowedTools = filterGitToolsForSnapshot(params.allowedTools);
     } else {
       const preparedRepo = await buildGitRepoTransport({
         sourceRepoDir: params.sourceRepoDir,

--- a/src/execution/mcp/inline-review-server.test.ts
+++ b/src/execution/mcp/inline-review-server.test.ts
@@ -3,12 +3,13 @@ import { createInlineReviewServer } from "./inline-review-server.ts";
 
 function createMockLogger() {
   const warnCalls: unknown[][] = [];
+  const infoCalls: unknown[][] = [];
   const logger = {
     warn: (...args: unknown[]) => warnCalls.push(args),
-    info: () => {},
+    info: (...args: unknown[]) => infoCalls.push(args),
     child: () => logger,
   };
-  return { logger, warnCalls };
+  return { logger, warnCalls, infoCalls };
 }
 
 function getToolHandler(server: ReturnType<typeof createInlineReviewServer>) {
@@ -237,7 +238,7 @@ describe("createInlineReviewServer validation diagnostics", () => {
       " context",
     ].join("\n");
 
-    const { logger, warnCalls } = createMockLogger();
+    const { logger, warnCalls, infoCalls } = createMockLogger();
     const server = createInlineReviewServer(
       async () => octokit as never,
       "acme",
@@ -264,8 +265,9 @@ describe("createInlineReviewServer validation diagnostics", () => {
     expect(result.isError).toBe(true);
     expect(result.content[0]?.text).toContain("src/file.ts");
     expect(result.content[0]?.text).toContain("RIGHT line 810 is not commentable");
-    expect(warnCalls).toHaveLength(1);
-    expect(warnCalls[0]?.[0]).toMatchObject({
+    expect(warnCalls).toHaveLength(0);
+    expect(infoCalls).toHaveLength(1);
+    expect(infoCalls[0]?.[0]).toMatchObject({
       deliveryId: "delivery-123",
       reviewOutputKey: "review-key",
       owner: "acme",
@@ -275,6 +277,183 @@ describe("createInlineReviewServer validation diagnostics", () => {
       line: 810,
       side: "RIGHT",
       reason: "line-not-commentable-in-pr-diff",
+    });
+  });
+
+  test("classifies GitHub thread line resolution errors as non-commentable and logs them below warning level", async () => {
+    const githubError = Object.assign(new Error("Validation Failed"), {
+      status: 422,
+      response: {
+        data: {
+          message: "Validation Failed",
+          errors: [
+            {
+              resource: "PullRequestReviewComment",
+              code: "custom",
+              field: "pull_request_review_thread.line",
+              message: "could not be resolved",
+            },
+          ],
+        },
+        headers: { "x-github-request-id": "REQ-LINE" },
+      },
+    });
+    const octokit = {
+      rest: {
+        pulls: {
+          listReviewComments: async () => ({ data: [] }),
+          listReviews: async () => ({ data: [] }),
+          get: async () => ({ data: { head: { sha: "abcdef1234" } } }),
+          createReviewComment: async () => {
+            throw githubError;
+          },
+        },
+        issues: { listComments: async () => ({ data: [] }) },
+      },
+    };
+
+    const { logger, warnCalls, infoCalls } = createMockLogger();
+    const server = createInlineReviewServer(
+      async () => octokit as never,
+      "acme",
+      "repo",
+      101,
+      [],
+      "review-key",
+      "delivery-123",
+      logger as never,
+    );
+    const handler = getToolHandler(server);
+
+    const result = await handler({
+      path: "src/file.ts",
+      line: 470,
+      side: "RIGHT",
+      body: "line comment",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain("path \"src/file.ts\" at RIGHT line 470");
+    expect(warnCalls).toHaveLength(0);
+    expect(infoCalls).toHaveLength(1);
+    expect(infoCalls[0]?.[0]).toMatchObject({
+      deliveryId: "delivery-123",
+      reviewOutputKey: "review-key",
+      path: "src/file.ts",
+      line: 470,
+      githubStatus: 422,
+      githubRequestId: "REQ-LINE",
+      reason: "review-thread-line-not-resolved",
+    });
+  });
+
+  test("ignores null GitHub validation error entries when classifying line resolution failures", async () => {
+    const githubError = Object.assign(new Error("Validation Failed"), {
+      status: 422,
+      response: {
+        data: {
+          message: "Validation Failed",
+          errors: [null],
+        },
+        headers: { "x-github-request-id": "REQ-NULL" },
+      },
+    });
+    const octokit = {
+      rest: {
+        pulls: {
+          listReviewComments: async () => ({ data: [] }),
+          listReviews: async () => ({ data: [] }),
+          get: async () => ({ data: { head: { sha: "abcdef1234" } } }),
+          createReviewComment: async () => {
+            throw githubError;
+          },
+        },
+        issues: { listComments: async () => ({ data: [] }) },
+      },
+    };
+
+    const { logger, warnCalls, infoCalls } = createMockLogger();
+    const server = createInlineReviewServer(
+      async () => octokit as never,
+      "acme",
+      "repo",
+      101,
+      [],
+      "review-key",
+      "delivery-123",
+      logger as never,
+    );
+    const handler = getToolHandler(server);
+
+    const result = await handler({
+      path: "src/file.ts",
+      line: 470,
+      side: "RIGHT",
+      body: "line comment",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(infoCalls).toHaveLength(0);
+    expect(warnCalls).toHaveLength(1);
+    expect(warnCalls[0]?.[0]).toMatchObject({
+      githubStatus: 422,
+      githubRequestId: "REQ-NULL",
+      reason: undefined,
+    });
+  });
+
+  test("ignores null GitHub validation errors object when classifying line resolution failures", async () => {
+    const githubError = Object.assign(new Error("Validation Failed"), {
+      status: 422,
+      response: {
+        data: {
+          message: "Validation Failed",
+          errors: null,
+        },
+        headers: { "x-github-request-id": "REQ-NULL-OBJECT" },
+      },
+    });
+    const octokit = {
+      rest: {
+        pulls: {
+          listReviewComments: async () => ({ data: [] }),
+          listReviews: async () => ({ data: [] }),
+          get: async () => ({ data: { head: { sha: "abcdef1234" } } }),
+          createReviewComment: async () => {
+            throw githubError;
+          },
+        },
+        issues: { listComments: async () => ({ data: [] }) },
+      },
+    };
+
+    const { logger, warnCalls, infoCalls } = createMockLogger();
+    const server = createInlineReviewServer(
+      async () => octokit as never,
+      "acme",
+      "repo",
+      101,
+      [],
+      "review-key",
+      "delivery-123",
+      logger as never,
+    );
+    const handler = getToolHandler(server);
+
+    const result = await handler({
+      path: "src/file.ts",
+      line: 470,
+      side: "RIGHT",
+      body: "line comment",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(infoCalls).toHaveLength(0);
+    expect(warnCalls).toHaveLength(1);
+    expect(warnCalls[0]?.[0]).toMatchObject({
+      githubStatus: 422,
+      githubRequestId: "REQ-NULL-OBJECT",
+      reason: undefined,
     });
   });
 

--- a/src/execution/mcp/inline-review-server.ts
+++ b/src/execution/mcp/inline-review-server.ts
@@ -58,6 +58,20 @@ function extractGitHubApiErrorDetails(error: unknown): GitHubApiErrorDetails {
   };
 }
 
+function isGitHubLineResolutionFailure(details: GitHubApiErrorDetails): boolean {
+  if (details.status !== 422 || details.responseErrors == null) {
+    return false;
+  }
+  const errors = Array.isArray(details.responseErrors) ? details.responseErrors : [details.responseErrors];
+  return errors.some((entry) => {
+    if (entry == null) return false;
+    const candidate = entry as { field?: unknown; message?: unknown };
+    return candidate.field === "pull_request_review_thread.line"
+      && typeof candidate.message === "string"
+      && candidate.message.includes("could not be resolved");
+  });
+}
+
 function formatGitHubValidationDetails(details: GitHubApiErrorDetails): string {
   const parts: string[] = [];
   if (details.status !== undefined) parts.push(`status ${details.status}`);
@@ -289,7 +303,10 @@ export function createInlineReviewServer(
                 " This usually means the PR number, repository, or file path is incorrect.";
             }
 
-            logger?.warn(
+            const localNonCommentableReason = errorMessage.includes("is not commentable in the PR diff");
+            const threadLineNotResolvedReason = isGitHubLineResolutionFailure(githubErrorDetails);
+            const logMethod = localNonCommentableReason || threadLineNotResolvedReason ? "info" : "warn";
+            logger?.[logMethod](
               {
                 deliveryId,
                 reviewOutputKey,
@@ -305,9 +322,11 @@ export function createInlineReviewServer(
                 githubRequestId: githubErrorDetails.requestId,
                 githubResponseMessage: githubErrorDetails.responseMessage,
                 githubResponseErrors: githubErrorDetails.responseErrors,
-                reason: errorMessage.includes("is not commentable in the PR diff")
+                reason: localNonCommentableReason
                   ? "line-not-commentable-in-pr-diff"
-                  : undefined,
+                  : threadLineNotResolvedReason
+                    ? "review-thread-line-not-resolved"
+                    : undefined,
               },
               "Inline review comment publication failed",
             );

--- a/src/execution/prepare-agent-workspace.test.ts
+++ b/src/execution/prepare-agent-workspace.test.ts
@@ -193,7 +193,7 @@ test("prepareAgentWorkspace uses archive transport for shallow repos with tracke
   await expect(stat(join(workspaceDir, "repo"))).rejects.toThrow();
 });
 
-test("prepareAgentWorkspace snapshots shallow PR workspaces without unshallowing", async () => {
+test("prepareAgentWorkspace uses archive transport for shallow PR workspaces without unshallowing", async () => {
   const tempRoot = await makeTempDir("kodiai-shallow-bundle-");
   const bareRepoDir = join(tempRoot, "origin.git");
   const seedRepoDir = join(tempRoot, "seed");
@@ -236,17 +236,21 @@ test("prepareAgentWorkspace snapshots shallow PR workspaces without unshallowing
 
   expect((await $`git -C ${shallowRepoDir} rev-parse --is-shallow-repository`.quiet().text()).trim()).toBe("true");
   expect(result.repoBundlePath).toBeUndefined();
-  expect(result.repoCwd).toBe(join(workspaceDir, "repo"));
+  expect(result.repoCwd).toBeUndefined();
 
   const rawAgentConfig = await readFile(join(workspaceDir, "agent-config.json"), "utf-8");
   const agentConfig = JSON.parse(rawAgentConfig) as {
     repoCwd?: string;
-    repoTransport?: unknown;
+    repoTransport?: { kind?: string; archivePath?: string };
+    allowedTools?: string[];
   };
 
-  expect(agentConfig.repoTransport).toBeUndefined();
-  expect(agentConfig.repoCwd).toBe(join(workspaceDir, "repo"));
-  expect((agentConfig as { allowedTools?: string[] }).allowedTools).toEqual(["Read", "Grep", "Glob"]);
-  expect(await readFile(join(workspaceDir, "repo", "feature.txt"), "utf-8")).toBe("one\ntwo\npr\n");
-  await expect(stat(join(workspaceDir, "repo", ".git"))).rejects.toThrow();
+  expect(agentConfig.repoCwd).toBeUndefined();
+  expect(agentConfig.repoTransport).toEqual({
+    kind: "working-tree-archive",
+    archivePath: join(workspaceDir, "repo.tar"),
+  });
+  expect(agentConfig.allowedTools).toEqual(["Read", "Grep", "Glob"]);
+  expect((await lstat(join(workspaceDir, "repo.tar"))).isFile()).toBe(true);
+  await expect(stat(join(workspaceDir, "repo"))).rejects.toThrow();
 });

--- a/src/knowledge/store.test.ts
+++ b/src/knowledge/store.test.ts
@@ -21,6 +21,41 @@ const mockLogger = {
 let sql: Sql;
 let store: KnowledgeStore;
 
+describe("KnowledgeStore recordFindings unit guards", () => {
+  test("skips malformed findings instead of passing undefined values to postgres", async () => {
+    const insertedValues: unknown[][] = [];
+    const warnCalls: unknown[][] = [];
+    const tx = ((strings: TemplateStringsArray, ...values: unknown[]) => {
+      insertedValues.push(values);
+      return Promise.resolve([]);
+    }) as unknown as Sql;
+    const sqlStub = {
+      begin: async (fn: (tx: Sql) => Promise<void>) => fn(tx),
+    } as unknown as Sql;
+    const logger = {
+      ...mockLogger,
+      warn: (...args: unknown[]) => warnCalls.push(args),
+    } as unknown as import("pino").Logger;
+    const unitStore = createKnowledgeStore({ sql: sqlStub, logger });
+
+    await unitStore.recordFindings([
+      {
+        reviewId: 1,
+        filePath: "src/example.ts",
+        severity: "major",
+        category: undefined,
+        confidence: 80,
+        title: "Missing category should not reach postgres",
+        suppressed: false,
+      } as unknown as Parameters<KnowledgeStore["recordFindings"]>[0][number],
+    ]);
+
+    expect(insertedValues).toHaveLength(0);
+    expect(warnCalls).toHaveLength(1);
+    expect(warnCalls[0]?.[0]).toMatchObject({ skipped: 1 });
+  });
+});
+
 /** Truncate all knowledge-related tables for test isolation. */
 async function truncateAll(): Promise<void> {
   await sql`TRUNCATE

--- a/src/knowledge/store.ts
+++ b/src/knowledge/store.ts
@@ -59,6 +59,20 @@ function _normalizeDbNumber(value: unknown): number | null {
   return Number.isFinite(normalized) ? normalized : null;
 }
 
+function _isValidFindingRecord(finding: FindingRecord): boolean {
+  return Number.isFinite(finding.reviewId)
+    && typeof finding.filePath === "string"
+    && finding.filePath.trim().length > 0
+    && typeof finding.severity === "string"
+    && finding.severity.trim().length > 0
+    && typeof finding.category === "string"
+    && finding.category.trim().length > 0
+    && Number.isFinite(finding.confidence)
+    && typeof finding.title === "string"
+    && finding.title.trim().length > 0
+    && typeof finding.suppressed === "boolean";
+}
+
 export function createKnowledgeStore(opts: {
   sql: Sql;
   logger: Logger;
@@ -88,8 +102,14 @@ export function createKnowledgeStore(opts: {
 
     async recordFindings(findings: FindingRecord[]): Promise<void> {
       if (findings.length === 0) return;
+      const validFindings = findings.filter(_isValidFindingRecord);
+      const skipped = findings.length - validFindings.length;
+      if (skipped > 0) {
+        logger.warn({ skipped, total: findings.length }, "Knowledge store skipped malformed finding records");
+      }
+      if (validFindings.length === 0) return;
       await sql.begin(async (tx) => {
-        for (const finding of findings) {
+        for (const finding of validFindings) {
           await (tx as unknown as Sql)`
             INSERT INTO findings (
               review_id, file_path, start_line, end_line,


### PR DESCRIPTION
## Summary
- avoid shallow-workspace checkout-index snapshots by using the working-tree archive transport
- classify GitHub PR review thread line-resolution failures as non-commentable outcomes and log them below warning level
- skip malformed knowledge-store finding records before postgres parameterization

## Production evidence
- xbmc/kodi-tv#1249 failed during workspace preparation before remote runtime startup with checkout-index unable to create a nested file path
- recent inline review publication warnings were GitHub 422 line-resolution failures or local non-commentable-line checks
- one recent knowledge-store write failed non-fatally because postgres received an undefined value

## Verification
- bun test src/execution/prepare-agent-workspace.test.ts -t archive
- bun test src/execution/executor.test.ts -t "archive transport for shallow PR"
- bun test src/execution/mcp/inline-review-server.test.ts -t "RIGHT-side|thread|structured"
- bun test src/knowledge/store.test.ts -t "skips malformed"

## Notes
- bun run tsc --noEmit still reports unrelated pre-existing type errors in scripts/tests, including missing slackWebhookRelaySources config stubs and existing test type issues.
