### PR TITLE
Stack 01: add review plan orchestration primitives

### DIFF
--- a/src/review-orchestration/review-plan.test.ts
+++ b/src/review-orchestration/review-plan.test.ts
@@ -1,0 +1,370 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildReviewPlan,
+  createDegradedReviewPlan,
+  resolveGraphValidationPlanStatus,
+  toReviewPlanDetailsSummary,
+  type CandidateFindingMode,
+  type GraphValidationPlanStatus,
+  type ReviewPlanInput,
+} from "./review-plan.ts";
+
+const baseInput = (): ReviewPlanInput => ({
+  task: {
+    taskType: "review-full",
+    routingReason: "standard",
+  },
+  change: {
+    changedFileCount: 3,
+    linesChanged: 42,
+    linesChangedSource: "diff-numstat",
+  },
+  budget: {
+    timeoutSeconds: 900,
+    maxTurns: 50,
+    maxTurnsSource: "timeout-risk",
+  },
+  context: {
+    sources: ["pr-metadata", "diff-summary"],
+    summary: "PR metadata and bounded diff summary",
+  },
+  gates: {
+    enabled: ["quality", "security"],
+    current: ["quality"],
+  },
+  policy: {
+    publish: "draft-review",
+    tools: "inline-comments-enabled",
+    retry: "retry-on-transient-failure",
+  },
+  graphValidation: {
+    status: "enabled",
+    reason: "graph-blast-radius-available",
+  },
+  candidateFinding: {
+    mode: "unavailable",
+    reason: "candidate-finding-not-wired",
+  },
+});
+
+describe("resolveGraphValidationPlanStatus", () => {
+  test("projects config-disabled graph validation as skipped", () => {
+    expect(resolveGraphValidationPlanStatus({ configEnabled: false })).toEqual({
+      status: "skipped",
+      reason: "config-disabled",
+    });
+  });
+
+  test("projects missing graph query capability as unavailable", () => {
+    expect(resolveGraphValidationPlanStatus({
+      configEnabled: true,
+      graphQueryAvailable: false,
+      graphBlastRadiusAvailable: true,
+    })).toEqual({
+      status: "unavailable",
+      reason: "review-graph-query-not-configured",
+    });
+  });
+
+  test("projects trivial bypass and missing blast radius as skipped states", () => {
+    expect(resolveGraphValidationPlanStatus({
+      configEnabled: true,
+      graphQueryAvailable: true,
+      graphBlastRadiusAvailable: true,
+      trivialChangeBypass: true,
+    })).toEqual({
+      status: "skipped",
+      reason: "trivial-change-bypass",
+    });
+
+    expect(resolveGraphValidationPlanStatus({
+      configEnabled: true,
+      graphQueryAvailable: true,
+      graphBlastRadiusAvailable: false,
+    })).toEqual({
+      status: "skipped",
+      reason: "no-graph-blast-radius",
+    });
+  });
+
+  test("projects available prerequisites as enabled before validation and applied after successful validation", () => {
+    expect(resolveGraphValidationPlanStatus({
+      configEnabled: true,
+      graphQueryAvailable: true,
+      graphBlastRadiusAvailable: true,
+    })).toEqual({
+      status: "enabled",
+      reason: "graph-blast-radius-available",
+    });
+
+    expect(resolveGraphValidationPlanStatus({
+      configEnabled: true,
+      graphQueryAvailable: true,
+      graphBlastRadiusAvailable: true,
+      finalValidationApplied: true,
+    })).toEqual({
+      status: "applied",
+      reason: "validated-findings",
+    });
+  });
+
+  test("does not leak malformed raw reason text into Review Details", () => {
+    const projected = resolveGraphValidationPlanStatus({
+      configEnabled: true,
+      graphQueryAvailable: true,
+      graphBlastRadiusAvailable: true,
+      finalValidationApplied: true,
+    });
+    const plan = buildReviewPlan({
+      ...baseInput(),
+      graphValidation: {
+        status: projected.status,
+        reason: JSON.stringify({ raw: "diff --git PROMPT_SECRET TOKEN=abc123" }),
+      },
+    }).plan;
+
+    const summary = toReviewPlanDetailsSummary(plan);
+
+    expect(projected).toEqual({ status: "applied", reason: "validated-findings" });
+    expect(plan.graphValidation.reason).toBe("-raw-:-diff---git-PROMPT_SECRET-TOKEN-abc123-");
+    expect(summary.text).toContain("graph=applied");
+    expect(summary.text).not.toContain("diff --git");
+    expect(summary.text).not.toContain("PROMPT_SECRET");
+    expect(summary.text).not.toContain("TOKEN");
+    expect(summary.text).not.toContain("{\"");
+  });
+});
+
+
+describe("buildReviewPlan", () => {
+  test("builds a ready typed plan with required routing, budget, context, policy, and placeholder fields", () => {
+    const result = buildReviewPlan(baseInput());
+
+    expect(result.status).toBe("ready");
+    expect(result.plan.status).toBe("ready");
+    expect(result.plan.task.taskType).toBe("review-full");
+    expect(result.plan.task.routingReason).toBe("standard");
+    expect(result.plan.change).toEqual({
+      changedFileCount: 3,
+      linesChanged: 42,
+      linesChangedSource: "diff-numstat",
+    });
+    expect(result.plan.budget).toEqual({
+      timeoutSeconds: 900,
+      maxTurns: 50,
+      maxTurnsSource: "timeout-risk",
+    });
+    expect(result.plan.context.sources).toEqual(["pr-metadata", "diff-summary"]);
+    expect(result.plan.gates.enabled).toEqual(["quality", "security"]);
+    expect(result.plan.gates.current).toEqual(["quality"]);
+    expect(result.plan.policy).toEqual({
+      publish: "draft-review",
+      tools: "inline-comments-enabled",
+      retry: "retry-on-transient-failure",
+    });
+    expect(result.plan.graphValidation.status).toBe("enabled");
+    expect(result.plan.candidateFinding.mode).toBe("unavailable");
+    expect(result.plan.hash).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  test("uses canonical JSON hashing independent of object key insertion order", () => {
+    const ordered = buildReviewPlan(baseInput()).plan;
+    const reorderedInput: ReviewPlanInput = {
+      policy: {
+        retry: "retry-on-transient-failure",
+        tools: "inline-comments-enabled",
+        publish: "draft-review",
+      },
+      gates: {
+        current: ["quality"],
+        enabled: ["quality", "security"],
+      },
+      context: {
+        summary: "PR metadata and bounded diff summary",
+        sources: ["pr-metadata", "diff-summary"],
+      },
+      budget: {
+        maxTurnsSource: "timeout-risk",
+        maxTurns: 50,
+        timeoutSeconds: 900,
+      },
+      change: {
+        linesChangedSource: "diff-numstat",
+        linesChanged: 42,
+        changedFileCount: 3,
+      },
+      task: {
+        routingReason: "standard",
+        taskType: "review-full",
+      },
+      candidateFinding: {
+        reason: "candidate-finding-not-wired",
+        mode: "unavailable",
+      },
+      graphValidation: {
+        reason: "graph-blast-radius-available",
+        status: "enabled",
+      },
+    };
+
+    expect(buildReviewPlan(reorderedInput).plan.hash).toBe(ordered.hash);
+  });
+
+  test("changes the stable hash when meaningful routing or policy inputs change", () => {
+    const standard = buildReviewPlan(baseInput()).plan.hash;
+    const tinyDiff = buildReviewPlan({
+      ...baseInput(),
+      task: {
+        taskType: "review-small-diff",
+        routingReason: "tiny-diff",
+      },
+    }).plan.hash;
+    const publishPolicyChanged = buildReviewPlan({
+      ...baseInput(),
+      policy: {
+        publish: "comment-only",
+        tools: "inline-comments-enabled",
+        retry: "retry-on-transient-failure",
+      },
+    }).plan.hash;
+
+    expect(tinyDiff).not.toBe(standard);
+    expect(publishPolicyChanged).not.toBe(standard);
+  });
+
+  test("supports the graph-validation and candidate-finding R094 vocabularies", () => {
+    const graphStatuses: GraphValidationPlanStatus[] = ["enabled", "unavailable", "skipped", "applied"];
+    const candidateModes: CandidateFindingMode[] = ["unavailable", "shadow", "preferred"];
+
+    for (const graphStatus of graphStatuses) {
+      for (const candidateMode of candidateModes) {
+        const result = buildReviewPlan({
+          ...baseInput(),
+          graphValidation: { status: graphStatus, reason: `${graphStatus}-reason` },
+          candidateFinding: { mode: candidateMode, reason: `${candidateMode}-reason` },
+        });
+
+        expect(result.plan.graphValidation.status).toBe(graphStatus);
+        expect(result.plan.candidateFinding.mode).toBe(candidateMode);
+      }
+    }
+  });
+
+  test("normalizes unknown or null candidate-finding mode to unavailable", () => {
+    const unknown = buildReviewPlan({
+      ...baseInput(),
+      candidateFinding: { mode: "surprise-mode", reason: "bad mode" },
+    } as unknown as ReviewPlanInput & Record<string, unknown>).plan;
+    const nullMode = buildReviewPlan({
+      ...baseInput(),
+      candidateFinding: { mode: null, reason: "null mode" },
+    } as unknown as ReviewPlanInput & Record<string, unknown>).plan;
+
+    expect(unknown.candidateFinding).toEqual({ mode: "unavailable", reason: "bad mode" });
+    expect(nullMode.candidateFinding).toEqual({ mode: "unavailable", reason: "null mode" });
+  });
+
+  test("defaults missing graph-validation input to a safe skipped config-disabled projection", () => {
+    const result = buildReviewPlan({
+      ...baseInput(),
+      graphValidation: undefined,
+    });
+
+    expect(result.plan.graphValidation).toEqual({
+      status: "skipped",
+      reason: "config-disabled",
+    });
+  });
+
+  test("handles missing optional budget/context fields, empty context sources, and count boundaries", () => {
+    const zero = buildReviewPlan({
+      ...baseInput(),
+      change: {
+        changedFileCount: 0,
+        linesChanged: 0,
+        linesChangedSource: "diff-numstat",
+      },
+      budget: {},
+      context: {
+        sources: [],
+      },
+    }).plan;
+    const large = buildReviewPlan({
+      ...baseInput(),
+      change: {
+        changedFileCount: 10_000,
+        linesChanged: 1_000_000,
+        linesChangedSource: "github-api",
+      },
+    }).plan;
+
+    expect(zero.change.changedFileCount).toBe(0);
+    expect(zero.change.linesChanged).toBe(0);
+    expect(zero.budget).toEqual({});
+    expect(zero.context.sources).toEqual([]);
+    expect(large.change.changedFileCount).toBe(10_000);
+    expect(large.change.linesChanged).toBe(1_000_000);
+    expect(large.hash).not.toBe(zero.hash);
+  });
+
+  test("rejects unsupported canonicalization values in direct builder tests", () => {
+    expect(() => buildReviewPlan({
+      ...baseInput(),
+      context: {
+        sources: ["pr-metadata"],
+        summary: undefined,
+      },
+    })).toThrow("Unsupported undefined value at context.summary");
+  });
+});
+
+describe("createDegradedReviewPlan", () => {
+  test("creates stable degraded metadata that can be projected without throwing", () => {
+    const first = createDegradedReviewPlan({
+      reason: "canonicalization-error",
+      message: "Unsupported undefined value at context.summary",
+      taskType: "review-full",
+      routingReason: "standard",
+    });
+    const second = createDegradedReviewPlan({
+      routingReason: "standard",
+      taskType: "review-full",
+      message: "Unsupported undefined value at context.summary",
+      reason: "canonicalization-error",
+    });
+
+    expect(first.status).toBe("degraded");
+    expect(first.degraded.reason).toBe("canonicalization-error");
+    expect(first.hash).toMatch(/^degraded-[a-f0-9]{16}$/);
+    expect(second.hash).toBe(first.hash);
+    expect(() => toReviewPlanDetailsSummary(first)).not.toThrow();
+  });
+});
+
+describe("toReviewPlanDetailsSummary", () => {
+  test("projects a compact Review Details line without raw prompts, diffs, files, or secrets", () => {
+    const plan = buildReviewPlan({
+      ...baseInput(),
+      rawPrompt: "PROMPT_SECRET should not be serialized",
+      rawDiff: "diff --git a/secret b/secret\n+TOKEN=abc123",
+      files: [{ path: "src/secret.ts", content: "export const token = 'abc123';" }],
+      secretToken: "abc123",
+    } as ReviewPlanInput & Record<string, unknown>).plan;
+
+    const summary = toReviewPlanDetailsSummary(plan);
+
+    expect(summary.label).toBe("Review plan");
+    expect(summary.text).toStartWith("Review plan: ready hash=");
+    expect(summary.text.length).toBeLessThanOrEqual(240);
+    expect(summary.text).toContain("route=standard");
+    expect(summary.text).toContain("files=3");
+    expect(summary.text).toContain("lines=42(diff-numstat)");
+    expect(summary.text).toContain("graph=enabled");
+    expect(summary.text).toContain("candidates=unavailable");
+    expect(summary.text).not.toContain("PROMPT_SECRET");
+    expect(summary.text).not.toContain("diff --git");
+    expect(summary.text).not.toContain("TOKEN");
+    expect(summary.text).not.toContain("src/secret.ts");
+    expect(summary.text).not.toContain("abc123");
+  });
+});

--- a/src/review-orchestration/review-plan.ts
+++ b/src/review-orchestration/review-plan.ts
@@ -1,0 +1,366 @@
+import { createHash } from "node:crypto";
+
+export type GraphValidationPlanStatus = "enabled" | "unavailable" | "skipped" | "applied";
+export type GraphValidationPlanReason =
+  | "config-disabled"
+  | "review-graph-query-not-configured"
+  | "trivial-change-bypass"
+  | "no-graph-blast-radius"
+  | "graph-blast-radius-available"
+  | "validated-findings";
+export type GraphValidationPlanProjection = {
+  status: GraphValidationPlanStatus;
+  reason: GraphValidationPlanReason;
+};
+export type ResolveGraphValidationPlanStatusInput = {
+  configEnabled?: boolean;
+  graphQueryAvailable?: boolean;
+  graphBlastRadiusAvailable?: boolean;
+  trivialChangeBypass?: boolean;
+  finalValidationApplied?: boolean;
+};
+export type CandidateFindingMode = "unavailable" | "shadow" | "preferred";
+export type ReviewPlanStatus = "ready";
+export type DegradedReviewPlanStatus = "degraded";
+
+export type ReviewPlanInput = {
+  task: {
+    taskType: string;
+    routingReason: string;
+  };
+  change: {
+    changedFileCount: number;
+    linesChanged: number;
+    linesChangedSource: string;
+  };
+  budget?: {
+    timeoutSeconds?: number;
+    maxTurns?: number;
+    maxTurnsSource?: string;
+  };
+  context?: {
+    sources?: string[];
+    summary?: string;
+  };
+  gates?: {
+    enabled?: string[];
+    current?: string[];
+  };
+  policy: {
+    publish: string;
+    tools: string;
+    retry: string;
+  };
+  graphValidation?: {
+    status: GraphValidationPlanStatus;
+    reason?: GraphValidationPlanReason | string;
+  };
+  candidateFinding?: {
+    mode: CandidateFindingMode;
+    reason?: string;
+  };
+};
+
+export type ReviewPlan = {
+  status: ReviewPlanStatus;
+  hash: string;
+  task: {
+    taskType: string;
+    routingReason: string;
+  };
+  change: {
+    changedFileCount: number;
+    linesChanged: number;
+    linesChangedSource: string;
+  };
+  budget: {
+    timeoutSeconds?: number;
+    maxTurns?: number;
+    maxTurnsSource?: string;
+  };
+  context: {
+    sources: string[];
+    summary?: string;
+  };
+  gates: {
+    enabled: string[];
+    current: string[];
+  };
+  policy: {
+    publish: string;
+    tools: string;
+    retry: string;
+  };
+  graphValidation: {
+    status: GraphValidationPlanStatus;
+    reason?: GraphValidationPlanReason | string;
+  };
+  candidateFinding: {
+    mode: CandidateFindingMode;
+    reason?: string;
+  };
+};
+
+export type DegradedReviewPlan = {
+  status: DegradedReviewPlanStatus;
+  hash: string;
+  degraded: {
+    reason: string;
+    message?: string;
+  };
+  task: {
+    taskType?: string;
+    routingReason?: string;
+  };
+  graphValidation: {
+    status: "skipped";
+    reason: "review-plan-degraded";
+  };
+  candidateFinding: {
+    mode: "unavailable";
+    reason: "review-plan-degraded";
+  };
+};
+
+export type ReviewPlanBuildResult =
+  | { status: "ready"; plan: ReviewPlan }
+  | { status: "degraded"; plan: DegradedReviewPlan };
+
+export type ReviewPlanDetailsSummary = {
+  label: "Review plan";
+  text: string;
+  status: ReviewPlanStatus | DegradedReviewPlanStatus;
+  hash: string;
+};
+
+type DegradedReviewPlanInput = {
+  reason: string;
+  message?: string;
+  taskType?: string;
+  routingReason?: string;
+};
+
+export function resolveGraphValidationPlanStatus(input: ResolveGraphValidationPlanStatusInput): GraphValidationPlanProjection {
+  if (!input.configEnabled) {
+    return { status: "skipped", reason: "config-disabled" };
+  }
+
+  if (!input.graphQueryAvailable) {
+    return { status: "unavailable", reason: "review-graph-query-not-configured" };
+  }
+
+  if (input.trivialChangeBypass) {
+    return { status: "skipped", reason: "trivial-change-bypass" };
+  }
+
+  if (!input.graphBlastRadiusAvailable) {
+    return { status: "skipped", reason: "no-graph-blast-radius" };
+  }
+
+  if (input.finalValidationApplied) {
+    return { status: "applied", reason: "validated-findings" };
+  }
+
+  return { status: "enabled", reason: "graph-blast-radius-available" };
+}
+
+export function buildReviewPlan(input: ReviewPlanInput): Extract<ReviewPlanBuildResult, { status: "ready" }> {
+  const planWithoutHash = {
+    status: "ready" as const,
+    task: {
+      taskType: input.task.taskType,
+      routingReason: input.task.routingReason,
+    },
+    change: {
+      changedFileCount: input.change.changedFileCount,
+      linesChanged: input.change.linesChanged,
+      linesChangedSource: input.change.linesChangedSource,
+    },
+    budget: normalizeBudget(input.budget),
+    context: normalizeContext(input.context),
+    gates: normalizeGates(input.gates),
+    policy: {
+      publish: input.policy.publish,
+      tools: input.policy.tools,
+      retry: input.policy.retry,
+    },
+    graphValidation: normalizeGraphValidation(input.graphValidation),
+    candidateFinding: normalizeCandidateFinding(input.candidateFinding),
+  };
+  const hash = hashCanonical(planWithoutHash);
+
+  return {
+    status: "ready",
+    plan: {
+      ...planWithoutHash,
+      hash,
+    },
+  };
+}
+
+export function createDegradedReviewPlan(input: DegradedReviewPlanInput): DegradedReviewPlan {
+  const degradedWithoutHash = {
+    status: "degraded" as const,
+    degraded: {
+      reason: input.reason,
+      ...(input.message === undefined ? {} : { message: input.message }),
+    },
+    task: {
+      ...(input.taskType === undefined ? {} : { taskType: input.taskType }),
+      ...(input.routingReason === undefined ? {} : { routingReason: input.routingReason }),
+    },
+    graphValidation: {
+      status: "skipped" as const,
+      reason: "review-plan-degraded" as const,
+    },
+    candidateFinding: {
+      mode: "unavailable" as const,
+      reason: "review-plan-degraded" as const,
+    },
+  };
+  const hash = `degraded-${hashCanonical(degradedWithoutHash).slice(0, 16)}`;
+
+  return {
+    ...degradedWithoutHash,
+    hash,
+  };
+}
+
+export function toReviewPlanDetailsSummary(plan: ReviewPlan | DegradedReviewPlan): ReviewPlanDetailsSummary {
+  if (plan.status === "degraded") {
+    const route = plan.task.routingReason ?? "unknown";
+    const reason = sanitizeSummaryToken(plan.degraded.reason);
+    return {
+      label: "Review plan",
+      status: "degraded",
+      hash: plan.hash,
+      text: boundSummary(`Review plan: degraded hash=${plan.hash} route=${route} reason=${reason} graph=skipped candidates=unavailable`),
+    };
+  }
+
+  return {
+    label: "Review plan",
+    status: "ready",
+    hash: plan.hash,
+    text: boundSummary([
+      `Review plan: ready hash=${plan.hash.slice(0, 12)}`,
+      `route=${sanitizeSummaryToken(plan.task.routingReason)}`,
+      `task=${sanitizeSummaryToken(plan.task.taskType)}`,
+      `files=${plan.change.changedFileCount}`,
+      `lines=${plan.change.linesChanged}(${sanitizeSummaryToken(plan.change.linesChangedSource)})`,
+      `budget=${formatBudget(plan.budget)}`,
+      `gates=${plan.gates.current.length}/${plan.gates.enabled.length}`,
+      `publish=${sanitizeSummaryToken(plan.policy.publish)}`,
+      `graph=${plan.graphValidation.status}`,
+      `candidates=${plan.candidateFinding.mode}`,
+    ].join(" ")),
+  };
+}
+
+function normalizeBudget(input: ReviewPlanInput["budget"]): ReviewPlan["budget"] {
+  if (!input) {
+    return {};
+  }
+
+  return stripUndefinedObject({
+    timeoutSeconds: input.timeoutSeconds,
+    maxTurns: input.maxTurns,
+    maxTurnsSource: input.maxTurnsSource,
+  });
+}
+
+function normalizeContext(input: ReviewPlanInput["context"]): ReviewPlan["context"] {
+  if (!input) {
+    return { sources: [] };
+  }
+
+  return {
+    sources: [...(input.sources ?? [])],
+    ...(input.summary === undefined && "summary" in input ? { summary: input.summary } : input.summary === undefined ? {} : { summary: input.summary }),
+  };
+}
+
+function normalizeGates(input: ReviewPlanInput["gates"]): ReviewPlan["gates"] {
+  return {
+    enabled: [...(input?.enabled ?? [])],
+    current: [...(input?.current ?? [])],
+  };
+}
+
+function normalizeGraphValidation(input: ReviewPlanInput["graphValidation"]): ReviewPlan["graphValidation"] {
+  if (!input) {
+    return resolveGraphValidationPlanStatus({ configEnabled: false });
+  }
+
+  return {
+    status: input.status,
+    ...(input.reason === undefined ? {} : { reason: sanitizeSummaryToken(String(input.reason)) }),
+  };
+}
+
+function normalizeCandidateFinding(input: ReviewPlanInput["candidateFinding"]): ReviewPlan["candidateFinding"] {
+  const mode = input?.mode === "shadow" || input?.mode === "preferred" ? input.mode : "unavailable";
+  return {
+    mode,
+    ...(input?.reason === undefined ? {} : { reason: input.reason }),
+  };
+}
+
+function stripUndefinedObject<T extends Record<string, unknown>>(value: T): T {
+  return Object.fromEntries(Object.entries(value).filter(([, entryValue]) => entryValue !== undefined)) as T;
+}
+
+function hashCanonical(value: unknown): string {
+  return createHash("sha256").update(canonicalJson(value)).digest("hex");
+}
+
+function canonicalJson(value: unknown, path = ""): string {
+  if (value === null) {
+    return "null";
+  }
+
+  if (typeof value === "string" || typeof value === "boolean") {
+    return JSON.stringify(value);
+  }
+
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw new TypeError(`Unsupported non-finite number at ${path || "<root>"}`);
+    }
+    return JSON.stringify(value);
+  }
+
+  if (value === undefined) {
+    throw new TypeError(`Unsupported undefined value at ${path || "<root>"}`);
+  }
+
+  if (typeof value === "bigint" || typeof value === "symbol" || typeof value === "function") {
+    throw new TypeError(`Unsupported ${typeof value} value at ${path || "<root>"}`);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map((item, index) => canonicalJson(item, `${path}[${index}]`)).join(",")}]`;
+  }
+
+  if (typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    const keys = Object.keys(record).sort();
+    return `{${keys.map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key], path ? `${path}.${key}` : key)}`).join(",")}}`;
+  }
+
+  throw new TypeError(`Unsupported value at ${path || "<root>"}`);
+}
+
+function formatBudget(budget: ReviewPlan["budget"]): string {
+  const maxTurns = budget.maxTurns === undefined ? "na" : `${budget.maxTurns}t`;
+  const timeout = budget.timeoutSeconds === undefined ? "na" : `${budget.timeoutSeconds}s`;
+  return `${maxTurns}/${timeout}`;
+}
+
+function sanitizeSummaryToken(value: string): string {
+  return value.replace(/[^a-zA-Z0-9._:-]+/g, "-").slice(0, 48) || "unknown";
+}
+
+function boundSummary(value: string): string {
+  return value.length <= 240 ? value : `${value.slice(0, 239)}…`;
+}


### PR DESCRIPTION
Reviewable split of #139. Adds pure review-plan primitives and tests. Stack base: main.