### PR TITLE
Refactor stack 4: M068 and M070 verification docs

### DIFF
--- a/.kodiai.yml
+++ b/.kodiai.yml
@@ -3,10 +3,6 @@ timeoutSeconds: 1800
 review:
   profile: strict
   minConfidence: 70
-  formatterSuggestions:
-    automatic: false
-    command: "python3 scripts/m066-formatter-smoke.py"
-    maxSuggestions: 1
   triggers:
     onSynchronize: true
   suppressions:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kodiai
 
-Kodiai  is an installable GitHub App that delivers AI-powered code review, conversational assistance, issue intelligence, and Slack integration. One installation replaces per-repo workflow YAML — configure behavior with an optional `.kodiai.yml` file.
+Kodiai is an installable GitHub App that delivers AI-powered code review, conversational assistance, issue intelligence, and Slack integration. One installation replaces per-repo workflow YAML — configure behavior with an optional `.kodiai.yml` file.
 
 Service-level runtime features like Slack webhook relay are configured through environment variables, not `.kodiai.yml`.
 


### PR DESCRIPTION
Supersedes the closed granular stack #140-#168 as part of a five-PR refactor branch replacement.\n\nThis PR groups M068/M070 verifier updates, docs, and package/config proof surfaces from the refactor branch.\n\nVerification previously run on final stacked state:\n- bunx tsc --noEmit --pretty false\n- bun test src/handlers/review.test.ts