### PR TITLE
Stack 12: update focused support tests

### DIFF
--- a/src/execution/config.test.ts
+++ b/src/execution/config.test.ts
@@ -43,11 +43,6 @@ test("returns defaults when no .kodiai.yml exists", async () => {
     expect(config.review.focusAreas).toEqual([]);
     expect(config.review.ignoredAreas).toEqual([]);
     expect(config.review.maxComments).toBe(7);
-    expect(config.review.graphValidation).toEqual({
-      enabled: false,
-      maxFindingsToValidate: 10,
-      contextMaxChars: 1000,
-    });
     expect(config.review.prioritization).toEqual({
       severity: 0.45,
       fileRisk: 0.3,
@@ -116,6 +111,78 @@ test("reads and validates .kodiai.yml when present", async () => {
   }
 });
 
+test("defaults review.graphValidation.enabled to false when no config exists", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "kodiai-test-"));
+  try {
+    const { config, warnings } = await loadRepoConfig(dir);
+
+    expect(config.review.graphValidation.enabled).toBe(false);
+    expect(warnings).toEqual([]);
+  } finally {
+    await rm(dir, { recursive: true });
+  }
+});
+
+test("defaults review.graphValidation.enabled to false when review block omits it", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "kodiai-test-"));
+  try {
+    await writeFile(join(dir, ".kodiai.yml"), "review:\n  enabled: true\n");
+    const { config, warnings } = await loadRepoConfig(dir);
+
+    expect(config.review.graphValidation.enabled).toBe(false);
+    expect(warnings).toEqual([]);
+  } finally {
+    await rm(dir, { recursive: true });
+  }
+});
+
+test("parses review.graphValidation.enabled true and false distinctly", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "kodiai-test-"));
+  try {
+    await writeFile(
+      join(dir, ".kodiai.yml"),
+      "review:\n  graphValidation:\n    enabled: true\n",
+    );
+    const enabled = await loadRepoConfig(dir);
+    expect(enabled.config.review.graphValidation.enabled).toBe(true);
+    expect(enabled.warnings).toEqual([]);
+
+    await writeFile(
+      join(dir, ".kodiai.yml"),
+      "review:\n  graphValidation:\n    enabled: false\n",
+    );
+    const disabled = await loadRepoConfig(dir);
+    expect(disabled.config.review.graphValidation.enabled).toBe(false);
+    expect(disabled.warnings).toEqual([]);
+  } finally {
+    await rm(dir, { recursive: true });
+  }
+});
+
+test("invalid review.graphValidation.enabled falls back review section with warning", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "kodiai-test-"));
+  try {
+    for (const enabledYaml of ["'true'", "{}", "[]"]) {
+      await writeFile(
+        join(dir, ".kodiai.yml"),
+        `review:\n  maxComments: 12\n  graphValidation:\n    enabled: ${enabledYaml}\n`,
+      );
+      const { config, warnings } = await loadRepoConfig(dir);
+
+      expect(config.review.graphValidation.enabled).toBe(false);
+      expect(config.review.maxComments).toBe(7);
+      expect(
+        warnings.some((warning) =>
+          warning.section === "review"
+          && warning.issues.some((issue) => issue.includes("graphValidation.enabled")),
+        ),
+      ).toBe(true);
+    }
+  } finally {
+    await rm(dir, { recursive: true });
+  }
+});
+
 test("defaults review.formatterSuggestions when no config exists", async () => {
   const dir = await mkdtemp(join(tmpdir(), "kodiai-test-"));
   try {
@@ -144,110 +211,6 @@ test("defaults review.formatterSuggestions when review block omits it", async ()
     expect(config.review.formatterSuggestions.maxSuggestions).toBe(10);
     expect((config.review.formatterSuggestions as Record<string, unknown>).enabled).toBeUndefined();
     expect(warnings).toEqual([]);
-  } finally {
-    await rm(dir, { recursive: true });
-  }
-});
-
-test("defaults review.graphValidation when review block omits it", async () => {
-  const dir = await mkdtemp(join(tmpdir(), "kodiai-test-"));
-  try {
-    await writeFile(join(dir, ".kodiai.yml"), "review:\n  enabled: true\n");
-    const { config, warnings } = await loadRepoConfig(dir);
-
-    expect(config.review.graphValidation).toEqual({
-      enabled: false,
-      maxFindingsToValidate: 10,
-      contextMaxChars: 1000,
-    });
-    expect(warnings).toEqual([]);
-  } finally {
-    await rm(dir, { recursive: true });
-  }
-});
-
-test("preserves review.graphValidation enabled intent from YAML", async () => {
-  const dir = await mkdtemp(join(tmpdir(), "kodiai-test-"));
-  try {
-    await writeFile(
-      join(dir, ".kodiai.yml"),
-      [
-        "review:",
-        "  graphValidation:",
-        "    enabled: true",
-        "    maxFindingsToValidate: 5",
-        "    contextMaxChars: 2000",
-        "",
-      ].join("\n"),
-    );
-    const { config, warnings } = await loadRepoConfig(dir);
-
-    expect(config.review.graphValidation).toEqual({
-      enabled: true,
-      maxFindingsToValidate: 5,
-      contextMaxChars: 2000,
-    });
-    expect(warnings).toEqual([]);
-  } finally {
-    await rm(dir, { recursive: true });
-  }
-});
-
-test("review.graphValidation fills omitted nested options with defaults", async () => {
-  const dir = await mkdtemp(join(tmpdir(), "kodiai-test-"));
-  try {
-    await writeFile(
-      join(dir, ".kodiai.yml"),
-      "review:\n  graphValidation:\n    enabled: true\n",
-    );
-    const { config, warnings } = await loadRepoConfig(dir);
-
-    expect(config.review.graphValidation).toEqual({
-      enabled: true,
-      maxFindingsToValidate: 10,
-      contextMaxChars: 1000,
-    });
-    expect(warnings).toEqual([]);
-  } finally {
-    await rm(dir, { recursive: true });
-  }
-});
-
-test("invalid review.graphValidation values fall back review section with warning", async () => {
-  const dir = await mkdtemp(join(tmpdir(), "kodiai-test-"));
-  try {
-    await writeFile(
-      join(dir, ".kodiai.yml"),
-      "review:\n  maxComments: 12\n  graphValidation:\n    enabled: sometimes\n",
-    );
-    const invalidEnabled = await loadRepoConfig(dir);
-    expect(invalidEnabled.config.review.maxComments).toBe(7);
-    expect(invalidEnabled.config.review.graphValidation.enabled).toBe(false);
-    expect(invalidEnabled.warnings.some((w) => w.section === "review")).toBe(true);
-
-    await writeFile(
-      join(dir, ".kodiai.yml"),
-      "review:\n  graphValidation:\n    enabled: true\n    maxFindingsToValidate: 0\n",
-    );
-    const invalidMaxFindings = await loadRepoConfig(dir);
-    expect(invalidMaxFindings.config.review.graphValidation).toEqual({
-      enabled: false,
-      maxFindingsToValidate: 10,
-      contextMaxChars: 1000,
-    });
-    expect(invalidMaxFindings.warnings.some((w) => w.section === "review")).toBe(true);
-
-    await writeFile(
-      join(dir, ".kodiai.yml"),
-      "review:\n  graphValidation:\n    enabled: true\n    contextMaxChars: 10001\n",
-    );
-    const invalidContext = await loadRepoConfig(dir);
-    expect(invalidContext.config.review.graphValidation).toEqual({
-      enabled: false,
-      maxFindingsToValidate: 10,
-      contextMaxChars: 1000,
-    });
-    expect(invalidContext.warnings.some((w) => w.section === "review")).toBe(true);
   } finally {
     await rm(dir, { recursive: true });
   }

--- a/src/execution/executor.test.ts
+++ b/src/execution/executor.test.ts
@@ -3,7 +3,7 @@ import { test, expect, afterEach, mock, beforeEach } from "bun:test";
 import { mkdtemp, rm, readFile, writeFile, mkdir, lstat, symlink, stat } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { buildSecurityClaudeMd, createExecutor, prepareAgentWorkspace } from "./executor.ts";
+import { buildSecurityClaudeMd, createExecutor, createReviewCandidateFindingCollector, prepareAgentWorkspace } from "./executor.ts";
 import type { ExecutionContext, ExecutionResult } from "./types.ts";
 import type { GitHubApp } from "../auth/github-app.ts";
 import type { Logger } from "pino";
@@ -359,6 +359,18 @@ function createTestableExecutor(deps: {
       let executorHandoffDurationMs: number | undefined;
       let remoteRuntimeDurationMs: number | undefined;
       let registeredMcpBearerToken: string | undefined;
+      const candidateFindingCollector = createReviewCandidateFindingCollector({
+        enabled: context.enableCandidateFindingTool,
+        repo: `${context.owner}/${context.repo}`,
+        pullNumber: context.prNumber,
+        reviewOutputKey: context.reviewOutputKey,
+        deliveryId: context.deliveryId,
+        logger,
+      });
+      const withCandidateFinding = (result: ExecutionResult): ExecutionResult => {
+        const candidateFinding = candidateFindingCollector.result();
+        return candidateFinding ? { ...result, candidateFinding } : result;
+      };
 
       const buildExecutorPhaseTimings = (params: {
         handoffStatus: "completed" | "degraded" | "unavailable";
@@ -454,21 +466,25 @@ function createTestableExecutor(deps: {
             : (context.enableInlineTools ?? !isMentionEvent);
         const enableCommentTools = context.enableCommentTools ?? !isWriteMode;
 
-        const { buildMcpServers, buildAllowedMcpTools } = await import("./mcp/index.ts");
-        const mcpServers = buildMcpServers({
+        const { buildMcpServerFactories, buildAllowedMcpTools } = await import("./mcp/index.ts");
+        const mcpServerDeps = {
           getOctokit,
           owner: context.owner,
           repo: context.repo,
           prNumber: context.prNumber,
           commentId: context.commentId,
           botHandles: context.botHandles,
+          reviewOutputKey: context.reviewOutputKey,
           deliveryId: context.deliveryId,
           logger,
           onPublish: () => { published = true; },
-          onPublishEvent: (event) => { publishEvents.push(event); },
+          onPublishEvent: (event: import("./types.ts").ExecutionPublishEvent) => { publishEvents.push(event); },
           enableInlineTools,
           enableCommentTools,
-        });
+          enableCandidateFindingTool: context.enableCandidateFindingTool,
+          candidateFindingRecorder: candidateFindingCollector.recorder,
+        };
+        const mcpFactories = buildMcpServerFactories(mcpServerDeps);
 
         const hasGitTools = await $`git -C ${context.workspace.dir} rev-parse --is-inside-work-tree`.quiet().nothrow()
           .then((result) => result.exitCode === 0 && result.stdout.toString().trim() === "true");
@@ -491,7 +507,7 @@ function createTestableExecutor(deps: {
             ? ["Read", "Grep", ...(hasGitTools ? ["Bash(git diff:*)", "Bash(git status:*)"] : [])]
             : ["Read", "Grep", "Glob", ...(hasGitTools ? ["Bash(git diff:*)", "Bash(git log:*)", "Bash(git show:*)", "Bash(git status:*)"] : [])];
         const writeTools = isWriteMode ? ["Edit", "Write", "MultiEdit"] : [];
-        const mcpTools = buildAllowedMcpTools(Object.keys(mcpServers));
+        const mcpTools = buildAllowedMcpTools(Object.keys(mcpFactories));
         const allowedTools = context.allowedToolsOverride ?? [...baseTools, ...writeTools, ...mcpTools];
 
         const { buildPrompt } = await import("./prompt.ts");
@@ -507,6 +523,7 @@ function createTestableExecutor(deps: {
           mountBase: "/mnt/kodiai-workspaces",
           jobId: context.deliveryId ?? crypto.randomUUID(),
         });
+        candidateFindingCollector.setArtifactPath(join(workspaceDir, "review-candidate-findings.json"));
         if (workspaceDir === context.workspace.dir) {
           // Test-harness shortcut only: production always stages into a distinct Azure Files dir.
           await writeFile(join(workspaceDir, "prompt.txt"), prompt);
@@ -523,7 +540,7 @@ function createTestableExecutor(deps: {
             maxTurns,
             allowedTools,
             taskType,
-            mcpServerNames: Object.keys(mcpServers),
+            mcpServerNames: Object.keys(mcpFactories),
             token: context.workspace.token,
           });
         }
@@ -531,12 +548,7 @@ function createTestableExecutor(deps: {
         const mcpBearerToken = Buffer.from(
           crypto.getRandomValues(new Uint8Array(32)),
         ).toString("hex");
-        const factories: Record<string, () => unknown> = {};
-        for (const [name, server] of Object.entries(mcpServers)) {
-          const captured = server;
-          factories[name] = () => captured;
-        }
-        mcpJobRegistry.register(mcpBearerToken, factories as never, (timeoutSeconds + 60) * 1000);
+        mcpJobRegistry.register(mcpBearerToken, mcpFactories as never, (timeoutSeconds + 60) * 1000);
         registeredMcpBearerToken = mcpBearerToken;
 
         const { buildAcaJobSpec } = await import("../jobs/aca-launcher.ts");
@@ -585,7 +597,7 @@ function createTestableExecutor(deps: {
           } catch {}
           mcpJobRegistry.unregister(mcpBearerToken);
           registeredMcpBearerToken = undefined;
-          return {
+          return withCandidateFinding({
             conclusion: "error",
             costUsd: undefined,
             numTurns: undefined,
@@ -610,13 +622,13 @@ function createTestableExecutor(deps: {
               remoteRuntimeDurationMs,
               remoteRuntimeDetail: "remote runtime timed out",
             }),
-          };
+          });
         }
 
         if (status === "failed") {
           mcpJobRegistry.unregister(mcpBearerToken);
           registeredMcpBearerToken = undefined;
-          return {
+          return withCandidateFinding({
             conclusion: "error",
             costUsd: undefined,
             numTurns: undefined,
@@ -638,7 +650,7 @@ function createTestableExecutor(deps: {
               remoteRuntimeDurationMs,
               remoteRuntimeDetail: "remote runtime failed",
             }),
-          };
+          });
         }
 
         const rawResult = await readResultFn(workspaceDir);
@@ -655,7 +667,7 @@ function createTestableExecutor(deps: {
         mcpJobRegistry.unregister(mcpBearerToken);
         registeredMcpBearerToken = undefined;
 
-        return {
+        return withCandidateFinding({
           ...jobResult,
           durationMs: jobResult.durationMs ?? durationMs,
           published: jobResult.published || published,
@@ -664,7 +676,7 @@ function createTestableExecutor(deps: {
               ? [...(jobResult.publishEvents ?? []), ...publishEvents]
               : jobResult.publishEvents,
           executorPhaseTimings,
-        };
+        });
       } catch (err) {
         const durationMs = Date.now() - startTime;
         const errorMessage = err instanceof Error ? err.message : String(err);
@@ -673,7 +685,7 @@ function createTestableExecutor(deps: {
           mcpJobRegistry.unregister(registeredMcpBearerToken);
           registeredMcpBearerToken = undefined;
         }
-        return {
+        return withCandidateFinding({
           conclusion: "error",
           costUsd: undefined,
           numTurns: undefined,
@@ -700,7 +712,7 @@ function createTestableExecutor(deps: {
               ? "remote runtime never started"
               : "remote runtime finished but result processing failed",
           }),
-        };
+        });
       }
     },
   };
@@ -1643,7 +1655,7 @@ test("prepareAgentWorkspace writes a review bundle transport for repos with trac
   }
 });
 
-test("prepareAgentWorkspace uses archive transport for shallow PR workspaces without unshallowing", async () => {
+test("prepareAgentWorkspace snapshots shallow PR workspaces without unshallowing", async () => {
   const tempRoot = await mkdtemp(join(tmpdir(), "kodiai-shallow-bundle-"));
   const bareRepoDir = join(tempRoot, "origin.git");
   const seedRepoDir = join(tempRoot, "seed");
@@ -1688,24 +1700,335 @@ test("prepareAgentWorkspace uses archive transport for shallow PR workspaces wit
 
     expect((await $`git -C ${shallowRepoDir} rev-parse --is-shallow-repository`.quiet().text()).trim()).toBe("true");
     expect(result.repoBundlePath).toBeUndefined();
-    expect(result.repoCwd).toBeUndefined();
+    expect(result.repoCwd).toBe(join(workspaceDir, "repo"));
 
     const rawAgentConfig = await readFile(join(workspaceDir, "agent-config.json"), "utf-8");
     const agentConfig = JSON.parse(rawAgentConfig) as {
       repoCwd?: string;
-      repoTransport?: { kind?: string; archivePath?: string };
-      allowedTools?: string[];
+      repoTransport?: unknown;
     };
 
-    expect(agentConfig.repoCwd).toBeUndefined();
-    expect(agentConfig.repoTransport).toEqual({
-      kind: "working-tree-archive",
-      archivePath: join(workspaceDir, "repo.tar"),
-    });
-    expect(agentConfig.allowedTools).toEqual(["Read", "Grep", "Glob"]);
-    expect((await lstat(join(workspaceDir, "repo.tar"))).isFile()).toBe(true);
-    await expect(stat(join(workspaceDir, "repo"))).rejects.toThrow();
+    expect(agentConfig.repoTransport).toBeUndefined();
+    expect(agentConfig.repoCwd).toBe(join(workspaceDir, "repo"));
+    expect((agentConfig as { allowedTools?: string[] }).allowedTools).toEqual(["Read", "Grep", "Glob"]);
+    expect(await readFile(join(workspaceDir, "repo", "feature.txt"), "utf-8")).toBe("one\ntwo\npr\n");
+    await expect(stat(join(workspaceDir, "repo", ".git"))).rejects.toThrow();
   } finally {
     await Promise.all(cleanupDirs.map((dir) => rm(dir, { recursive: true, force: true })));
+  }
+});
+
+function getMcpToolHandler(server: unknown, toolName: string) {
+  const candidate = server as {
+    instance?: {
+      _registeredTools?: Record<
+        string,
+        {
+          handler: (
+            input: Record<string, unknown>,
+          ) => Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean }>;
+        }
+      >;
+    };
+  };
+
+  const registeredTool = candidate.instance?._registeredTools?.[toolName];
+  if (!registeredTool) {
+    throw new Error(`tool '${toolName}' is not registered`);
+  }
+  return registeredTool.handler;
+}
+
+test("ACA dispatch: candidate finding tool records through shared factory state and returns sidecar metadata", async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), "kodiai-executor-test-"));
+  const config = makeConfig();
+  const logger = makeLogger();
+  const registry = createMcpJobRegistry();
+  let registeredToken: string | undefined;
+
+  const wrappedRegistry = {
+    register: (token: string, factories: never, ttlMs?: number) => {
+      registeredToken = token;
+      registry.register(token, factories, ttlMs);
+    },
+    unregister: registry.unregister.bind(registry),
+    hasToken: registry.hasToken.bind(registry),
+    getFactory: registry.getFactory.bind(registry),
+  };
+
+  const executor = createTestableExecutor({
+    githubApp: makeGithubApp(),
+    logger,
+    config,
+    mcpJobRegistry: wrappedRegistry as never,
+    launchFn: async () => ({ executionName: "exec-candidate" }),
+    pollFn: async () => {
+      const firstFactory = registry.getFactory(registeredToken!, "review_candidate_finding")!;
+      const secondFactory = registry.getFactory(registeredToken!, "review_candidate_finding")!;
+      expect(firstFactory).toBeFunction();
+      expect(secondFactory).toBeFunction();
+
+      const firstServer = firstFactory();
+      const secondServer = secondFactory();
+      expect(firstServer).not.toBe(secondServer);
+      const firstHandler = getMcpToolHandler(firstServer, "record_candidate_finding");
+      const secondHandler = getMcpToolHandler(secondServer, "record_candidate_finding");
+      await firstHandler({
+        filePath: "src/feature.ts",
+        startLine: 10,
+        severity: "major",
+        category: "correctness",
+        title: "Candidate issue",
+        body: "This is a shadow-only candidate body.",
+      });
+      await secondHandler({
+        filePath: "src/feature.ts",
+        startLine: 11,
+        severity: "minor",
+        category: "style",
+        title: "Second candidate",
+        body: "This verifies fresh factory instances share executor collector state.",
+      });
+      return { status: "succeeded", durationMs: 1000 };
+    },
+    readResultFn: async () => makeJobResult({ published: false }),
+    createWorkspaceDirFn: async () => tmpDir!,
+  });
+
+  const result = await executor.execute(makeContext(tmpDir!, {
+    enableCandidateFindingTool: true,
+    reviewOutputKey: "review-key-1",
+    deliveryId: "delivery-candidate-1",
+  }));
+
+  const rawAgentConfig = await readFile(join(tmpDir!, "agent-config.json"), "utf-8");
+  const agentConfig = JSON.parse(rawAgentConfig) as { allowedTools: string[] };
+  expect(agentConfig.allowedTools).toContain("mcp__review_candidate_finding__record_candidate_finding");
+  expect(result.published).toBe(false);
+  expect(result.candidateFinding).toEqual(expect.objectContaining({
+    status: "shadow",
+    repo: "xbmc/xbmc",
+    pullNumber: 1,
+    reviewOutputKey: "review-key-1",
+    deliveryId: "delivery-candidate-1",
+    artifactPresent: true,
+    artifactBasename: "review-candidate-findings.json",
+    counts: { input: 2, recorded: 2, rejected: 0, errors: 0 },
+  }));
+  expect(result.candidateFinding?.findings.map((finding) => finding.title)).toEqual([
+    "Candidate issue",
+    "Second candidate",
+  ]);
+  expect(JSON.stringify(result.candidateFinding)).not.toContain(tmpDir!);
+
+  const sidecar = JSON.parse(await readFile(join(tmpDir!, "review-candidate-findings.json"), "utf-8")) as {
+    findings: Array<{ title: string }>;
+  };
+  expect(sidecar.findings.map((finding) => finding.title)).toEqual(["Candidate issue", "Second candidate"]);
+});
+
+test("ACA dispatch: candidate finding result is present with zero calls when enabled", async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), "kodiai-executor-test-"));
+  const executor = createTestableExecutor({
+    githubApp: makeGithubApp(),
+    logger: makeLogger(),
+    config: makeConfig(),
+    mcpJobRegistry: createMcpJobRegistry(),
+    launchFn: async () => ({ executionName: "exec-candidate-zero" }),
+    pollFn: async () => ({ status: "succeeded", durationMs: 1000 }),
+    readResultFn: async () => makeJobResult({ published: false }),
+    createWorkspaceDirFn: async () => tmpDir!,
+  });
+
+  const result = await executor.execute(makeContext(tmpDir!, {
+    enableCandidateFindingTool: true,
+    reviewOutputKey: "review-key-zero",
+  }));
+
+  expect(result.candidateFinding).toEqual(expect.objectContaining({
+    status: "shadow",
+    artifactPresent: false,
+    counts: { input: 0, recorded: 0, rejected: 0, errors: 0 },
+  }));
+});
+
+test("ACA dispatch: candidate finding is disabled by default", async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), "kodiai-executor-test-"));
+  const executor = createTestableExecutor({
+    githubApp: makeGithubApp(),
+    logger: makeLogger(),
+    config: makeConfig(),
+    mcpJobRegistry: createMcpJobRegistry(),
+    launchFn: async () => ({ executionName: "exec-candidate-disabled" }),
+    pollFn: async () => ({ status: "succeeded", durationMs: 1000 }),
+    readResultFn: async () => makeJobResult({ published: false }),
+    createWorkspaceDirFn: async () => tmpDir!,
+  });
+
+  const result = await executor.execute(makeContext(tmpDir!, {
+    reviewOutputKey: "review-key-disabled",
+  }));
+
+  const rawAgentConfig = await readFile(join(tmpDir!, "agent-config.json"), "utf-8");
+  const agentConfig = JSON.parse(rawAgentConfig) as { allowedTools: string[] };
+  expect(agentConfig.allowedTools).not.toContain("mcp__review_candidate_finding__record_candidate_finding");
+  expect(result.candidateFinding).toBeUndefined();
+});
+
+test("ACA dispatch: candidate finding enabled without correlation returns unavailable metadata", async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), "kodiai-executor-test-"));
+  const executor = createTestableExecutor({
+    githubApp: makeGithubApp(),
+    logger: makeLogger(),
+    config: makeConfig(),
+    mcpJobRegistry: createMcpJobRegistry(),
+    launchFn: async () => ({ executionName: "exec-candidate-missing-correlation" }),
+    pollFn: async () => ({ status: "succeeded", durationMs: 1000 }),
+    readResultFn: async () => makeJobResult({ published: false }),
+    createWorkspaceDirFn: async () => tmpDir!,
+  });
+
+  const result = await executor.execute(makeContext(tmpDir!, {
+    enableCandidateFindingTool: true,
+    reviewOutputKey: undefined,
+  }));
+
+  expect(result.candidateFinding).toEqual(expect.objectContaining({
+    status: "unavailable",
+    reason: "missing-correlation",
+    artifactPresent: false,
+    counts: { input: 0, recorded: 0, rejected: 0, errors: 0 },
+  }));
+});
+
+test("ACA dispatch: malformed candidate input increments rejected count without failing execution", async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), "kodiai-executor-test-"));
+  const registry = createMcpJobRegistry();
+  let registeredToken: string | undefined;
+  const wrappedRegistry = {
+    register: (token: string, factories: never, ttlMs?: number) => {
+      registeredToken = token;
+      registry.register(token, factories, ttlMs);
+    },
+    unregister: registry.unregister.bind(registry),
+    hasToken: registry.hasToken.bind(registry),
+    getFactory: registry.getFactory.bind(registry),
+  };
+
+  const executor = createTestableExecutor({
+    githubApp: makeGithubApp(),
+    logger: makeLogger(),
+    config: makeConfig(),
+    mcpJobRegistry: wrappedRegistry as never,
+    launchFn: async () => ({ executionName: "exec-candidate-rejected" }),
+    pollFn: async () => {
+      const factory = registry.getFactory(registeredToken!, "review_candidate_finding")!;
+      const handler = getMcpToolHandler(factory(), "record_candidate_finding");
+      await handler({
+        filePath: "../secret.ts",
+        startLine: 1,
+        title: "Unsafe path",
+        body: "Body",
+      });
+      return { status: "succeeded", durationMs: 1000 };
+    },
+    readResultFn: async () => makeJobResult({ published: false }),
+    createWorkspaceDirFn: async () => tmpDir!,
+  });
+
+  const result = await executor.execute(makeContext(tmpDir!, {
+    enableCandidateFindingTool: true,
+    reviewOutputKey: "review-key-rejected",
+  }));
+
+  expect(result.conclusion).toBe("success");
+  expect(result.published).toBe(false);
+  expect(result.candidateFinding).toEqual(expect.objectContaining({
+    status: "shadow",
+    counts: { input: 1, recorded: 0, rejected: 1, errors: 0 },
+  }));
+  expect(result.candidateFinding?.rejections).toEqual([{ index: 0, reason: "unsafe-file-path" }]);
+});
+
+test("ACA dispatch: candidate sidecar write failure preserves in-memory candidate findings", async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), "kodiai-executor-test-"));
+  const registry = createMcpJobRegistry();
+  let registeredToken: string | undefined;
+  const wrappedRegistry = {
+    register: (token: string, factories: never, ttlMs?: number) => {
+      registeredToken = token;
+      registry.register(token, factories, ttlMs);
+    },
+    unregister: registry.unregister.bind(registry),
+    hasToken: registry.hasToken.bind(registry),
+    getFactory: registry.getFactory.bind(registry),
+  };
+
+  const executor = createTestableExecutor({
+    githubApp: makeGithubApp(),
+    logger: makeLogger(),
+    config: makeConfig(),
+    mcpJobRegistry: wrappedRegistry as never,
+    launchFn: async () => ({ executionName: "exec-candidate-sidecar-failure" }),
+    pollFn: async () => {
+      await rm(tmpDir!, { recursive: true, force: true });
+      const factory = registry.getFactory(registeredToken!, "review_candidate_finding")!;
+      const handler = getMcpToolHandler(factory(), "record_candidate_finding");
+      await handler({
+        filePath: "src/feature.ts",
+        startLine: 10,
+        title: "Candidate issue",
+        body: "Body",
+      });
+      return { status: "succeeded", durationMs: 1000 };
+    },
+    readResultFn: async () => makeJobResult({ published: false }),
+    createWorkspaceDirFn: async () => tmpDir!,
+  });
+
+  const result = await executor.execute(makeContext(tmpDir!, {
+    enableCandidateFindingTool: true,
+    reviewOutputKey: "review-key-sidecar-failure",
+  }));
+
+  expect(result.conclusion).toBe("success");
+  expect(result.published).toBe(false);
+  expect(result.candidateFinding).toEqual(expect.objectContaining({
+    status: "shadow",
+    artifactPresent: false,
+    counts: { input: 1, recorded: 1, rejected: 0, errors: 1 },
+    reason: "sidecar-write-failed",
+  }));
+  expect(result.candidateFinding?.findings).toHaveLength(1);
+  expect(result.candidateFinding?.findings[0]?.title).toBe("Candidate issue");
+  tmpDir = undefined;
+});
+
+test("ACA dispatch: timeout, failed, and local error paths include candidate metadata", async () => {
+  for (const scenario of ["timed-out", "failed", "local-error"] as const) {
+    tmpDir = await mkdtemp(join(tmpdir(), `kodiai-executor-${scenario}-`));
+    const executor = createTestableExecutor({
+      githubApp: makeGithubApp(),
+      logger: makeLogger(),
+      config: makeConfig(),
+      mcpJobRegistry: createMcpJobRegistry(),
+      launchFn: scenario === "local-error" ? async () => { throw new Error("launch failed"); } : async () => ({ executionName: `exec-${scenario}` }),
+      pollFn: async () => ({ status: scenario === "failed" ? "failed" : "timed-out", durationMs: 1000 }),
+      cancelFn: async () => {},
+      createWorkspaceDirFn: async () => tmpDir!,
+    });
+
+    const result = await executor.execute(makeContext(tmpDir!, {
+      enableCandidateFindingTool: true,
+      reviewOutputKey: `review-key-${scenario}`,
+    }));
+
+    expect(result.conclusion).toBe("error");
+    expect(result.candidateFinding).toEqual(expect.objectContaining({
+      reviewOutputKey: `review-key-${scenario}`,
+      counts: { input: 0, recorded: 0, rejected: 0, errors: 0 },
+    }));
+    await rm(tmpDir!, { recursive: true, force: true });
+    tmpDir = undefined;
   }
 });

--- a/src/execution/prepare-agent-workspace.test.ts
+++ b/src/execution/prepare-agent-workspace.test.ts
@@ -193,7 +193,7 @@ test("prepareAgentWorkspace uses archive transport for shallow repos with tracke
   await expect(stat(join(workspaceDir, "repo"))).rejects.toThrow();
 });
 
-test("prepareAgentWorkspace uses archive transport for shallow PR workspaces without unshallowing", async () => {
+test("prepareAgentWorkspace snapshots shallow PR workspaces without unshallowing", async () => {
   const tempRoot = await makeTempDir("kodiai-shallow-bundle-");
   const bareRepoDir = join(tempRoot, "origin.git");
   const seedRepoDir = join(tempRoot, "seed");
@@ -236,21 +236,17 @@ test("prepareAgentWorkspace uses archive transport for shallow PR workspaces wit
 
   expect((await $`git -C ${shallowRepoDir} rev-parse --is-shallow-repository`.quiet().text()).trim()).toBe("true");
   expect(result.repoBundlePath).toBeUndefined();
-  expect(result.repoCwd).toBeUndefined();
+  expect(result.repoCwd).toBe(join(workspaceDir, "repo"));
 
   const rawAgentConfig = await readFile(join(workspaceDir, "agent-config.json"), "utf-8");
   const agentConfig = JSON.parse(rawAgentConfig) as {
     repoCwd?: string;
-    repoTransport?: { kind?: string; archivePath?: string };
-    allowedTools?: string[];
+    repoTransport?: unknown;
   };
 
-  expect(agentConfig.repoCwd).toBeUndefined();
-  expect(agentConfig.repoTransport).toEqual({
-    kind: "working-tree-archive",
-    archivePath: join(workspaceDir, "repo.tar"),
-  });
-  expect(agentConfig.allowedTools).toEqual(["Read", "Grep", "Glob"]);
-  expect((await lstat(join(workspaceDir, "repo.tar"))).isFile()).toBe(true);
-  await expect(stat(join(workspaceDir, "repo"))).rejects.toThrow();
+  expect(agentConfig.repoTransport).toBeUndefined();
+  expect(agentConfig.repoCwd).toBe(join(workspaceDir, "repo"));
+  expect((agentConfig as { allowedTools?: string[] }).allowedTools).toEqual(["Read", "Grep", "Glob"]);
+  expect(await readFile(join(workspaceDir, "repo", "feature.txt"), "utf-8")).toBe("one\ntwo\npr\n");
+  await expect(stat(join(workspaceDir, "repo", ".git"))).rejects.toThrow();
 });

--- a/src/execution/review-prompt.test.ts
+++ b/src/execution/review-prompt.test.ts
@@ -792,6 +792,104 @@ test("buildReviewPrompt omits tool availability contract when publish tools are 
   expect(prompt).not.toContain("## Tool Availability Contract");
 });
 
+
+test("buildReviewPrompt renders candidate finding as separate optional shadow capture section", () => {
+  const prompt = buildReviewPrompt(
+    baseContext({
+      publishToolNames: [
+        "mcp__github_comment__create_comment",
+        "mcp__github_inline_comment__create_inline_comment",
+      ],
+      candidateFindingToolName: "record_candidate_finding",
+      candidateFindingMode: "shadow",
+    }),
+  );
+
+  const publishSection = prompt.match(/## Tool Availability Contract[\s\S]*?(?=\n## |$)/)?.[0] ?? "";
+  const candidateSection = prompt.match(/## Shadow Candidate Finding Capture[\s\S]*?(?=\n## |$)/)?.[0] ?? "";
+
+  expect(candidateSection).toContain("record_candidate_finding");
+  expect(candidateSection).toContain("optional");
+  expect(candidateSection).toContain("shadow-only");
+  expect(candidateSection).toContain("does not publish");
+  expect(candidateSection).toContain("does not replace");
+  expect(candidateSection).toContain("ignore candidate-capture failures");
+  expect(candidateSection).toContain("unavailable");
+  expect(publishSection).toContain("mcp__github_comment__create_comment");
+  expect(publishSection).toContain("mcp__github_inline_comment__create_inline_comment");
+  expect(publishSection).toContain("MUST attempt the available publish tools");
+  expect(publishSection).not.toContain("record_candidate_finding");
+});
+
+test("buildReviewPrompt prefers candidate finding capture over duplicate direct publication", () => {
+  const prompt = buildReviewPrompt(
+    baseContext({
+      publishToolNames: [
+        "mcp__github_comment__create_comment",
+        "mcp__github_inline_comment__create_inline_comment",
+      ],
+      candidateFindingToolName: "record_candidate_finding",
+      candidateFindingMode: "preferred",
+    }),
+  );
+
+  const publishSection = prompt.match(/## Tool Availability Contract[\s\S]*?(?=\n## |$)/)?.[0] ?? "";
+  const candidateSection = prompt.match(/## Candidate-Preferred Finding Capture[\s\S]*?(?=\n## |$)/)?.[0] ?? "";
+
+  expect(candidateSection).toContain("record_candidate_finding");
+  expect(candidateSection).toContain("candidate-preferred publication path");
+  expect(candidateSection).toContain("record every actionable draft finding before using direct GitHub publish tools");
+  expect(candidateSection).toContain("Do not publish duplicate direct GitHub comments for findings already recorded as candidates");
+  expect(candidateSection).toContain("explain the fallback reason in your final text");
+  expect(publishSection).toContain("audited fallback");
+  expect(publishSection).not.toContain("MUST attempt the available publish tools before ending the run");
+  expect(prompt).not.toContain("## Shadow Candidate Finding Capture");
+});
+
+test("buildReviewPrompt degrades preferred candidate mode when the candidate tool is unavailable", () => {
+  const prompt = buildReviewPrompt(
+    baseContext({
+      publishToolNames: ["mcp__github_inline_comment__create_inline_comment"],
+      candidateFindingMode: "preferred",
+    }),
+  );
+
+  const publishSection = prompt.match(/## Tool Availability Contract[\s\S]*?(?=\n## |$)/)?.[0] ?? "";
+
+  expect(prompt).not.toContain("## Candidate-Preferred Finding Capture");
+  expect(prompt).not.toContain("record every actionable draft finding before using direct GitHub publish tools");
+  expect(publishSection).toContain("MUST attempt the available publish tools");
+});
+
+test("buildReviewPrompt treats unknown candidate mode as unavailable", () => {
+  const prompt = buildReviewPrompt(
+    baseContext({
+      publishToolNames: ["mcp__github_inline_comment__create_inline_comment"],
+      candidateFindingToolName: "record_candidate_finding",
+      candidateFindingMode: "surprise-mode",
+    }),
+  );
+
+  expect(prompt).toContain("## Tool Availability Contract");
+  expect(prompt).not.toContain("## Candidate-Preferred Finding Capture");
+  expect(prompt).not.toContain("## Shadow Candidate Finding Capture");
+});
+
+test("buildReviewPrompt omits optional candidate finding section when candidate fields are absent", () => {
+  const prompt = buildReviewPrompt(
+    baseContext({
+      publishToolNames: [
+        "mcp__github_comment__create_comment",
+        "mcp__github_inline_comment__create_inline_comment",
+      ],
+    }),
+  );
+
+  expect(prompt).toContain("## Tool Availability Contract");
+  expect(prompt).not.toContain("## Shadow Candidate Finding Capture");
+  expect(prompt).not.toContain("record_candidate_finding");
+});
+
 test("buildReviewPrompt includes suppression section when suppressions provided", () => {
   const prompt = buildReviewPrompt(
     baseContext({

--- a/src/lib/review-utils.test.ts
+++ b/src/lib/review-utils.test.ts
@@ -2,8 +2,10 @@ import { describe, it, expect } from "bun:test";
 import { formatReviewDetailsSummary } from "./review-utils.ts";
 import type { ReviewFirstPassPayload } from "./review-first-pass.ts";
 import { projectContributorExperienceContract } from "../contributor/experience-contract.ts";
-import { projectReviewHandlerCandidatePublicationBridgeEvidence } from "../issue-131/review-handler-publication-bridge.ts";
-import type { CandidateVerificationPublicationEvidenceSummary } from "../specialists/candidate-verification-publication-evidence.ts";
+import type { ReviewPlanDetailsSummary } from "../review-orchestration/review-plan.ts";
+import type { ReviewReducerDetailsSummary } from "../review-orchestration/review-reducer.ts";
+import type { ReviewCandidateFindingDetailsSummary } from "../review-orchestration/review-candidate-finding.ts";
+import type { ReviewCandidatePublicationRuntimeDetailsSummary } from "../review-orchestration/review-candidate-publication-runtime.ts";
 
 const BOUNDED_TIMEOUT_FIRST_PASS: ReviewFirstPassPayload = {
   state: "bounded-first-pass",
@@ -35,77 +37,239 @@ const BASE_PARAMS = {
   }).reviewDetails,
 };
 
-const M072_CANARIES = [
-  "M072_RAW_CANDIDATE_BODY_SHOULD_NOT_LEAK",
-  "M072_SPECIALIST_PROSE_SHOULD_NOT_LEAK",
-  "M072_PROMPT_SHOULD_NOT_LEAK",
-  "M072_MODEL_OUTPUT_SHOULD_NOT_LEAK",
-  "M072_DIFF_SHOULD_NOT_LEAK",
-  "M072_FINGERPRINT_SHOULD_NOT_LEAK",
-  "M072_GITHUB_COMMENT_BODY_SHOULD_NOT_LEAK",
-] as const;
-
-function candidatePublicationSummary(
-  overrides: Partial<CandidateVerificationPublicationEvidenceSummary> = {},
-): CandidateVerificationPublicationEvidenceSummary {
-  return {
-    aggregateStatus: "published",
-    counts: { attempted: 1, allowed: 1, denied: 0, published: 1, skipped: 0, failed: 0 },
-    publicationDenialCounts: {},
-    reasonCategories: ["full-support"],
-    verificationStateCounts: { verified: 1, partially_verified: 0, unverified: 0, disproven: 0, unavailable: 0 },
-    candidateVerificationCounts: {
-      candidateCount: 1,
-      evidenceCount: 2,
-      verifiedCount: 1,
-      partiallyVerifiedCount: 0,
-      unverifiedCount: 0,
-      disprovenCount: 0,
-      publicationEligibleCount: 1,
-      duplicateCount: 0,
-      disagreementCount: 0,
-      unclassifiableCount: 0,
-      malformedRecordCount: 0,
-      truncatedCandidateCount: 0,
-      truncatedEvidenceCount: 0,
-      policyCandidateCount: 1,
-    },
-    metadata: {
-      hasDeliveryId: true,
-      hasReviewOutputKey: true,
-      hasCorrelationKey: true,
-      deliveryId: "delivery-123",
-      reviewOutputKey: "review-output-456",
-      correlationKey: "correlation-789",
-    },
-    redactionFlags: {
-      privateOnly: true,
-      candidateBodiesIncluded: false,
-      specialistProseIncluded: false,
-      rawPromptsIncluded: false,
-      rawModelOutputIncluded: false,
-      diffsIncluded: false,
-      evidencePayloadsIncluded: false,
-      rawFingerprintsIncluded: false,
-      unsafeInputFieldCount: 0,
-      discardedRawPayload: false,
-      discardedPublicationFields: false,
-      discardedEvidencePayloads: false,
-      candidateAttemptIncluded: false,
-      candidateKeyIncluded: false,
-      publicationEvidenceIncluded: false,
-    },
-    ...overrides,
-  };
+function reviewPlanLineCount(body: string): number {
+  return body.split("\n").filter((line) => line.includes("Review plan:")).length;
 }
 
-function expectNoM072CanaryLeak(value: string): void {
-  for (const canary of M072_CANARIES) {
-    expect(value).not.toContain(canary);
-  }
+function reviewReducerLineCount(body: string): number {
+  return body.split("\n").filter((line) => line.includes("Review reducer:")).length;
+}
+
+function reviewCandidateLineCount(body: string): number {
+  return body.split("\n").filter((line) => line.includes("Review candidates:")).length;
+}
+
+function reviewCandidatePublicationLineCount(body: string): number {
+  return body.split("\n").filter((line) => line.includes("Review candidate publication:")).length;
 }
 
 describe("formatReviewDetailsSummary", () => {
+  it("renders exactly one compact ready review plan line without dumping structured plan data", () => {
+    const result = formatReviewDetailsSummary({
+      ...BASE_PARAMS,
+      reviewPlan: {
+        label: "Review plan",
+        status: "ready",
+        hash: "abcdef1234567890",
+        text: "Review plan: ready hash=abcdef123456 route=standard task=review.full files=4 lines=212(local-diff) budget=na/900s gates=1/2 publish=inline+summary graph=enabled candidates=shadow",
+      } satisfies ReviewPlanDetailsSummary,
+    });
+
+    expect(reviewPlanLineCount(result)).toBe(1);
+    expect(result).toContain("- Review plan: ready hash=abcdef123456 route=standard task=review.full files=4 lines=212(local-diff) budget=na/900s gates=1/2 publish=inline+summary graph=enabled candidates=shadow");
+    expect(result).not.toContain("{\"");
+    expect(result).not.toContain("routing:");
+    expect(result).not.toContain("diff --git");
+    expect(result).not.toContain("prompt text");
+  });
+
+  it("renders exactly one compact degraded review plan line without throwing on missing hash or unknown projection fields", () => {
+    const result = formatReviewDetailsSummary({
+      ...BASE_PARAMS,
+      reviewPlan: {
+        label: "Review plan",
+        status: "degraded",
+        text: "Review plan: degraded route=unknown reason=builder-error graph=skipped candidates=unavailable",
+        routing: { prompt: "prompt text", diff: "diff --git a/secret b/secret" },
+      } as never,
+    });
+
+    expect(reviewPlanLineCount(result)).toBe(1);
+    expect(result).toContain("- Review plan: degraded route=unknown reason=builder-error graph=skipped candidates=unavailable");
+    expect(result).not.toContain("{\"");
+    expect(result).not.toContain("routing:");
+    expect(result).not.toContain("diff --git");
+    expect(result).not.toContain("prompt text");
+  });
+
+  it("preserves no-plan Review Details output and marker placement when reviewPlan is omitted", () => {
+    const completedAt = "2026-04-22T20:15:00.000Z";
+    const result = formatReviewDetailsSummary({ ...BASE_PARAMS, completedAt });
+
+    expect(reviewPlanLineCount(result)).toBe(0);
+    expect(result).not.toContain("Review plan:");
+    expect(result).toContain("- Review completed: 2026-04-22T20:15:00.000Z");
+    expect(result).toContain("\n\n</details>\n\n<!-- kodiai:review-details:test-key-001 -->");
+  });
+
+  it("renders exactly one compact review reducer line next to the review plan line", () => {
+    const result = formatReviewDetailsSummary({
+      ...BASE_PARAMS,
+      reviewPlan: {
+        label: "Review plan",
+        status: "ready",
+        hash: "abcdef1234567890",
+        text: "Review plan: ready hash=abcdef123456 route=standard task=review.full files=4 lines=212(local-diff) budget=na/900s gates=1/2 publish=inline+summary graph=enabled candidates=shadow",
+      } satisfies ReviewPlanDetailsSummary,
+      reviewReducer: {
+        label: "Review reducer",
+        status: "ready",
+        text: "Review reducer: ready input=2 kept=1 suppressed=1 rewritten=0 deprioritized=0 lowConfidence=0 auditEvents=1 severityDemoted=0 graphValidated=1 graphUncertain=0",
+      } satisfies ReviewReducerDetailsSummary,
+    });
+
+    expect(reviewPlanLineCount(result)).toBe(1);
+    expect(reviewReducerLineCount(result)).toBe(1);
+    expect(result.indexOf("Review plan:")).toBeLessThan(result.indexOf("Review reducer:"));
+    expect(result).toContain("- Review reducer: ready input=2 kept=1 suppressed=1 rewritten=0 deprioritized=0 lowConfidence=0 auditEvents=1 severityDemoted=0 graphValidated=1 graphUncertain=0");
+    expect(result).not.toContain("diff --git");
+    expect(result).not.toContain("prompt text");
+  });
+
+  it("renders exactly one compact review candidate line after plan and reducer lines", () => {
+    const result = formatReviewDetailsSummary({
+      ...BASE_PARAMS,
+      reviewPlan: {
+        label: "Review plan",
+        status: "ready",
+        hash: "abcdef1234567890",
+        text: "Review plan: ready hash=abcdef123456 route=standard task=review.full files=4 lines=212(local-diff) budget=na/900s gates=1/2 publish=inline+summary graph=enabled candidates=shadow",
+      } satisfies ReviewPlanDetailsSummary,
+      reviewReducer: {
+        label: "Review reducer",
+        status: "ready",
+        text: "Review reducer: ready input=2 kept=1 suppressed=1 rewritten=0 deprioritized=0 lowConfidence=0 auditEvents=1 severityDemoted=0 graphValidated=1 graphUncertain=0",
+      } satisfies ReviewReducerDetailsSummary,
+      reviewCandidateFinding: {
+        label: "Review candidates",
+        status: "shadow",
+        text: "Review candidates: shadow recorded=1 rejected=0 errors=0 artifact=present repo=owner-repo pr=42 key=review-output-abc123 delivery=delivery-001",
+      } satisfies ReviewCandidateFindingDetailsSummary,
+    });
+
+    expect(reviewCandidateLineCount(result)).toBe(1);
+    expect(result.indexOf("Review plan:")).toBeLessThan(result.indexOf("Review reducer:"));
+    expect(result.indexOf("Review reducer:")).toBeLessThan(result.indexOf("Review candidates:"));
+    expect(result).toContain("- Review candidates: shadow recorded=1 rejected=0 errors=0 artifact=present repo=owner-repo pr=42 key=review-output-abc123 delivery=delivery-001");
+  });
+
+  it("omits candidate metadata when omitted or malformed without breaking Review Details", () => {
+    const omitted = formatReviewDetailsSummary({ ...BASE_PARAMS });
+    const malformed = formatReviewDetailsSummary({
+      ...BASE_PARAMS,
+      reviewCandidateFinding: {
+        label: "Review candidates",
+        status: "shadow",
+        text: 17,
+      } as never,
+    });
+
+    expect(reviewCandidateLineCount(omitted)).toBe(0);
+    expect(reviewCandidateLineCount(malformed)).toBe(0);
+    expect(malformed).toContain("<summary>Review Details</summary>");
+    expect(malformed).toContain("<!-- kodiai:review-details:test-key-001 -->");
+  });
+
+  it("does not leak raw candidate title body diff prompt token or secret-like strings in public details", () => {
+    const result = formatReviewDetailsSummary({
+      ...BASE_PARAMS,
+      reviewCandidateFinding: {
+        label: "Review candidates",
+        status: "degraded",
+        text: "Review candidates: degraded recorded=0 rejected=1 errors=1 artifact=absent reason=scanner-redacted repo=owner-repo pr=42 key=review-output-abc123",
+        rawTitle: "Raw candidate title",
+        rawBody: "Raw body with diff --git and prompt text",
+        token: "ghp_secret_token_value",
+        secret: "sk-secret-value",
+      } as never,
+    });
+
+    expect(reviewCandidateLineCount(result)).toBe(1);
+    expect(result).toContain("- Review candidates: degraded recorded=0 rejected=1 errors=1 artifact=absent reason=scanner-redacted repo=owner-repo pr=42 key=review-output-abc123");
+    expect(result).not.toContain("Raw candidate title");
+    expect(result).not.toContain("Raw body");
+    expect(result).not.toContain("diff --git");
+    expect(result).not.toContain("prompt text");
+    expect(result).not.toContain("ghp_secret_token_value");
+    expect(result).not.toContain("sk-secret-value");
+  });
+
+  it("renders exactly one bounded candidate-approved publication line after candidate details", () => {
+    const result = formatReviewDetailsSummary({
+      ...BASE_PARAMS,
+      reviewCandidateFinding: {
+        label: "Review candidates",
+        status: "shadow",
+        text: "Review candidates: shadow recorded=2 rejected=0 errors=0 artifact=present repo=owner-repo pr=42 key=review-output-abc123 delivery=delivery-001",
+      } satisfies ReviewCandidateFindingDetailsSummary,
+      reviewCandidatePublication: {
+        label: "Review candidate publication runtime",
+        text: "Review candidate publication runtime: candidate-approved approvedRefs=2 rewrittenRefs=1 publishable=3 candidatePublished=3 skipped=0 blocked=0 failed=0 directPublished=0 fallbackEvidence=0 malformed=0 reasons=candidate-publisher-published",
+      } satisfies ReviewCandidatePublicationRuntimeDetailsSummary,
+    });
+
+    expect(reviewCandidatePublicationLineCount(result)).toBe(1);
+    expect(result.indexOf("Review candidates:")).toBeLessThan(result.indexOf("Review candidate publication:"));
+    expect(result).toContain("- Review candidate publication: mode=candidate-approved approved=2 rewritten=1 published=3 directFallback=0 reasons=candidate-publisher-published");
+    expect(result).not.toContain("Review candidate publication runtime:");
+  });
+
+  it("renders direct fallback publication state as audited fallback evidence", () => {
+    const result = formatReviewDetailsSummary({
+      ...BASE_PARAMS,
+      reviewCandidatePublication: {
+        label: "Review candidate publication runtime",
+        text: "Review candidate publication runtime: direct-fallback approvedRefs=0 rewrittenRefs=0 publishable=0 candidatePublished=0 skipped=0 blocked=0 failed=0 directPublished=2 fallbackEvidence=2 malformed=0 reasons=direct-fallback-attempted,direct-fallback-published",
+      } satisfies ReviewCandidatePublicationRuntimeDetailsSummary,
+    });
+
+    expect(reviewCandidatePublicationLineCount(result)).toBe(1);
+    expect(result).toContain("- Review candidate publication: mode=direct-fallback approved=0 rewritten=0 published=0 directFallback=2 reasons=direct-fallback-attempted,direct-fallback-published");
+  });
+
+  it("omits missing candidate publication metadata and degrades malformed metadata without breaking Review Details", () => {
+    const omitted = formatReviewDetailsSummary({ ...BASE_PARAMS });
+    const malformed = formatReviewDetailsSummary({
+      ...BASE_PARAMS,
+      reviewCandidatePublication: {
+        label: "Review candidate publication runtime",
+        text: 17,
+      } as never,
+    });
+
+    expect(reviewCandidatePublicationLineCount(omitted)).toBe(0);
+    expect(reviewCandidatePublicationLineCount(malformed)).toBe(1);
+    expect(malformed).toContain("- Review candidate publication: mode=degraded approved=0 rewritten=0 published=0 directFallback=0 reasons=malformed-runtime-summary");
+    expect(malformed).toContain("<summary>Review Details</summary>");
+    expect(malformed).toContain("<!-- kodiai:review-details:test-key-001 -->");
+  });
+
+  it("caps oversized candidate publication reasons and redacts secret prompt and diff markers", () => {
+    const result = formatReviewDetailsSummary({
+      ...BASE_PARAMS,
+      reviewCandidatePublication: {
+        label: "Review candidate publication runtime",
+        text: "Review candidate publication runtime: degraded approvedRefs=1 rewrittenRefs=0 publishable=1 candidatePublished=0 skipped=0 blocked=0 failed=1 directPublished=0 fallbackEvidence=0 malformed=1 reasons=candidate-publisher-failed,sk-secret-value,ghp_secret_token_value,BEGIN PROMPT,diff --git,hidden instructions,oversized reason one,oversized reason two,oversized reason three,oversized reason four,oversized reason five,oversized reason six",
+      } satisfies ReviewCandidatePublicationRuntimeDetailsSummary,
+    });
+
+    expect(reviewCandidatePublicationLineCount(result)).toBe(1);
+    expect(result).toContain("- Review candidate publication: mode=degraded approved=1 rewritten=0 published=0 directFallback=0 reasons=candidate-publisher-failed,redacted,redacted,prompt-redacted,diff-redacted,prompt-redacted");
+    expect(result).toContain("+6 more");
+    expect(result).not.toContain("sk-secret-value");
+    expect(result).not.toContain("ghp_secret_token_value");
+    expect(result).not.toContain("BEGIN PROMPT");
+    expect(result).not.toContain("diff --git");
+    expect(result).not.toContain("hidden instructions");
+  });
+
+  it("omits the review reducer line when reducer metadata is omitted", () => {
+    const result = formatReviewDetailsSummary({ ...BASE_PARAMS });
+
+    expect(reviewReducerLineCount(result)).toBe(0);
+    expect(result).not.toContain("Review reducer:");
+  });
+
   it("renders bounded first-pass diagnostics from the normalized contract", () => {
     const result = formatReviewDetailsSummary({
       ...BASE_PARAMS,
@@ -230,30 +394,6 @@ describe("formatReviewDetailsSummary", () => {
       expect(result).not.toContain("established contributor guidance");
       expect(result).not.toContain("senior contributor guidance");
     }
-  });
-
-  it("renders compact shadow specialist aggregate evidence without raw payload surfaces", () => {
-    const result = formatReviewDetailsSummary({
-      ...BASE_PARAMS,
-      shadowSpecialistReviewDetails: {
-        reviewDetailsLine: "Shadow specialist: lane=docs-config-truth status=degraded reason=unsafe-publication-field candidateCount=4 decisionCount=4 decisionCounts=candidate:1,duplicate:1,evidence-conflict:1,dismissed:1,unclassifiable:0 duplicateCount=1 disagreementCount=1 metricAvailability=token:y,cost:y,latency:y visiblePublicationDenied=true approvalPublicationDenied=true privateOnly=true shadowOnly=true reviewOutputKey=test-key-001 deliveryId=delivery-shadow-metrics correlationKey=abc123",
-      },
-    });
-
-    expect(result).toContain("- Shadow specialist: lane=docs-config-truth status=degraded");
-    expect(result).toContain("candidateCount=4");
-    expect(result).toContain("decisionCount=4");
-    expect(result).toContain("duplicateCount=1");
-    expect(result).toContain("disagreementCount=1");
-    expect(result).toContain("metricAvailability=token:y,cost:y,latency:y");
-    expect(result).toContain("visiblePublicationDenied=true");
-    expect(result).toContain("approvalPublicationDenied=true");
-    expect(result).toContain("privateOnly=true");
-    expect(result).toContain("shadowOnly=true");
-    expect(result).toContain("correlationKey=abc123");
-    expect(result).not.toContain("SPECIALIST_SHOULD_NEVER_PUBLISH");
-    expect(result).not.toContain("candidate-a");
-    expect(result).not.toContain("raw prompt");
   });
 
   it("renders usage line when usageLimit is present", () => {
@@ -575,201 +715,5 @@ describe("formatReviewDetailsSummary", () => {
     expect(result).not.toContain("- Requested profile:");
     expect(result).not.toContain("- Effective profile:");
     expect(result).not.toContain("- Bounded review:");
-  });
-
-  it("renders compact M070 candidate-verification publication evidence without raw payload content", () => {
-    const result = formatReviewDetailsSummary({
-      ...BASE_PARAMS,
-      candidateVerificationPublicationEvidence: {
-        aggregateStatus: "mixed",
-        counts: { attempted: 2, allowed: 1, denied: 1, published: 1, skipped: 1, failed: 0 },
-        publicationDenialCounts: { "publication-ineligible": 1 },
-        reasonCategories: ["publication-ineligible", "evidence-conflict"],
-        verificationStateCounts: { verified: 1, partially_verified: 0, unverified: 1, disproven: 0, unavailable: 0 },
-        candidateVerificationCounts: {
-          candidateCount: 2,
-          evidenceCount: 2,
-          verifiedCount: 1,
-          partiallyVerifiedCount: 0,
-          unverifiedCount: 1,
-          disprovenCount: 0,
-          publicationEligibleCount: 1,
-        },
-        metadata: {
-          hasDeliveryId: true,
-          hasReviewOutputKey: true,
-          hasCorrelationKey: true,
-          deliveryId: "delivery-m070",
-          reviewOutputKey: "review-output-m070",
-          correlationKey: "corr-m070",
-        },
-        redactionFlags: {
-          privateOnly: true,
-          candidateBodiesIncluded: false,
-          specialistProseIncluded: false,
-          rawPromptsIncluded: false,
-          rawModelOutputIncluded: false,
-          diffsIncluded: false,
-          evidencePayloadsIncluded: false,
-          rawFingerprintsIncluded: false,
-          publicationEvidenceIncluded: false,
-          unsafeInputFieldCount: 3,
-        },
-        candidate: "M070_RAW_CANDIDATE_SHOULD_NOT_LEAK",
-        specialistProse: "M070_SPECIALIST_PROSE_SHOULD_NOT_LEAK",
-        prompt: "M070_PROMPT_SHOULD_NOT_LEAK",
-        diff: "M070_DIFF_SHOULD_NOT_LEAK",
-        fingerprint: "M070_FINGERPRINT_SHOULD_NOT_LEAK",
-        toolPayload: "M070_TOOL_PAYLOAD_SHOULD_NOT_LEAK",
-        evidencePayload: "M070_EVIDENCE_PAYLOAD_SHOULD_NOT_LEAK",
-      } as never,
-    });
-
-    expect(result).toContain("- M070 candidate verification publication: status=mixed");
-    expect(result).toContain("counts=attempted:2,allowed:1,denied:1,published:1,skipped:1,failed:0");
-    expect(result).toContain("denialCounts=publication-ineligible:1");
-    expect(result).toContain("reasons=publication-ineligible,evidence-conflict");
-    expect(result).toContain("deliveryIdValue:delivery-m070");
-    expect(result).toContain("reviewOutputKeyValue:review-output-m070");
-    expect(result).toContain("correlationKeyValue:corr-m070");
-    expect(result).toContain("redaction=privateOnly:y,candidateBodies:n,specialistProse:n,rawPrompts:n,rawModelOutput:n,diffs:n,evidencePayloads:n,rawFingerprints:n,publicationEvidence:n,unsafeFields:3");
-    for (const forbidden of [
-      "M070_RAW_CANDIDATE_SHOULD_NOT_LEAK",
-      "M070_SPECIALIST_PROSE_SHOULD_NOT_LEAK",
-      "M070_PROMPT_SHOULD_NOT_LEAK",
-      "M070_DIFF_SHOULD_NOT_LEAK",
-      "M070_FINGERPRINT_SHOULD_NOT_LEAK",
-      "M070_TOOL_PAYLOAD_SHOULD_NOT_LEAK",
-      "M070_EVIDENCE_PAYLOAD_SHOULD_NOT_LEAK",
-    ]) {
-      expect(result).not.toContain(forbidden);
-    }
-  });
-
-  it("drops malformed M070 candidate-verification publication evidence fail-open", () => {
-    const result = formatReviewDetailsSummary({
-      ...BASE_PARAMS,
-      candidateVerificationPublicationEvidence: {
-        aggregateStatus: "mixed",
-        counts: "not-counts",
-        candidate: "M070_MALFORMED_RAW_CANDIDATE_SHOULD_NOT_LEAK",
-      } as never,
-    });
-
-    expect(result).toContain("<summary>Review Details</summary>");
-    expect(result).not.toContain("M070 candidate verification publication");
-    expect(result).not.toContain("M070_MALFORMED_RAW_CANDIDATE_SHOULD_NOT_LEAK");
-  });
-
-  it("renders compact M072 allowed candidate publication bridge diagnostics", () => {
-    const bridge = projectReviewHandlerCandidatePublicationBridgeEvidence({
-      evidenceSummary: candidatePublicationSummary(),
-      deliveryId: "delivery-123",
-      reviewOutputKey: "review-output-456",
-      upstreamCorrelationKey: "upstream-correlation-789",
-    }).reviewDetails;
-
-    const result = formatReviewDetailsSummary({
-      ...BASE_PARAMS,
-      candidatePublicationBridge: bridge,
-    });
-
-    expect(result).toContain("- M072 candidate publication bridge: status=allowed");
-    expect(result).toContain("bridgeVersion=candidate-publication-bridge.v1");
-    expect(result).toContain("bridgeId=candidate-publication-record:");
-    expect(result).toContain("recordKey=candidate-publication-record:");
-    expect(result).toContain("correlationKey=candidate-publication-bridge:");
-    expect(result).toContain("source=review-handler-publication");
-    expect(result).toContain("candidateRef=candidate-publication-summary-");
-    expect(result).toContain("verification=verified");
-    expect(result).toContain("counts=candidateCount:1,evidenceCount:2,verifiedCount:1,partiallyVerifiedCount:0,unverifiedCount:0,disprovenCount:0,publicationEligibleCount:1,malformedRecordCount:0,unsafeInputFieldCount:0");
-    expect(result).toContain("reasons=full-support");
-    expect(result).toContain("malformed=none");
-    expect(result).toContain("presence=deliveryId:y,reviewOutputKey:y,upstreamCorrelationKey:y,policyCorrelationKey:y");
-    expect(result).toContain("handoffOwner=available");
-    expect(result).toContain("redaction=privateOnly:y,rawPayloads:n,publicationFields:n,evidencePayloads:n,githubCommentBody:n,reducerRawPayload:n");
-    expectNoM072CanaryLeak(result);
-  });
-
-  it("renders denied and malformed M072 bridge projections without raw candidate leakage", () => {
-    const deniedBridge = projectReviewHandlerCandidatePublicationBridgeEvidence({
-      evidenceSummary: candidatePublicationSummary({
-        aggregateStatus: "denied",
-        counts: { attempted: 1, allowed: 0, denied: 1, published: 0, skipped: 0, failed: 0 },
-        reasonCategories: ["no-evidence", "publication-ineligible"],
-        verificationStateCounts: { verified: 0, partially_verified: 0, unverified: 1, disproven: 0, unavailable: 0 },
-        candidateVerificationCounts: {
-          ...candidatePublicationSummary().candidateVerificationCounts,
-          evidenceCount: 0,
-          verifiedCount: 0,
-          unverifiedCount: 1,
-          publicationEligibleCount: 0,
-        },
-      }),
-      deliveryId: "delivery-123",
-      reviewOutputKey: "review-output-456",
-      upstreamCorrelationKey: "upstream-correlation-789",
-    }).reviewDetails;
-    const malformedBridge = projectReviewHandlerCandidatePublicationBridgeEvidence({
-      evidenceSummary: { counts: "bad", body: "M072_GITHUB_COMMENT_BODY_SHOULD_NOT_LEAK" } as never,
-      deliveryId: undefined,
-      reviewOutputKey: undefined,
-      upstreamCorrelationKey: undefined,
-    }).reviewDetails;
-
-    const denied = formatReviewDetailsSummary({ ...BASE_PARAMS, candidatePublicationBridge: deniedBridge });
-    const malformed = formatReviewDetailsSummary({ ...BASE_PARAMS, candidatePublicationBridge: malformedBridge });
-
-    expect(denied).toContain("- M072 candidate publication bridge: status=denied");
-    expect(denied).toContain("reasons=no-evidence,publication-ineligible");
-    expect(denied).toContain("handoffOwner=available");
-    expect(malformed).toContain("- M072 candidate publication bridge: status=malformed");
-    expect(malformed).toContain("malformed=missing-delivery-id,missing-review-output-key,missing-correlation-key");
-    expect(malformed).toContain("presence=deliveryId:n,reviewOutputKey:n,upstreamCorrelationKey:n,policyCorrelationKey:n");
-    expect(malformed).toContain("discardedPublicationFields:y");
-    expectNoM072CanaryLeak(denied);
-    expectNoM072CanaryLeak(malformed);
-  });
-
-  it("fails closed for unsafe or invalid M072 bridge Review Details input", () => {
-    const unsafe = formatReviewDetailsSummary({
-      ...BASE_PARAMS,
-      candidatePublicationBridge: {
-        status: "allowed",
-        bridgeVersion: "M072_PROMPT_SHOULD_NOT_LEAK",
-        bridgeId: "M072_MODEL_OUTPUT_SHOULD_NOT_LEAK",
-        recordKey: "M072_RAW_CANDIDATE_BODY_SHOULD_NOT_LEAK",
-        correlationKey: "M072_DIFF_SHOULD_NOT_LEAK",
-        sourceLabel: "M072_SPECIALIST_PROSE_SHOULD_NOT_LEAK",
-        candidateRef: "M072_FINGERPRINT_SHOULD_NOT_LEAK",
-        verificationState: "verified",
-        reasonCategories: ["M072_GITHUB_COMMENT_BODY_SHOULD_NOT_LEAK", "publication-ineligible"],
-        malformedReasonCodes: ["M072_DIFF_SHOULD_NOT_LEAK", "missing-delivery-id"],
-        counts: { candidateCount: 999_999, unsafeInputFieldCount: 3 },
-        presence: { hasDeliveryId: true },
-        reducerHandoffAvailable: true,
-        redaction: {
-          privateOnly: false,
-          rawPayloadsIncluded: true,
-          publicationFieldsIncluded: true,
-          evidencePayloadsIncluded: true,
-          githubCommentBodyIncluded: true,
-          reducerHandoffIncludesRawPayload: true,
-        },
-      },
-    });
-    const malformed = formatReviewDetailsSummary({
-      ...BASE_PARAMS,
-      candidatePublicationBridge: "M072_RAW_CANDIDATE_BODY_SHOULD_NOT_LEAK" as never,
-    });
-
-    expect(unsafe).toContain("- M072 candidate publication bridge: status=unavailable");
-    expect(unsafe).toContain("reasons=unsafe-redaction-flags");
-    expect(unsafe).toContain("rawPayloads:y");
-    expect(unsafe).not.toContain("status=allowed; bridgeVersion");
-    expect(malformed).toContain("- M072 candidate publication bridge: status=unavailable");
-    expect(malformed).toContain("reasons=malformed-bridge-projection");
-    expectNoM072CanaryLeak(unsafe);
-    expectNoM072CanaryLeak(malformed);
   });
 });

--- a/src/review-graph/graph-validation-status.test.ts
+++ b/src/review-graph/graph-validation-status.test.ts
@@ -17,7 +17,7 @@ function configWithGraphValidation(enabled: boolean): Pick<RepoConfig, "review">
         maxFindingsToValidate: 7,
         contextMaxChars: 700,
       },
-    } as RepoConfig["review"],
+    } as unknown as RepoConfig["review"],
   };
 }
 

--- a/src/specialists/shadow-specialist-review-details.test.ts
+++ b/src/specialists/shadow-specialist-review-details.test.ts
@@ -182,8 +182,7 @@ describe("buildShadowSpecialistReviewDetailsProjection", () => {
         discardedPublicationFields: true,
         discardedApprovalFields: true,
       },
-    });
-
+    } as unknown as Parameters<typeof buildShadowSpecialistReviewDetailsProjection>[0]);
     expect(projection.status).toBe("degraded");
     expect(projection.reason).toHaveLength(96);
     expect(projection.reason).not.toContain("\n");
@@ -238,7 +237,7 @@ describe("buildShadowSpecialistReviewDetailsProjection", () => {
       commentBody: "SECRET_BODY_SENTINEL",
       approval: "SECRET_APPROVAL_SENTINEL",
       tierMode: "SECRET_TIER_SENTINEL",
-    });
+    } as unknown as Parameters<typeof buildShadowSpecialistReviewDetailsProjection>[0]);
 
     expect(projection).toMatchObject({
       laneId: null,

--- a/src/specialists/shadow-specialist-subflow.test.ts
+++ b/src/specialists/shadow-specialist-subflow.test.ts
@@ -78,7 +78,7 @@ describe("runShadowSpecialistSubflow", () => {
       correlationKey: "corr-2",
       readOnly: true,
     });
-    expect(Object.keys(calls[0]).sort()).toEqual([
+    expect(Object.keys(calls[0]!).sort()).toEqual([
       "changedPaths",
       "correlationKey",
       "deliveryId",


### PR DESCRIPTION
Stacked split of #139. Adds focused non-monolithic tests for the support surfaces. The giant review.test.ts changes are intentionally left for a later extraction split.