### PR TITLE
Stack 10: add review support surfaces

### DIFF
--- a/src/execution/config.ts
+++ b/src/execution/config.ts
@@ -125,18 +125,9 @@ const formatterSuggestionsSchema = z
 
 const graphValidationSchema = z
   .object({
-    /** Enable optional second-pass validation for graph-amplified findings. */
     enabled: z.boolean().default(false),
-    /** Maximum graph-amplified findings to validate per review. */
-    maxFindingsToValidate: z.number().int().min(1).max(100).default(10),
-    /** Character budget for graph-validation change context. */
-    contextMaxChars: z.number().int().min(100).max(10000).default(1000),
   })
-  .default({
-    enabled: false,
-    maxFindingsToValidate: 10,
-    contextMaxChars: 1000,
-  });
+  .default({ enabled: false });
 
 const reviewSchema = z
   .object({
@@ -232,11 +223,7 @@ const reviewSchema = z
       command: DEFAULT_FORMATTER_SUGGESTION_COMMAND,
       maxSuggestions: 10,
     },
-    graphValidation: {
-      enabled: false,
-      maxFindingsToValidate: 10,
-      contextMaxChars: 1000,
-    },
+    graphValidation: { enabled: false },
     pathInstructions: [],
     outputLanguage: "en",
   });

--- a/src/execution/executor.ts
+++ b/src/execution/executor.ts
@@ -1,5 +1,5 @@
 import { cp, mkdir, writeFile, stat } from "node:fs/promises";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { $ } from "bun";
 import type { Logger } from "pino";
 import type { GitHubApp } from "../auth/github-app.ts";
@@ -30,9 +30,14 @@ import {
   createAzureFilesWorkspaceDir,
 } from "../jobs/workspace.ts";
 import type { PromptSectionRecord } from "../telemetry/types.ts";
-import type { CandidateVerificationPublicationEvidenceSummary } from "../specialists/candidate-verification-publication-evidence.ts";
 import { TASK_TYPES } from "../llm/task-types.ts";
 import { SMALL_DIFF_REVIEW_BASE_TOOLS } from "../lib/review-routing.ts";
+import {
+  type ReviewCandidateFinding,
+  type ReviewCandidateFindingExecutionResult,
+  type ReviewCandidateFindingRecorder,
+  type ReviewCandidateFindingRejection,
+} from "../review-orchestration/review-candidate-finding.ts";
 
 export function buildSecurityClaudeMd(): string {
   return `# Security Policy
@@ -151,34 +156,6 @@ function normalizeExecutorPhaseTimingsFromResult(params: {
   return fallback.map((phase) => normalizedByName.get(phase.name) ?? phase);
 }
 
-function hasCandidateVerificationPublicationEvidence(
-  summary: CandidateVerificationPublicationEvidenceSummary | undefined,
-): summary is CandidateVerificationPublicationEvidenceSummary {
-  if (!summary) return false;
-  const counts = summary.counts;
-  return Boolean(counts && (
-    counts.attempted > 0 ||
-    counts.allowed > 0 ||
-    counts.denied > 0 ||
-    counts.published > 0 ||
-    counts.skipped > 0 ||
-    counts.failed > 0
-  ));
-}
-
-function withCandidateVerificationPublicationEvidence<T extends ExecutionResult>(
-  result: T,
-  evidence: CandidateVerificationPublicationEvidenceSummary | undefined,
-): T {
-  if (!hasCandidateVerificationPublicationEvidence(evidence)) {
-    return result;
-  }
-  return {
-    ...result,
-    candidateVerificationPublicationEvidence: evidence,
-  };
-}
-
 async function hasGitWorkspace(repoDir: string): Promise<boolean> {
   const result = await $`git -C ${repoDir} rev-parse --is-inside-work-tree`.quiet().nothrow();
   return result.exitCode === 0 && result.stdout.toString().trim() === "true";
@@ -290,6 +267,24 @@ async function buildGitArchiveTransport(params: {
   };
 }
 
+async function hasTrackedSymlinks(repoDir: string): Promise<boolean> {
+  const result = await $`git -C ${repoDir} ls-files -s`.quiet().nothrow();
+  if (result.exitCode !== 0) {
+    return false;
+  }
+  return result.stdout.toString().split(/\r?\n/).some((line) => line.startsWith("120000 "));
+}
+
+async function exportGitWorkingTreeSnapshot(params: {
+  sourceRepoDir: string;
+  workspaceDir: string;
+}): Promise<string> {
+  const repoCwd = join(params.workspaceDir, "repo");
+  await mkdir(repoCwd, { recursive: true });
+  await $`git -C ${params.sourceRepoDir} checkout-index -a -f --prefix=${repoCwd + "/"}`.quiet();
+  return repoCwd;
+}
+
 function filterGitToolsForSnapshot(allowedTools: string[]): string[] {
   return allowedTools.filter((tool) => !tool.startsWith("Bash(git "));
 }
@@ -320,12 +315,21 @@ export async function prepareAgentWorkspace(params: {
       .then((value) => value.trim() === "true")
       .catch(() => false);
     if (sourceIsShallow) {
-      const preparedRepo = await buildGitArchiveTransport({
-        sourceRepoDir: params.sourceRepoDir,
-        workspaceDir: params.workspaceDir,
-      });
-      repoTransport = preparedRepo.repoTransport;
-      allowedTools = filterGitToolsForSnapshot(params.allowedTools);
+      const sourceHasTrackedSymlinks = await hasTrackedSymlinks(params.sourceRepoDir);
+      if (sourceHasTrackedSymlinks) {
+        const preparedRepo = await buildGitArchiveTransport({
+          sourceRepoDir: params.sourceRepoDir,
+          workspaceDir: params.workspaceDir,
+        });
+        repoTransport = preparedRepo.repoTransport;
+        allowedTools = filterGitToolsForSnapshot(params.allowedTools);
+      } else {
+        repoCwd = await exportGitWorkingTreeSnapshot({
+          sourceRepoDir: params.sourceRepoDir,
+          workspaceDir: params.workspaceDir,
+        });
+        allowedTools = filterGitToolsForSnapshot(params.allowedTools);
+      }
     } else {
       const preparedRepo = await buildGitRepoTransport({
         sourceRepoDir: params.sourceRepoDir,
@@ -358,6 +362,139 @@ export async function prepareAgentWorkspace(params: {
   return { repoCwd, repoBundlePath, repoTransport };
 }
 
+type ReviewCandidateFindingCollector = {
+  recorder?: ReviewCandidateFindingRecorder;
+  setArtifactPath: (path: string) => void;
+  result: () => ReviewCandidateFindingExecutionResult | undefined;
+};
+
+const REVIEW_CANDIDATE_FINDING_ARTIFACT_BASENAME = "review-candidate-findings.json";
+const MAX_RETAINED_REVIEW_CANDIDATE_FINDINGS = 100;
+
+export function createReviewCandidateFindingCollector(params: {
+  enabled?: boolean;
+  repo: string;
+  pullNumber?: number;
+  reviewOutputKey?: string;
+  deliveryId?: string;
+  logger: Logger;
+  maxRetainedFindings?: number;
+}): ReviewCandidateFindingCollector {
+  if (!params.enabled) {
+    return {
+      setArtifactPath: () => {},
+      result: () => undefined,
+    };
+  }
+
+  const maxRetainedFindings = Math.max(0, Math.floor(params.maxRetainedFindings ?? MAX_RETAINED_REVIEW_CANDIDATE_FINDINGS));
+  const repo = params.repo;
+  const pullNumber = params.pullNumber ?? 0;
+  const reviewOutputKey = params.reviewOutputKey ?? "";
+  const deliveryId = params.deliveryId;
+  const findings: ReviewCandidateFinding[] = [];
+  const rejections: ReviewCandidateFindingRejection[] = [];
+  let inputCount = 0;
+  let recordedCount = 0;
+  let errorCount = 0;
+  let status: ReviewCandidateFindingExecutionResult["status"] = pullNumber > 0 && reviewOutputKey ? "shadow" : "unavailable";
+  let reason: string | undefined = status === "unavailable" ? "missing-correlation" : undefined;
+  let artifactPath: string | undefined;
+  let artifactBasename: string | undefined;
+  let artifactPresent = false;
+
+  const buildResult = (): ReviewCandidateFindingExecutionResult => ({
+    status,
+    repo,
+    pullNumber,
+    reviewOutputKey,
+    ...(deliveryId ? { deliveryId } : {}),
+    artifactPresent,
+    ...(artifactBasename && artifactPresent ? { artifactBasename } : {}),
+    findings: findings.slice(),
+    rejections: rejections.slice(),
+    counts: {
+      input: inputCount,
+      recorded: recordedCount,
+      rejected: rejections.length,
+      errors: errorCount,
+    },
+    ...(reason ? { reason } : {}),
+  });
+
+  const writeSidecar = async () => {
+    if (!artifactPath || status === "unavailable") {
+      return;
+    }
+
+    const payload = {
+      schemaVersion: 1,
+      repo,
+      pullNumber,
+      reviewOutputKey,
+      ...(deliveryId ? { deliveryId } : {}),
+      counts: buildResult().counts,
+      findings,
+      rejections,
+    };
+
+    try {
+      await writeFile(artifactPath, JSON.stringify(payload, null, 2));
+      artifactPresent = true;
+    } catch (err) {
+      artifactPresent = false;
+      errorCount++;
+      reason = "sidecar-write-failed";
+      params.logger.warn(
+        {
+          event: "review-candidate-finding-sidecar-write-failed",
+          repo,
+          prNumber: pullNumber,
+          reviewOutputKey,
+          deliveryId,
+          counts: buildResult().counts,
+          artifactBasename,
+          err,
+        },
+        "Shadow candidate finding sidecar write failed",
+      );
+    }
+  };
+
+  const recorder: ReviewCandidateFindingRecorder | undefined = status === "unavailable"
+    ? undefined
+    : {
+        recordCandidateFinding: async (finding) => {
+          inputCount++;
+          recordedCount++;
+          if (findings.length < maxRetainedFindings) {
+            findings.push(finding);
+          }
+          await writeSidecar();
+        },
+        recordCandidateFindingRejection: async (rejection) => {
+          inputCount++;
+          rejections.push({ index: rejections.length, reason: rejection.reason });
+          await writeSidecar();
+        },
+        recordCandidateFindingError: async (failureReason) => {
+          errorCount++;
+          status = "degraded";
+          reason = failureReason;
+          await writeSidecar();
+        },
+      };
+
+  return {
+    recorder,
+    setArtifactPath: (path) => {
+      artifactPath = path;
+      artifactBasename = basename(path);
+    },
+    result: () => buildResult(),
+  };
+}
+
 export function createExecutor(deps: {
   githubApp: GitHubApp;
   logger: Logger;
@@ -379,7 +516,36 @@ export function createExecutor(deps: {
       let executorHandoffDurationMs: number | undefined;
       let remoteRuntimeDurationMs: number | undefined;
       let registeredMcpBearerToken: string | undefined;
-      let candidateVerificationPublicationEvidence: CandidateVerificationPublicationEvidenceSummary | undefined;
+      const candidateFindingCollector = createReviewCandidateFindingCollector({
+        enabled: context.enableCandidateFindingTool,
+        repo: `${context.owner}/${context.repo}`,
+        pullNumber: context.prNumber,
+        reviewOutputKey: context.reviewOutputKey,
+        deliveryId: context.deliveryId,
+        logger,
+      });
+      const withCandidateFinding = (result: ExecutionResult): ExecutionResult => {
+        const candidateFinding = candidateFindingCollector.result();
+        if (!candidateFinding) {
+          return result;
+        }
+        logger.info(
+          {
+            event: "review-candidate-finding-executor-result",
+            repo: candidateFinding.repo,
+            prNumber: candidateFinding.pullNumber,
+            reviewOutputKey: candidateFinding.reviewOutputKey,
+            deliveryId: candidateFinding.deliveryId,
+            status: candidateFinding.status,
+            counts: candidateFinding.counts,
+            artifactPresent: candidateFinding.artifactPresent,
+            artifactBasename: candidateFinding.artifactBasename,
+            reason: candidateFinding.reason,
+          },
+          "Shadow candidate finding executor metadata finalized",
+        );
+        return { ...result, candidateFinding };
+      };
 
       try {
         // Load repo config (.kodiai.yml) with defaults
@@ -470,10 +636,6 @@ export function createExecutor(deps: {
           botHandles: context.botHandles,
           reviewOutputKey: context.reviewOutputKey,
           deliveryId: context.deliveryId,
-          candidateVerificationContext: context.candidateVerificationContext,
-          candidateVerificationPublicationEvidenceSink: (summary: CandidateVerificationPublicationEvidenceSummary) => {
-            candidateVerificationPublicationEvidence = summary;
-          },
           logger,
           onPublish: () => {
             published = true;
@@ -489,6 +651,9 @@ export function createExecutor(deps: {
           prDiffForCommentValidation: context.prDiffForCommentValidation,
           enableIssueTools,
           triageConfig,
+          enableCandidateFindingTool: context.enableCandidateFindingTool,
+          candidateFindingRecorder: candidateFindingCollector.recorder,
+          candidateVerificationContext: context.candidateVerificationContext,
         };
 
         // Build allowed tools list
@@ -547,6 +712,7 @@ export function createExecutor(deps: {
           mountBase: "/mnt/kodiai-workspaces",
           jobId: context.deliveryId ?? crypto.randomUUID(),
         });
+        candidateFindingCollector.setArtifactPath(join(workspaceDir, REVIEW_CANDIDATE_FINDING_ARTIFACT_BASENAME));
         await prepareAgentWorkspace({
           sourceRepoDir: context.workspace.dir,
           workspaceDir,
@@ -647,7 +813,7 @@ export function createExecutor(deps: {
           });
           mcpJobRegistry.unregister(mcpBearerToken);
           registeredMcpBearerToken = undefined;
-          return withCandidateVerificationPublicationEvidence({
+          return withCandidateFinding({
             conclusion: "error",
             costUsd: undefined,
             numTurns: undefined,
@@ -666,7 +832,7 @@ export function createExecutor(deps: {
             stopReason: undefined,
             publishEvents: publishEvents.length > 0 ? publishEvents : undefined,
             executorPhaseTimings,
-          }, candidateVerificationPublicationEvidence);
+          });
         }
 
         // Handle job failure
@@ -686,9 +852,6 @@ export function createExecutor(deps: {
             const failedResult = rawResult as Partial<ExecutionResult> & {
               executorPhaseTimings?: unknown;
             };
-            if (hasCandidateVerificationPublicationEvidence(failedResult.candidateVerificationPublicationEvidence)) {
-              candidateVerificationPublicationEvidence = failedResult.candidateVerificationPublicationEvidence;
-            }
             if (typeof failedResult.errorMessage === "string" && failedResult.errorMessage.trim().length > 0) {
               resultErrorMessage = failedResult.errorMessage;
             }
@@ -710,7 +873,7 @@ export function createExecutor(deps: {
           }
           mcpJobRegistry.unregister(mcpBearerToken);
           registeredMcpBearerToken = undefined;
-          return withCandidateVerificationPublicationEvidence({
+          return withCandidateFinding({
             conclusion: "error",
             costUsd: undefined,
             numTurns: undefined,
@@ -729,7 +892,7 @@ export function createExecutor(deps: {
             stopReason: undefined,
             publishEvents: publishEvents.length > 0 ? publishEvents : undefined,
             executorPhaseTimings,
-          }, candidateVerificationPublicationEvidence);
+          });
         }
 
         // succeeded — read result from workspace
@@ -737,9 +900,6 @@ export function createExecutor(deps: {
         const jobResult = rawResult as ExecutionResult & {
           executorPhaseTimings?: unknown;
         };
-        if (hasCandidateVerificationPublicationEvidence(jobResult.candidateVerificationPublicationEvidence)) {
-          candidateVerificationPublicationEvidence = jobResult.candidateVerificationPublicationEvidence;
-        }
         const executorPhaseTimings = normalizeExecutorPhaseTimingsFromResult({
           candidate: jobResult.executorPhaseTimings,
           fallback: buildExecutorPhaseTimings({
@@ -756,7 +916,7 @@ export function createExecutor(deps: {
         registeredMcpBearerToken = undefined;
 
         // Merge published / publishEvents from MCP callbacks (fired during pollUntilComplete)
-        return withCandidateVerificationPublicationEvidence({
+        return withCandidateFinding({
           ...jobResult,
           durationMs: jobResult.durationMs ?? durationMs,
           published: jobResult.published || published,
@@ -768,7 +928,7 @@ export function createExecutor(deps: {
                 ]
               : jobResult.publishEvents,
           executorPhaseTimings,
-        }, candidateVerificationPublicationEvidence);
+        });
       } catch (err) {
         const durationMs = Date.now() - startTime;
         const errorMessage =
@@ -792,7 +952,7 @@ export function createExecutor(deps: {
             : "remote runtime finished but result processing failed",
         });
 
-        return withCandidateVerificationPublicationEvidence({
+        return withCandidateFinding({
           conclusion: "error",
           costUsd: undefined,
           numTurns: undefined,
@@ -808,7 +968,7 @@ export function createExecutor(deps: {
           stopReason: undefined,
           publishEvents: publishEvents.length > 0 ? publishEvents : undefined,
           executorPhaseTimings,
-        }, candidateVerificationPublicationEvidence);
+        });
       }
     },
   };

--- a/src/execution/review-prompt.ts
+++ b/src/execution/review-prompt.ts
@@ -199,7 +199,18 @@ function buildModeInstructions(mode: "standard" | "enhanced"): string {
   ].join("\n");
 }
 
-function buildToolAvailabilityContract(toolNames: string[]): string {
+type PromptCandidateFindingMode = "shadow" | "preferred" | "unavailable";
+
+function normalizePromptCandidateFindingMode(mode: unknown): PromptCandidateFindingMode {
+  return mode === "shadow" || mode === "preferred" ? mode : "unavailable";
+}
+
+function buildToolAvailabilityContract(params: {
+  toolNames: string[];
+  candidateFindingMode?: PromptCandidateFindingMode;
+  candidateFindingToolAvailable?: boolean;
+}): string {
+  const { toolNames, candidateFindingMode = "unavailable", candidateFindingToolAvailable = false } = params;
   if (toolNames.length === 0) {
     return "";
   }
@@ -207,6 +218,20 @@ function buildToolAvailabilityContract(toolNames: string[]): string {
   const uniqueToolNames = [...new Set(toolNames.map((tool) => tool.trim()).filter(Boolean))];
   if (uniqueToolNames.length === 0) {
     return "";
+  }
+
+  if (candidateFindingMode === "preferred" && candidateFindingToolAvailable) {
+    return [
+      "## Tool Availability Contract",
+      "",
+      "The following direct GitHub publish tools are available as audited fallback in this run:",
+      ...uniqueToolNames.map((tool) => `- \`${tool}\``),
+      "",
+      "Prefer the candidate-approved publication path: record findings with the candidate capture tool first and do not duplicate those findings through direct GitHub comments.",
+      "Use direct GitHub publish tools only when candidate capture, approval, or candidate publication is unavailable, degraded, or a tool call fails.",
+      "If direct fallback is used, name the fallback tool and explain the fallback reason in your final result.",
+      "Do NOT claim the GitHub comment tools are unavailable unless a tool call actually returns an error.",
+    ].join("\n");
   }
 
   return [
@@ -219,6 +244,39 @@ function buildToolAvailabilityContract(toolNames: string[]): string {
     "Do NOT claim the GitHub comment tools are unavailable unless a tool call actually returns an error.",
     "If a publish tool call fails, name the tool and quote the exact error in your final result.",
     "Ending the run with unpublished findings before attempting the available publish tools is incorrect.",
+  ].join("\n");
+}
+
+function buildCandidateFindingCaptureSection(params: {
+  toolName?: string;
+  mode?: PromptCandidateFindingMode;
+}): string {
+  const toolName = params.toolName?.trim();
+  const mode = params.mode ?? "unavailable";
+  if (!toolName || mode === "unavailable") {
+    return "";
+  }
+
+  if (mode === "preferred") {
+    return [
+      "## Candidate-Preferred Finding Capture",
+      "",
+      `The candidate-preferred publication path is available through \`${toolName}\`.`,
+      `For every actionable draft finding, call \`${toolName}\` to record every actionable draft finding before using direct GitHub publish tools.`,
+      "Do not publish duplicate direct GitHub comments for findings already recorded as candidates.",
+      "Use direct GitHub publish tools only as audited fallback when candidate capture, approval, or candidate publication is unavailable, degraded, or a candidate tool call fails.",
+      "If you use direct fallback publication, explain the fallback reason in your final text without including raw prompts, raw diffs, raw candidate payloads, or secrets.",
+    ].join("\n");
+  }
+
+  return [
+    "## Shadow Candidate Finding Capture",
+    "",
+    `The optional shadow-only tool available is \`${toolName}\`.`,
+    "This tool records candidate findings for bounded internal analysis only; it does not publish GitHub comments or visible review output.",
+    "It does not replace `mcp__github_inline_comment__create_inline_comment` or `mcp__github_comment__create_comment` for actionable findings.",
+    "If you find actionable issues, you MUST still use the GitHub publish tools described above.",
+    "If candidate capture is unavailable, degraded, or any call fails, ignore candidate-capture failures and continue the review/publication path unchanged.",
   ].join("\n");
 }
 
@@ -1708,6 +1766,8 @@ export function buildReviewPromptDetails(context: {
   structuralImpact?: StructuralImpactPayload | null;
   reviewBoundedness?: ReviewBoundednessContract | null;
   publishToolNames?: string[];
+  candidateFindingToolName?: string;
+  candidateFindingMode?: "shadow" | "preferred" | "unavailable";
   gitDiffInstructionsAvailable?: boolean;
   diffContent?: string;
 }): PromptBuildResult {
@@ -1932,6 +1992,13 @@ export function buildReviewPromptDetails(context: {
   pushBudgetedSection("review-knowledge-context", knowledgeContextLines, REVIEW_SECTION_BUDGETS.knowledgeContext);
 
   const gitDiffInstructionsAvailable = context.gitDiffInstructionsAvailable !== false;
+  const candidateFindingMode = normalizePromptCandidateFindingMode(context.candidateFindingMode);
+  const candidateFindingToolAvailable = Boolean(context.candidateFindingToolName?.trim());
+  const candidatePreferred = candidateFindingMode === "preferred" && candidateFindingToolAvailable;
+  const issueReportingInstruction = candidatePreferred
+    ? "Record actionable draft findings with the candidate capture tool first; use `mcp__github_inline_comment__create_inline_comment` only as audited fallback when candidate capture or approval is unavailable or degraded."
+    : "Use the `mcp__github_inline_comment__create_inline_comment` tool to post inline comments on the specific file and line where the issue occurs.";
+
   const instructionLines: string[] = [
     "## Reading the code",
     "",
@@ -1965,7 +2032,7 @@ export function buildReviewPromptDetails(context: {
     "",
     "## How to report issues",
     "",
-    "Use the `mcp__github_inline_comment__create_inline_comment` tool to post inline comments on the specific file and line where the issue occurs.",
+    issueReportingInstruction,
     "",
     "When you have a concrete fix, include a GitHub suggestion block in your comment body:",
     "",
@@ -1978,9 +2045,21 @@ export function buildReviewPromptDetails(context: {
     "The suggestion block replaces the entire line range (from startLine to line). Make sure the replacement is syntactically complete.",
   ];
 
-  const toolAvailabilityContract = buildToolAvailabilityContract(context.publishToolNames ?? []);
+  const toolAvailabilityContract = buildToolAvailabilityContract({
+    toolNames: context.publishToolNames ?? [],
+    candidateFindingMode,
+    candidateFindingToolAvailable,
+  });
   if (toolAvailabilityContract) {
     instructionLines.push("", toolAvailabilityContract);
+  }
+
+  const candidateFindingCaptureSection = buildCandidateFindingCaptureSection({
+    toolName: context.candidateFindingToolName,
+    mode: candidateFindingMode,
+  });
+  if (candidateFindingCaptureSection) {
+    instructionLines.push("", candidateFindingCaptureSection);
   }
 
   if (context.checkpointEnabled === true) {
@@ -2429,6 +2508,8 @@ export function buildReviewPrompt(context: {
   reviewBoundedness?: ReviewBoundednessContract | null;
   diffContent?: string;
   publishToolNames?: string[];
+  candidateFindingToolName?: string;
+  candidateFindingMode?: "shadow" | "preferred" | "unavailable";
 }): string {
   return buildReviewPromptDetails(context).text;
 }

--- a/src/handlers/mention.ts
+++ b/src/handlers/mention.ts
@@ -2007,7 +2007,6 @@ export function createMentionHandler(deps: {
               posted: formatterResult.posted,
               publisherSkipped: formatterResult.publisherSkipped,
               publisherFailed: formatterResult.publisherFailed,
-              reason: formatterResult.reason,
               partialFailure: formatterResult.partialFailure ?? false,
               visibleReplyPosted,
               visibleReplyFailed,

--- a/src/handlers/review-m070-integration-harness.ts
+++ b/src/handlers/review-m070-integration-harness.ts
@@ -249,13 +249,21 @@ export async function runReviewWithShadowMetrics(options: ReviewWithShadowMetric
     },
   };
 
-  createReviewHandler({
+  createReviewHandler(({
     eventRouter: {
       register: (eventKey, handler) => handlers.set(eventKey, handler),
       dispatch: async () => undefined,
     } as EventRouter,
     jobQueue: {
-      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn({ queuedAtMs: 1, startedAtMs: 1, waitMs: 0 }),
+      enqueue: async <T>(_installationId: number, fn: (metadata: JobQueueRunMetadata) => Promise<T>) => fn({
+        jobId: "job-m070-integration",
+        lane: "review",
+        key: "installation-123:pr-28172",
+        queuedAtMs: 1,
+        startedAtMs: 1,
+        waitMs: 0,
+        setPhase: () => undefined,
+      }),
       getQueueSize: () => 0,
       getPendingCount: () => 0,
       getActiveJobs: getEmptyActiveJobs,
@@ -299,7 +307,7 @@ export async function runReviewWithShadowMetrics(options: ReviewWithShadowMetric
     }),
     shadowSpecialistSubflow: options.shadowSpecialistSubflow ?? (async (input) => createMaliciousShadowResult(input)),
     logger,
-  });
+  }) as Parameters<typeof createReviewHandler>[0] & { shadowSpecialistSubflow?: ReviewWithShadowMetricsOptions["shadowSpecialistSubflow"] });
 
   const handler = handlers.get("pull_request.review_requested");
   if (!handler) {

--- a/src/knowledge/store.ts
+++ b/src/knowledge/store.ts
@@ -59,29 +59,6 @@ function _normalizeDbNumber(value: unknown): number | null {
   return Number.isFinite(normalized) ? normalized : null;
 }
 
-function _normalizeDbInteger(value: unknown, fallback = 0): number {
-  const normalized = _normalizeDbNumber(value);
-  return normalized == null ? fallback : Math.trunc(normalized);
-}
-
-function _normalizeDbText(value: unknown, fallback: string): string {
-  return typeof value === "string" && value.trim().length > 0 ? value : fallback;
-}
-
-function _isValidFindingRecord(finding: FindingRecord): boolean {
-  return Number.isFinite(finding.reviewId)
-    && typeof finding.filePath === "string"
-    && finding.filePath.trim().length > 0
-    && typeof finding.severity === "string"
-    && finding.severity.trim().length > 0
-    && typeof finding.category === "string"
-    && finding.category.trim().length > 0
-    && Number.isFinite(finding.confidence)
-    && typeof finding.title === "string"
-    && finding.title.trim().length > 0
-    && typeof finding.suppressed === "boolean";
-}
-
 export function createKnowledgeStore(opts: {
   sql: Sql;
   logger: Logger;
@@ -90,19 +67,6 @@ export function createKnowledgeStore(opts: {
 
   const store: KnowledgeStore = {
     async recordReview(entry: ReviewRecord): Promise<number> {
-      const repo = _normalizeDbText(entry.repo, "unknown/unknown");
-      const prNumber = _normalizeDbInteger(entry.prNumber, 0);
-      const filesAnalyzed = _normalizeDbInteger(entry.filesAnalyzed, 0);
-      const linesChanged = _normalizeDbInteger(entry.linesChanged, 0);
-      const findingsCritical = _normalizeDbInteger(entry.findingsCritical, 0);
-      const findingsMajor = _normalizeDbInteger(entry.findingsMajor, 0);
-      const findingsMedium = _normalizeDbInteger(entry.findingsMedium, 0);
-      const findingsMinor = _normalizeDbInteger(entry.findingsMinor, 0);
-      const findingsTotal = _normalizeDbInteger(entry.findingsTotal, 0);
-      const suppressionsApplied = _normalizeDbInteger(entry.suppressionsApplied, 0);
-      const durationMs = _normalizeDbNumber(entry.durationMs);
-      const conclusion = _normalizeDbText(entry.conclusion, "unknown");
-
       const [inserted] = await sql`
         INSERT INTO reviews (
           repo, pr_number, head_sha, delivery_id,
@@ -111,11 +75,11 @@ export function createKnowledgeStore(opts: {
           suppressions_applied, config_snapshot,
           duration_ms, model, conclusion
         ) VALUES (
-          ${repo}, ${prNumber}, ${entry.headSha ?? null}, ${entry.deliveryId ?? null},
-          ${filesAnalyzed}, ${linesChanged},
-          ${findingsCritical}, ${findingsMajor}, ${findingsMedium}, ${findingsMinor}, ${findingsTotal},
-          ${suppressionsApplied}, ${entry.configSnapshot ?? null},
-          ${durationMs}, ${entry.model ?? null}, ${conclusion}
+          ${entry.repo}, ${entry.prNumber}, ${entry.headSha ?? null}, ${entry.deliveryId ?? null},
+          ${entry.filesAnalyzed}, ${entry.linesChanged},
+          ${entry.findingsCritical}, ${entry.findingsMajor}, ${entry.findingsMedium}, ${entry.findingsMinor}, ${entry.findingsTotal},
+          ${entry.suppressionsApplied}, ${entry.configSnapshot ?? null},
+          ${entry.durationMs ?? null}, ${entry.model ?? null}, ${entry.conclusion}
         )
         RETURNING id
       `;
@@ -124,14 +88,8 @@ export function createKnowledgeStore(opts: {
 
     async recordFindings(findings: FindingRecord[]): Promise<void> {
       if (findings.length === 0) return;
-      const validFindings = findings.filter(_isValidFindingRecord);
-      const skipped = findings.length - validFindings.length;
-      if (skipped > 0) {
-        logger.warn({ skipped, total: findings.length }, "Knowledge store skipped malformed finding records");
-      }
-      if (validFindings.length === 0) return;
       await sql.begin(async (tx) => {
-        for (const finding of validFindings) {
+        for (const finding of findings) {
           await (tx as unknown as Sql)`
             INSERT INTO findings (
               review_id, file_path, start_line, end_line,

--- a/src/lib/review-utils.ts
+++ b/src/lib/review-utils.ts
@@ -21,6 +21,10 @@ import { summarizeStructuralImpactDegradation } from "../structural-impact/degra
 import type { StructuralImpactPayload } from "../structural-impact/types.ts";
 import type { ReviewBoundednessContract } from "./review-boundedness.ts";
 import type { ReviewFirstPassPayload } from "./review-first-pass.ts";
+import type { ReviewPlanDetailsSummary } from "../review-orchestration/review-plan.ts";
+import type { ReviewReducerDetailsSummary } from "../review-orchestration/review-reducer.ts";
+import type { ReviewCandidateFindingDetailsSummary } from "../review-orchestration/review-candidate-finding.ts";
+import type { ReviewCandidatePublicationRuntimeDetailsSummary } from "../review-orchestration/review-candidate-publication-runtime.ts";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -220,12 +224,6 @@ function formatCandidateVerificationMetadata(value: unknown): string {
     `reviewOutputKey:${metadata.hasReviewOutputKey === true ? "y" : "n"}`,
     `correlationKey:${metadata.hasCorrelationKey === true ? "y" : "n"}`,
   ];
-  const deliveryId = boundedReviewDetailsValue(metadata.deliveryId);
-  const reviewOutputKey = boundedReviewDetailsValue(metadata.reviewOutputKey);
-  const correlationKey = boundedReviewDetailsValue(metadata.correlationKey);
-  if (deliveryId) parts.push(`deliveryIdValue:${deliveryId}`);
-  if (reviewOutputKey) parts.push(`reviewOutputKeyValue:${reviewOutputKey}`);
-  if (correlationKey) parts.push(`correlationKeyValue:${correlationKey}`);
   return parts.join(",");
 }
 
@@ -337,6 +335,164 @@ function formatReviewPlanReviewDetailsLine(summary?: ReviewPlanReviewDetailsForm
   }
 }
 
+function formatReviewPlanDetailsLine(reviewPlan?: ReviewPlanDetailsSummary | null): string[] {
+  try {
+    const text = typeof reviewPlan?.text === "string"
+      ? reviewPlan.text.trim().replace(/\s+/g, " ")
+      : "";
+    return text ? [`- ${text}`] : [];
+  } catch {
+    return [];
+  }
+}
+
+function formatReviewReducerDetailsLine(reviewReducer?: ReviewReducerDetailsSummary | null): string[] {
+  try {
+    const text = typeof reviewReducer?.text === "string"
+      ? reviewReducer.text.trim().replace(/\s+/g, " ")
+      : "";
+    return text ? [`- ${text}`] : [];
+  } catch {
+    return [];
+  }
+}
+
+export function formatReviewCandidateFindingDetailsLine(
+  reviewCandidateFinding?: ReviewCandidateFindingDetailsSummary | null,
+): string[] {
+  try {
+    if (reviewCandidateFinding?.label !== "Review candidates") return [];
+    if (
+      reviewCandidateFinding.status !== "shadow"
+      && reviewCandidateFinding.status !== "unavailable"
+      && reviewCandidateFinding.status !== "degraded"
+    ) {
+      return [];
+    }
+
+    const text = typeof reviewCandidateFinding.text === "string"
+      ? sanitizeReviewCandidateDetailsText(reviewCandidateFinding.text)
+      : "";
+    if (!text || !text.startsWith("Review candidates:")) return [];
+    return [`- ${text}`];
+  } catch {
+    return [];
+  }
+}
+
+function sanitizeReviewCandidateDetailsText(value: string): string {
+  return value
+    .replace(/sk-[a-zA-Z0-9_-]+/g, "redacted")
+    .replace(/gh[pousr]_[a-zA-Z0-9_]+/g, "redacted")
+    .replace(/TOKEN\s*=\s*[^\s]+/gi, "token-redacted")
+    .replace(/PROMPT[_-]?SECRET/gi, "prompt-redacted")
+    .replace(/diff --git/gi, "diff-redacted")
+    .replace(/BEGIN\s+PROMPT/gi, "prompt-redacted")
+    .replace(/system prompt|hidden instructions/gi, "prompt-redacted")
+    .trim()
+    .replace(/\s+/g, " ")
+    .slice(0, 260);
+}
+
+const REVIEW_CANDIDATE_PUBLICATION_MODES = new Set([
+  "candidate-approved",
+  "candidate-approved-partial",
+  "direct-fallback",
+  "fallback-disallowed",
+  "blocked",
+  "degraded",
+]);
+const MAX_REVIEW_CANDIDATE_PUBLICATION_REASONS = 6;
+
+export function formatReviewCandidatePublicationDetailsLine(
+  reviewCandidatePublication?: ReviewCandidatePublicationRuntimeDetailsSummary | null,
+): string[] {
+  try {
+    if (!reviewCandidatePublication) return [];
+    if (reviewCandidatePublication.label !== "Review candidate publication runtime") return [];
+    if (typeof reviewCandidatePublication.text !== "string" || reviewCandidatePublication.text.trim().length === 0) {
+      return [formatMalformedReviewCandidatePublicationDetailsLine()];
+    }
+
+    const normalized = normalizeReviewCandidatePublicationDetailsText(reviewCandidatePublication.text);
+    return normalized ? [`- ${normalized}`] : [formatMalformedReviewCandidatePublicationDetailsLine()];
+  } catch {
+    return [formatMalformedReviewCandidatePublicationDetailsLine()];
+  }
+}
+
+function normalizeReviewCandidatePublicationDetailsText(value: string): string | null {
+  const text = sanitizeReviewCandidatePublicationDetailsText(value);
+  const match = text.match(/^Review candidate publication runtime:\s+(\S+)\s*/);
+  if (!match) return null;
+
+  const rawMode = sanitizeReviewCandidatePublicationToken(match[1] ?? "degraded");
+  const mode = REVIEW_CANDIDATE_PUBLICATION_MODES.has(rawMode) ? rawMode : "degraded";
+  const approved = extractCandidatePublicationCount(text, "approvedRefs");
+  const rewritten = extractCandidatePublicationCount(text, "rewrittenRefs");
+  const published = extractCandidatePublicationCount(text, "candidatePublished");
+  const directFallback = Math.max(
+    extractCandidatePublicationCount(text, "fallbackEvidence"),
+    extractCandidatePublicationCount(text, "directPublished"),
+  );
+  const reasons = formatReviewCandidatePublicationReasons(text);
+
+  return `Review candidate publication: mode=${mode} approved=${approved} rewritten=${rewritten} published=${published} directFallback=${directFallback} reasons=${reasons}`;
+}
+
+function formatMalformedReviewCandidatePublicationDetailsLine(): string {
+  return "- Review candidate publication: mode=degraded approved=0 rewritten=0 published=0 directFallback=0 reasons=malformed-runtime-summary";
+}
+
+function extractCandidatePublicationCount(text: string, key: string): number {
+  const match = text.match(new RegExp(`(?:^|\\s)${key}=(-?\\d+)`));
+  if (!match) return 0;
+  const value = Number.parseInt(match[1] ?? "0", 10);
+  return Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+function formatReviewCandidatePublicationReasons(text: string): string {
+  const marker = "reasons=";
+  const markerIndex = text.indexOf(marker);
+  if (markerIndex < 0) return "none";
+
+  const reasonText = text.slice(markerIndex + marker.length).trim();
+  if (!reasonText || reasonText === "none") return "none";
+
+  const reasons = reasonText
+    .split(",")
+    .map((reason) => sanitizeReviewCandidatePublicationToken(reason))
+    .filter((reason) => reason.length > 0);
+
+  if (reasons.length === 0) return "none";
+
+  const cappedReasons = reasons.slice(0, MAX_REVIEW_CANDIDATE_PUBLICATION_REASONS);
+  const remaining = reasons.length - cappedReasons.length;
+  return remaining > 0 ? `${cappedReasons.join(",")} +${remaining} more` : cappedReasons.join(",");
+}
+
+function sanitizeReviewCandidatePublicationDetailsText(value: string): string {
+  return value
+    .replace(/sk-[a-zA-Z0-9_-]+/g, "redacted")
+    .replace(/gh[pousr]_[a-zA-Z0-9_]+/g, "redacted")
+    .replace(/TOKEN\s*=\s*[^\s]+/gi, "token-redacted")
+    .replace(/PROMPT[_-]?SECRET/gi, "prompt-redacted")
+    .replace(/diff --git/gi, "diff-redacted")
+    .replace(/BEGIN\s+PROMPT/gi, "prompt-redacted")
+    .replace(/system prompt|hidden instructions/gi, "prompt-redacted")
+    .trim()
+    .replace(/\s+/g, " ")
+    .slice(0, 1_000);
+}
+
+function sanitizeReviewCandidatePublicationToken(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9:_-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 64);
+}
 
 function boundedBridgeToken(value: unknown, fallback = "unavailable", maxLength = 160): string {
   const text = boundedReviewDetailsValue(value, maxLength);
@@ -959,6 +1115,10 @@ export function formatReviewDetailsSummary(params: {
   candidateVerificationPublicationEvidence?: CandidateVerificationPublicationEvidenceReviewDetails | null;
   candidatePublicationBridge?: CandidatePublicationBridgeReviewDetails | null;
   reviewPlanSummary?: ReviewPlanReviewDetailsFormatterSummary | null;
+  reviewPlan?: ReviewPlanDetailsSummary | null;
+  reviewReducer?: ReviewReducerDetailsSummary | null;
+  reviewCandidateFinding?: ReviewCandidateFindingDetailsSummary | null;
+  reviewCandidatePublication?: ReviewCandidatePublicationRuntimeDetailsSummary | null;
   prioritization?: {
     findingsScored: number;
     topScore: number | null;
@@ -1001,6 +1161,10 @@ export function formatReviewDetailsSummary(params: {
     candidateVerificationPublicationEvidence,
     candidatePublicationBridge,
     reviewPlanSummary,
+    reviewPlan,
+    reviewReducer,
+    reviewCandidateFinding,
+    reviewCandidatePublication,
     prioritization,
     usageLimit,
     tokenUsage,
@@ -1090,6 +1254,10 @@ export function formatReviewDetailsSummary(params: {
     "<details>",
     "<summary>Review Details</summary>",
     "",
+    ...formatReviewPlanDetailsLine(reviewPlan),
+    ...formatReviewReducerDetailsLine(reviewReducer),
+    ...formatReviewCandidateFindingDetailsLine(reviewCandidateFinding),
+    ...formatReviewCandidatePublicationDetailsLine(reviewCandidatePublication),
     ...primaryReviewDetailLines,
     ...timeoutProgressLines,
     lineCountText,

--- a/src/review-audit/review-output-artifacts.ts
+++ b/src/review-audit/review-output-artifacts.ts
@@ -99,8 +99,8 @@ export type ReviewOutputArtifactsOctokit = {
         pull_number: number;
         per_page?: number;
         page?: number;
-        sort?: string;
-        direction?: string;
+        sort?: "updated" | "created";
+        direction?: "asc" | "desc";
       }): Promise<{ data: ReviewCommentLike[] }>;
       listReviews(args: {
         owner: string;
@@ -117,8 +117,8 @@ export type ReviewOutputArtifactsOctokit = {
         issue_number: number;
         per_page?: number;
         page?: number;
-        sort?: string;
-        direction?: string;
+        sort?: "updated" | "created";
+        direction?: "asc" | "desc";
       }): Promise<{ data: IssueCommentLike[] }>;
     };
   };

--- a/src/review-graph/graph-validation-status.ts
+++ b/src/review-graph/graph-validation-status.ts
@@ -15,7 +15,7 @@ export type GraphValidationPreStatus = {
 export type GraphValidationRuntimeStatus = {
   gate: typeof GRAPH_VALIDATION_GATE;
   gateResult: "skipped" | "unavailable" | "applied" | "failure";
-  reason: "config-disabled" | "graph-context-unavailable" | "validation-applied" | "no-findings-validated" | "validation-failed" | "validation-threw";
+  reason: "config-disabled" | "graph-context-unavailable" | "graph-context-available" | "validation-applied" | "no-findings-validated" | "validation-failed" | "validation-threw";
   enabled: boolean;
   graphContextAvailable: boolean;
   findingCount?: number;

--- a/src/specialists/shadow-specialist.ts
+++ b/src/specialists/shadow-specialist.ts
@@ -379,12 +379,12 @@ function normalizeNonNegativeInteger(value: unknown): number | null {
 }
 
 function detectUnsafeFields(value: unknown): ShadowSpecialistRedactionFlags {
-  const flags = {
+  const flags: { -readonly [K in keyof ShadowSpecialistRedactionFlags]: ShadowSpecialistRedactionFlags[K] } = {
     unsafeFieldCount: 0,
     discardedRawPayload: false,
     discardedPublicationFields: false,
     discardedApprovalFields: false,
-  } satisfies ShadowSpecialistRedactionFlags;
+  };
 
   const visit = (node: unknown): void => {
     if (Array.isArray(node)) {


### PR DESCRIPTION
Stacked split of #139. Adds executor, prompt, review-utils, and audit support surfaces needed by handler wiring.