### PR TITLE
Refactor stack 3: M067 verifier coverage

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -25,7 +25,6 @@
 - [docs/runbooks/slack-webhook-relay.md](runbooks/slack-webhook-relay.md)
 - [docs/runbooks/xbmc-cutover.md](runbooks/xbmc-cutover.md)
 - [docs/runbooks/xbmc-ops.md](runbooks/xbmc-ops.md)
-- [docs/smoke/m053-formatter-suggestions.md](smoke/m053-formatter-suggestions.md)
 - [docs/smoke/m066-formatter-suggestions.md](smoke/m066-formatter-suggestions.md)
 - [docs/smoke/phase27-uat-notes.md](smoke/phase27-uat-notes.md)
 - [docs/smoke/phase72-telemetry-follow-through.md](smoke/phase72-telemetry-follow-through.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,7 +40,6 @@ Test evidence and verification records in [`smoke/`](smoke/):
 - **[Phase 74: Reliability Regression Gate](smoke/phase74-reliability-regression-gate.md)** — Pre-release reliability gate for issue write-mode
 - **[Phase 75: Live OPS Verification Closure](smoke/phase75-live-ops-verification-closure.md)** — Release candidate OPS closure procedure
 - **[Phase 80: Slack Operator Hardening](smoke/phase80-slack-operator-hardening.md)** — Slack v1 channel gating and operator verification
-- **[M053 Formatter Suggestions Proof Alignment](smoke/m053-formatter-suggestions.md)** — M053/S05/R085 alignment note that maps accepted M066 live proof to the milestone closure criteria
 - **[M066 Formatter Suggestions Smoke Proof](smoke/m066-formatter-suggestions.md)** — Accepted proof record for same-PR formatter suggestions, including the default-command xbmc/xbmc validation
 - **[Slack Webhook Relay](smoke/slack-webhook-relay.md)** — Accepted, suppressed, and failed-delivery smoke path for webhook relay
 - **[xbmc/kodiai Write Flow](smoke/xbmc-kodiai-write-flow.md)** — End-to-end write-mode smoke test for xbmc/kodiai

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,9 +22,6 @@ review:
     automatic: false
     command: "git clang-format --diff origin/{baseRef} HEAD"
     maxSuggestions: 10
-  graphValidation:
-    # Optional second-pass validation for graph-amplified findings; disabled by default.
-    enabled: false
   triggers:
     onOpened: true
     onReadyForReview: true
@@ -189,6 +186,20 @@ Use the nested `review.triggers.onSynchronize` shape. Legacy `review.onSynchroni
 
 If `true`, Kodiai submits an approving GitHub review when the review completes cleanly with no published findings. The default is `false`, so clean reviews publish the same approval-shaped content as a normal PR issue comment instead of changing GitHub's review approval state. Set this to `true` only for repositories that explicitly want Kodiai to approve PRs.
 
+### `review.graphValidation`
+
+Controls optional graph-amplified review validation. This is disabled by default and remains fail-open: if graph prerequisites are unavailable or validation cannot run, Kodiai continues the normal review path and records the bounded status/reason instead of blocking review publication or changing findings destructively.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `enabled` | `boolean` | `false` | Opt in to graph-amplified validation when the required graph context is available |
+
+```yaml
+review:
+  graphValidation:
+    enabled: true
+```
+
 ### `review.formatterSuggestions`
 
 Controls formatter-generated GitHub suggestion reviews for explicit mention requests. This section does **not** make formatter suggestions part of normal automatic PR reviews yet; `automatic` is parsed now but remains reserved until runtime wiring is added.
@@ -219,37 +230,12 @@ review:
 
 Override `command` only when the repository needs different formatter tooling. The default command runs `git-clang-format` in diff mode against the PR head.
 
-Repository-local smoke override note: this repository's `.kodiai.yml` intentionally overrides the product default with `command: "python3 scripts/m066-formatter-smoke.py"` and `maxSuggestions: 1` for the controlled formatter-suggestion smoke. That override keeps repo-local proof deterministic and bounded; it should not be copied as the general default and should not be removed by documentation-only cleanup.
-
 Operational notes:
 
 - The command must write a git unified diff to stdout; no suggestions are published when stdout has no applicable PR diff hunks.
 - Explicit PR mentions can request formatter suggestions with `@kodiai format suggestions` or combine review and formatting with `@kodiai review format suggestions` / `@kodiai review & format suggestions`.
 - The published proof surface is a same-PR Pull Request Review containing `suggestion` blocks, not a branch push or automatic commit.
-- See the [Formatter Suggestions Runbook](runbooks/formatter-suggestions.md) for smoke testing, `bun run verify:m066:s05`, failure interpretation, and bounded proof capture.
-- See [M066 Formatter Suggestions Smoke Proof](smoke/m066-formatter-suggestions.md) for the accepted live same-PR evidence and [M053 Formatter Suggestions Proof Alignment](smoke/m053-formatter-suggestions.md) for how M053/S05/R085 reuses that evidence without claiming automatic-review formatter suggestions are live.
-
-### `review.graphValidation`
-
-Optional second-pass validation for graph-amplified review findings. This is disabled by default and only applies when the review runtime has graph context for indirectly impacted files; if graph context, validation support, or the validation model is unavailable, Kodiai fails open and keeps the original review findings rather than blocking or dropping results.
-
-| Field | Type | Default | Description |
-|---|---|---|---|
-| `enabled` | `boolean` | `false` | Enable optional graph-amplified finding validation when graph context is available. |
-| `maxFindingsToValidate` | `number` | `10` | Maximum graph-amplified findings to validate per review. Valid range: `1–100`. |
-| `contextMaxChars` | `number` | `1000` | Character budget for the change-context summary used by validation. Valid range: `100–10000`. |
-
-Example:
-
-```yaml
-review:
-  graphValidation:
-    enabled: true
-    maxFindingsToValidate: 10
-    contextMaxChars: 1000
-```
-
-Do not use this setting as a hard gate. The validation path is intentionally best-effort and fail-open so review behavior remains available when graph context or validation dependencies are missing.
+- See the [Formatter Suggestions Runbook](runbooks/formatter-suggestions.md) for smoke testing, verifier usage, and failure interpretation.
 
 ### `review.prompt`
 

--- a/docs/runbooks/formatter-suggestions.md
+++ b/docs/runbooks/formatter-suggestions.md
@@ -28,18 +28,6 @@ review:
     maxSuggestions: 10
 ```
 
-This repository intentionally keeps a controlled-smoke override in `.kodiai.yml`:
-
-```yaml
-review:
-  formatterSuggestions:
-    automatic: false
-    command: "python3 scripts/m066-formatter-smoke.py"
-    maxSuggestions: 1
-```
-
-That repository override exists only to make the local formatter-suggestion smoke deterministic and tightly bounded. It does not change the product default command documented above, and maintainers should not normalize it away as part of proof-capture or documentation cleanup.
-
 Fields:
 
 | Field | Default | Notes |
@@ -127,9 +115,9 @@ Run the live verifier with the captured identifiers:
 bun run verify:m066:s05 -- --repo <owner/repo> --review-output-key <captured-mention-format-suggestions-key> --delivery-id <captured-delivery-id> --json
 ```
 
-The verifier requires GitHub App access through environment-managed operational inputs such as `GITHUB_APP_ID` and `GITHUB_PRIVATE_KEY` or `GITHUB_PRIVATE_KEY_BASE64`; do not paste credential values into files, logs, proof records, or chat transcripts.
+The verifier requires GitHub App access through `GITHUB_APP_ID` and `GITHUB_PRIVATE_KEY` or `GITHUB_PRIVATE_KEY_BASE64`.
 
-Passing proof means the verifier found exactly one matching `COMMENTED` Pull Request Review on the target PR and at least one associated review comment with a fenced `suggestion` block. Treat verifier failures, unavailable GitHub/Azure proof systems, malformed identifiers, wrong-action keys, and issue-comment-only surfaces as bounded operational failures, not proof success.
+Passing proof means the verifier found exactly one matching `COMMENTED` Pull Request Review on the target PR and at least one associated review comment with a fenced `suggestion` block.
 
 Common verifier failures:
 
@@ -200,4 +188,4 @@ Do not reuse proof identifiers across retries. Each trigger has its own delivery
 
 ## Proof record
 
-Use the smoke template at [Formatter Suggestions Smoke Proof](../smoke/m066-formatter-suggestions.md), and use [M053 Formatter Suggestions Proof Alignment](../smoke/m053-formatter-suggestions.md) when closing M053/S05/R085 against the accepted M066 evidence. Keep proof artifacts bounded: public PR/review/comment URLs, delivery id, review id, reviewOutputKey, deployed revision, verifier JSON, and concise log summaries are acceptable. Do not include GitHub App private keys, tokens, raw formatter stdout, or unbounded formatter stderr.
+Use the smoke template at [Formatter Suggestions Smoke Proof](../smoke/m066-formatter-suggestions.md). Keep proof artifacts bounded: public PR/review/comment URLs, delivery id, review id, reviewOutputKey, deployed revision, verifier JSON, and concise log summaries are acceptable. Do not include GitHub App private keys, tokens, raw formatter stdout, or unbounded formatter stderr.


### PR DESCRIPTION
Supersedes the closed granular stack #140-#168 as part of a five-PR refactor branch replacement.\n\nThis PR groups the M067 verifier and verifier-test coverage from the refactor branch.\n\nVerification previously run on final stacked state:\n- bunx tsc --noEmit --pretty false\n- bun test src/handlers/review.test.ts