### PR TITLE
fix: clean up production warning followups

### DIFF
--- a/src/execution/executor.ts
+++ b/src/execution/executor.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { cp, mkdir, writeFile, stat } from "node:fs/promises";
 import { basename, join } from "node:path";
 import { $ } from "bun";
@@ -760,7 +761,7 @@ export function createExecutor(deps: {
           {
             executionName,
             workspaceDir,
-            mcpTokenPrefix: mcpBearerToken.slice(0, 8),
+            mcpTokenLogId: createHash("sha256").update(mcpBearerToken).digest("hex").slice(0, 16),
             timeoutMs,
           },
           "ACA Job launched, polling for completion",

--- a/src/execution/mcp/http-server.test.ts
+++ b/src/execution/mcp/http-server.test.ts
@@ -60,6 +60,16 @@ describe("createMcpJobRegistry", () => {
     expect(reg.hasToken("tok-2")).toBe(false);
   });
 
+  test("unregistering an unknown token does not mark it retired", () => {
+    const reg = createMcpJobRegistry();
+    reg.unregister("never-registered");
+
+    expect(reg.inspectToken("never-registered")).toEqual({
+      ok: false,
+      reason: "missing",
+    });
+  });
+
   test("getFactory returns undefined for unknown server", () => {
     const reg = createMcpJobRegistry();
     reg.register("tok-3", { test_server: makeFactory() });

--- a/src/execution/mcp/http-server.test.ts
+++ b/src/execution/mcp/http-server.test.ts
@@ -114,12 +114,14 @@ describe("createMcpHttpRoutes", () => {
     expect(body.error).toBe("Unauthorized");
   });
 
-  test("unauthorized requests log missing versus expired token reasons", async () => {
+  test("unauthorized requests log missing versus expected expired token reasons", async () => {
     const registry = createMcpJobRegistry();
     registry.register("expired-token", { test_server: makeFactory() }, -1);
     const warnings: Array<Record<string, unknown>> = [];
+    const infos: Array<Record<string, unknown>> = [];
     const logger = {
       warn: (data: Record<string, unknown>) => warnings.push(data),
+      info: (data: Record<string, unknown>) => infos.push(data),
     };
     const app = createMcpHttpRoutes(registry, logger as never);
 
@@ -129,10 +131,11 @@ describe("createMcpHttpRoutes", () => {
     expect(missing.status).toBe(401);
     expect(expired.status).toBe(401);
     expect(warnings).toContainEqual(expect.objectContaining({ authFailureReason: "missing" }));
-    expect(warnings).toContainEqual(expect.objectContaining({ authFailureReason: "expired" }));
-    expect(warnings.find((entry) => entry.authFailureReason === "expired")).toEqual(
-      expect.objectContaining({ ttlRemainingMs: expect.any(Number) }),
-    );
+    expect(infos).toContainEqual(expect.objectContaining({
+      authFailureReason: "expired",
+      authFailureExpected: true,
+      ttlRemainingMs: expect.any(Number),
+    }));
   });
 
   test("valid token + unknown server name → 404", async () => {
@@ -158,10 +161,16 @@ describe("createMcpHttpRoutes", () => {
     expect(text).toContain("capabilities");
   });
 
-  test("unregister removes token → subsequent request → 401", async () => {
+  test("unregister removes token and logs late requests as expected retired-token auth misses", async () => {
     const registry = createMcpJobRegistry();
     registry.register("valid-token", { test_server: makeFactory() });
-    const app = createMcpHttpRoutes(registry);
+    const warnings: Array<Record<string, unknown>> = [];
+    const infos: Array<Record<string, unknown>> = [];
+    const logger = {
+      warn: (data: Record<string, unknown>) => warnings.push(data),
+      info: (data: Record<string, unknown>) => infos.push(data),
+    };
+    const app = createMcpHttpRoutes(registry, logger as never);
 
     // First request succeeds
     const res1 = await mcpPost(app, "test_server", "valid-token");
@@ -170,8 +179,37 @@ describe("createMcpHttpRoutes", () => {
     // Unregister
     registry.unregister("valid-token");
 
-    // Second request rejected
+    // Second request rejected but classified as expected lifecycle noise
     const res2 = await mcpPost(app, "test_server", "valid-token");
     expect(res2.status).toBe(401);
+    expect(infos).toContainEqual(expect.objectContaining({
+      authFailureReason: "retired",
+      authFailureExpected: true,
+      tokenLogId: expect.any(String),
+    }));
+    expect(infos.find((entry) => entry.authFailureReason === "retired")?.tokenLogId).not.toBe("valid-to");
+    expect(warnings).not.toContainEqual(expect.objectContaining({ authFailureReason: "retired" }));
+  });
+
+  test("token sharing a retired token prefix is still treated as missing", async () => {
+    const registry = createMcpJobRegistry();
+    registry.register("valid-token", { test_server: makeFactory() });
+    const warnings: Array<Record<string, unknown>> = [];
+    const infos: Array<Record<string, unknown>> = [];
+    const logger = {
+      warn: (data: Record<string, unknown>) => warnings.push(data),
+      info: (data: Record<string, unknown>) => infos.push(data),
+    };
+    const app = createMcpHttpRoutes(registry, logger as never);
+
+    registry.unregister("valid-token");
+
+    const res = await mcpPost(app, "test_server", "valid-token-but-different");
+    expect(res.status).toBe(401);
+    expect(warnings).toContainEqual(expect.objectContaining({
+      authFailureReason: "missing",
+      tokenLogId: expect.any(String),
+    }));
+    expect(infos).not.toContainEqual(expect.objectContaining({ authFailureReason: "retired" }));
   });
 });

--- a/src/execution/mcp/http-server.ts
+++ b/src/execution/mcp/http-server.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { Hono } from "hono";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import type { McpSdkServerConfigWithInstance } from "@anthropic-ai/claude-agent-sdk";
@@ -17,18 +18,46 @@ type McpJobEntry = {
  * Each entry maps server names to factory functions that produce a fresh
  * McpSdkServerConfigWithInstance on every call (required for stateless mode).
  */
+const RETIRED_TOKEN_TTL_MS = 5 * 60 * 1000;
+
 export function createMcpJobRegistry() {
   const registry = new Map<string, McpJobEntry>();
+  const retiredTokenFingerprints = new Map<string, number>();
+
+  const tokenFingerprint = (token: string): string =>
+    createHash("sha256").update(token).digest("hex");
+
+  const tokenLogId = (token: string): string => tokenFingerprint(token).slice(0, 16);
+
+  const pruneRetiredTokens = (): void => {
+    const now = Date.now();
+    for (const [fingerprint, expiresAt] of retiredTokenFingerprints) {
+      if (expiresAt <= now) {
+        retiredTokenFingerprints.delete(fingerprint);
+      }
+    }
+  };
+
+  const markRetired = (token: string): void => {
+    pruneRetiredTokens();
+    retiredTokenFingerprints.set(tokenFingerprint(token), Date.now() + RETIRED_TOKEN_TTL_MS);
+  };
 
   const inspectToken = (token: string):
     | { ok: true; ttlRemainingMs: number }
-    | { ok: false; reason: "missing" | "expired"; ttlRemainingMs?: number } => {
+    | { ok: false; reason: "missing" | "expired" | "retired"; ttlRemainingMs?: number } => {
     const entry = registry.get(token);
-    if (!entry) return { ok: false, reason: "missing" };
+    if (!entry) {
+      pruneRetiredTokens();
+      return retiredTokenFingerprints.has(tokenFingerprint(token))
+        ? { ok: false, reason: "retired" }
+        : { ok: false, reason: "missing" };
+    }
 
     const ttlRemainingMs = entry.expiresAt - Date.now();
     if (ttlRemainingMs <= 0) {
       registry.delete(token);
+      markRetired(token);
       return { ok: false, reason: "expired", ttlRemainingMs };
     }
 
@@ -46,9 +75,14 @@ export function createMcpJobRegistry() {
 
     unregister(token: string): void {
       registry.delete(token);
+      markRetired(token);
     },
 
     inspectToken,
+
+    getTokenLogId(token: string): string {
+      return tokenLogId(token);
+    },
 
     hasToken(token: string): boolean {
       return inspectToken(token).ok;
@@ -91,7 +125,7 @@ export function createMcpHttpRoutes(
 
     if (!token) {
       logger?.warn(
-        { tokenPrefix: undefined, authFailureReason: "missing" },
+        { authFailureReason: "missing" },
         "MCP HTTP: unauthorized",
       );
       return c.json({ error: "Unauthorized" }, 401);
@@ -99,10 +133,14 @@ export function createMcpHttpRoutes(
 
     const authState = registry.inspectToken(token);
     if (!authState.ok) {
-      logger?.warn(
+      const logAuthFailure = authState.reason === "retired" || authState.reason === "expired"
+        ? logger?.info.bind(logger)
+        : logger?.warn.bind(logger);
+      logAuthFailure?.(
         {
-          tokenPrefix: token.slice(0, 8),
+          tokenLogId: registry.getTokenLogId(token),
           authFailureReason: authState.reason,
+          authFailureExpected: authState.reason === "retired" || authState.reason === "expired",
           ...(authState.ttlRemainingMs !== undefined
             ? { ttlRemainingMs: authState.ttlRemainingMs }
             : {}),
@@ -117,7 +155,7 @@ export function createMcpHttpRoutes(
 
     if (!factory) {
       logger?.warn(
-        { serverName, tokenPrefix: token.slice(0, 8) },
+        { serverName, tokenLogId: registry.getTokenLogId(token) },
         "MCP HTTP: server not found",
       );
       return c.json({ error: "Not Found" }, 404);

--- a/src/execution/mcp/http-server.ts
+++ b/src/execution/mcp/http-server.ts
@@ -74,8 +74,9 @@ export function createMcpJobRegistry() {
     },
 
     unregister(token: string): void {
-      registry.delete(token);
-      markRetired(token);
+      if (registry.delete(token)) {
+        markRetired(token);
+      }
     },
 
     inspectToken,

--- a/src/handlers/addon-check.test.ts
+++ b/src/handlers/addon-check.test.ts
@@ -488,7 +488,7 @@ describe("createAddonCheckHandler", () => {
   it("emits bounded all-timeout classification and avoids a misleading clean comment", async () => {
     const files = ["plugin.video.foo/addon.xml", "plugin.audio.bar/addon.xml"];
     const { app, octokit } = createMockGithubAppWithIssues(files, []);
-    const { logger, infoCalls } = createMockLogger();
+    const { logger, infoCalls, warnCalls } = createMockLogger();
     const subprocess = makeCheckerSubprocessByAddon({
       "plugin.audio.bar": "__TIMEOUT__",
       "plugin.video.foo": "__TIMEOUT__",
@@ -510,6 +510,13 @@ describe("createAddonCheckHandler", () => {
     await router.captured[0]!.handler(
       makePrEvent("xbmc/repo-plugins", 42, { baseBranch: "omega" }),
     );
+
+    const rawTimeoutWarning = warnCalls.find((c) => c.message === "addon-check: runner timed out");
+    expect(rawTimeoutWarning).toBeUndefined();
+
+    const budgetSkipLogs = infoCalls.filter((c) => c.message === "addon-check: runner skipped after budget");
+    expect(budgetSkipLogs).toHaveLength(2);
+    expect(budgetSkipLogs.every((c) => c.bindings.timeBudgetMs === 1)).toBe(true);
 
     const gateLog = findClassificationLog(infoCalls);
     expect(gateLog).toBeDefined();

--- a/src/handlers/identity-suggest.test.ts
+++ b/src/handlers/identity-suggest.test.ts
@@ -229,7 +229,7 @@ describe("suggestIdentityLink", () => {
         : (init?.headers as Record<string, string> | undefined)?.authorization;
       if (authHeader === "Bearer xoxb-missing-scope" && missingScopeForFirstToken) {
         missingScopeForFirstToken = false;
-        return jsonResponse({ ok: false, error: "missing_scope" });
+        return jsonResponse({ ok: false, error: "missing_scope" }, { status: 403 });
       }
       return jsonResponse({ ok: true, members: [] });
     });

--- a/src/handlers/identity-suggest.ts
+++ b/src/handlers/identity-suggest.ts
@@ -63,11 +63,7 @@ async function fetchSlackMembers(
     signal: AbortSignal.timeout(10_000),
   });
 
-  if (!response.ok) {
-    throw new Error(`Slack users.list HTTP ${response.status}`);
-  }
-
-  const data = (await response.json()) as {
+  let data: {
     ok?: boolean;
     error?: string;
     members?: Array<{
@@ -76,10 +72,23 @@ async function fetchSlackMembers(
       is_bot?: boolean;
       profile?: { display_name?: string; real_name?: string };
     }>;
-  };
+  } | null = null;
 
-  if (!data.ok) {
-    const errorCode = data.error ?? "unknown";
+  try {
+    data = (await response.json()) as typeof data;
+  } catch {
+    if (!response.ok) {
+      throw new Error(`Slack users.list HTTP ${response.status}`);
+    }
+    throw new Error("Slack users.list returned malformed JSON");
+  }
+
+  if (!response.ok && data?.error !== "missing_scope") {
+    throw new Error(`Slack users.list HTTP ${response.status}`);
+  }
+
+  if (!data?.ok) {
+    const errorCode = data?.error ?? "unknown";
     if (errorCode === "missing_scope") {
       slackMemberLookupDisabledReasonsByToken.set(botToken, errorCode);
       if (slackMemberLookupDisabledReasonsByToken.size > MAX_DISABLED_SLACK_MEMBER_LOOKUP_TOKENS) {
@@ -89,7 +98,7 @@ async function fetchSlackMembers(
         }
       }
       logger.info(
-        { reason: errorCode },
+        { reason: errorCode, httpStatus: response.status },
         "Slack member lookup disabled; missing users.list scope",
       );
       return [];

--- a/src/handlers/review.test.ts
+++ b/src/handlers/review.test.ts
@@ -5510,9 +5510,9 @@ describe("createReviewHandler diff collection resilience", () => {
     }
   });
 
-  test("uses GitHub PR file metadata when merge-base recovery times out", async () => {
+  test("warns when GitHub PR file metadata fallback has partial patch coverage", async () => {
     const workspaceFixture = await createNoMergeBaseFixture({ includePhase27Fields: true });
-    const { logger } = createCaptureLogger();
+    const { logger, entries } = createCaptureLogger();
 
     try {
       const result = await collectDiffContext({
@@ -5558,6 +5558,61 @@ describe("createReviewHandler diff collection resilience", () => {
       expect(result.diffContent).toContain("--- a/src/api/old-phase27-uat-example.ts");
       expect(result.diffContent).toContain("+++ b/src/api/phase27-uat-example.ts");
       expect(result.diffContent).toContain("@@ -1 +1 @@");
+      const fallbackLog = entries.find((entry) =>
+        entry.message === "Diff collection degraded to GitHub PR files fallback"
+      );
+      expect(fallbackLog?.data?.fallbackEvidenceQuality).toBe("patch-partial");
+      expect(fallbackLog?.data?.patchFilesCount).toBe(1);
+    } finally {
+      await workspaceFixture.cleanup();
+    }
+  });
+
+  test("logs patch-complete GitHub PR file metadata fallback below warning level", async () => {
+    const workspaceFixture = await createNoMergeBaseFixture({ includePhase27Fields: true });
+    const { logger, entries } = createCaptureLogger();
+
+    try {
+      const result = await collectDiffContext({
+        workspaceDir: workspaceFixture.dir,
+        baseRef: "main",
+        maxFilesForFullDiff: 200,
+        logger,
+        baseLog: { deliveryId: "delivery-123", prNumber: 101 },
+        runGitCommand: async () => ({
+          exitCode: 124,
+          stdout: "",
+          stderr: "timed out",
+          timedOut: true,
+        }),
+        fallbackDiffProvider: async () => [
+          {
+            filename: "src/api/phase27-uat-example.ts",
+            status: "modified",
+            additions: 7,
+            deletions: 2,
+            patch: "@@ -1 +1 @@\n-old\n+new",
+          },
+          {
+            filename: "docs/phase27-note.md",
+            status: "added",
+            additions: 1,
+            deletions: 0,
+            patch: "@@ -0,0 +1 @@\n+note",
+          },
+        ],
+      });
+
+      expect(result.strategy).toBe("github-pr-files-fallback");
+      expect(result.diffContent).toContain("diff --git a/src/api/phase27-uat-example.ts b/src/api/phase27-uat-example.ts");
+      const infoLog = entries.find((entry) =>
+        entry.message === "Diff collection used GitHub PR files fallback with patch evidence"
+      );
+      expect(infoLog?.data?.fallbackEvidenceQuality).toBe("patch-complete");
+      expect(infoLog?.data?.patchFilesCount).toBe(2);
+      expect(entries.find((entry) =>
+        entry.message === "Diff collection degraded to GitHub file-list fallback"
+      )).toBeUndefined();
     } finally {
       await workspaceFixture.cleanup();
     }

--- a/src/handlers/review.ts
+++ b/src/handlers/review.ts
@@ -1841,22 +1841,29 @@ async function buildDiffCollectionFallback(params: {
     const changedFiles = uniqueFiles.map((file) => file.filename);
     const numstatLines = buildFallbackNumstatLines(uniqueFiles);
     const diffContent = buildFallbackPatchDiff(uniqueFiles);
+    const patchFilesCount = uniqueFiles.filter((file) => typeof file.patch === "string" && file.patch.trim().length > 0).length;
+    const hasCompletePatchFallback = uniqueFiles.length > 0 && patchFilesCount === uniqueFiles.length && diffContent !== undefined;
+    const logFallback = hasCompletePatchFallback ? logger.info.bind(logger) : logger.warn.bind(logger);
 
-    logger.warn(
+    logFallback(
       {
         ...baseLog,
         gate: "diff-collection",
         stage,
         reason,
         strategy: "github-pr-files-fallback",
+        fallbackEvidenceQuality: hasCompletePatchFallback ? "patch-complete" : "patch-partial",
         deepenAttempts,
         unshallowAttempted,
         mergeBaseRecovered,
         diffRange,
         changedFilesCount: changedFiles.length,
-        patchFilesCount: uniqueFiles.filter((file) => typeof file.patch === "string" && file.patch.trim().length > 0).length,
+        patchFilesCount,
+        diffContentAvailable: diffContent !== undefined,
       },
-      "Diff collection degraded to GitHub PR files fallback",
+      hasCompletePatchFallback
+        ? "Diff collection used GitHub PR files fallback with patch evidence"
+        : "Diff collection degraded to GitHub PR files fallback",
     );
 
     return {
@@ -7322,7 +7329,11 @@ export function createReviewHandler(deps: {
                     });
 
                       const retryCheckpoint = (await knowledgeStore?.getCheckpoint?.(retryReviewOutputKey)) ?? null;
+                      const retryHasStructuredProgress =
+                        (retryCheckpoint?.filesReviewed?.length ?? 0) > 0 ||
+                        (retryCheckpoint?.filesInspected?.length ?? 0) > 0;
                       const retryHasResults =
+                        retryHasStructuredProgress ||
                         (retryCheckpoint?.findingCount ?? 0) >= 1 ||
                         (retryResult.published ?? false);
                       const retryTimeoutClassification = classifyReviewTimeoutOutcome({

--- a/src/lib/retry-scope-reducer.test.ts
+++ b/src/lib/retry-scope-reducer.test.ts
@@ -37,7 +37,18 @@ describe("computeRetryScope", () => {
     expect(res.filesToReview[0]!.filePath).toBe("b.ts");
   });
 
-  test("at 0% reviewed: scope = 50% of remaining", () => {
+  test("small PR retries all remaining files when the first pass reviewed none", () => {
+    const allFiles = makeScores(["a.py", "b.py", "c.py", "d.py"], [10, 40, 20, 30]);
+    const res = computeRetryScope({
+      allFiles,
+      filesAlreadyReviewed: [],
+      totalFiles: 4,
+    });
+    expect(res.scopeRatio).toBe(1);
+    expect(res.filesToReview.map((file) => file.filePath)).toEqual(["b.py", "d.py", "c.py", "a.py"]);
+  });
+
+  test("at 0% reviewed: scope = 50% of remaining for larger PRs", () => {
     const allFiles = makeScores(
       ["a.ts", "b.ts", "c.ts", "d.ts", "e.ts", "f.ts", "g.ts", "h.ts", "i.ts", "j.ts"],
       [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],

--- a/src/lib/retry-scope-reducer.ts
+++ b/src/lib/retry-scope-reducer.ts
@@ -1,5 +1,7 @@
 import type { FileRiskScore } from "./file-risk-scorer.ts";
 
+const SMALL_PR_RETRY_ALL_REMAINING_FILE_COUNT = 5;
+
 export type RetryScopeParams = {
   allFiles: FileRiskScore[];
   filesAlreadyReviewed: string[];
@@ -21,6 +23,14 @@ export function computeRetryScope(params: RetryScopeParams): RetryScopeResult {
 
   if (remaining.length === 0) {
     return { filesToReview: [], scopeRatio: 0 };
+  }
+
+  if (
+    totalFiles > 0
+    && totalFiles <= SMALL_PR_RETRY_ALL_REMAINING_FILE_COUNT
+    && filesAlreadyReviewed.length === 0
+  ) {
+    return { filesToReview: remaining, scopeRatio: 1 };
   }
 
   const reviewedFraction = totalFiles > 0 ? filesAlreadyReviewed.length / totalFiles : 0;

--- a/src/lib/review-continuation-lifecycle.test.ts
+++ b/src/lib/review-continuation-lifecycle.test.ts
@@ -105,6 +105,52 @@ describe("planReviewContinuation", () => {
     });
   });
 
+  test("keeps the original timeout when a small-PR retry covers all remaining files", async () => {
+    const mod = await loadLifecycleModule();
+    expect(mod).not.toBeNull();
+
+    const decision = mod!.planReviewContinuation({
+      reviewOutputKey: "review-small-pr",
+      firstPass: makeFirstPass({
+        coveredScope: { reviewedFiles: 0, totalFiles: 4 },
+        remainingScope: { remainingFiles: 4, totalFiles: 4 },
+        findingCount: 0,
+      }),
+      checkpoint: makeCheckpoint({
+        reviewOutputKey: "review-small-pr",
+        filesReviewed: [],
+        filesInspected: [],
+        findingCount: 0,
+        totalFiles: 4,
+      }),
+      riskScores: makeRiskScores([
+        ["src/a.py", 10],
+        ["src/b.py", 40],
+        ["src/c.py", 20],
+        ["src/d.py", 30],
+      ]),
+      timeoutSeconds: 364,
+      hasPublishedInlineFindings: false,
+      isChronicTimeout: false,
+      estimateContinuationTimeout: ({ timeoutSeconds, files }) => ({
+        riskLevel: "low",
+        dynamicTimeoutSeconds: timeoutSeconds,
+        reasoning: `${files.length} files`,
+        shouldReduceScope: false,
+      }),
+    });
+
+    expect(decision.decision).toBe("schedule-continuation");
+    if (decision.decision !== "schedule-continuation") throw new Error("expected scheduled continuation");
+    expect(decision.continuationFiles).toEqual(["src/b.py", "src/d.py", "src/c.py", "src/a.py"]);
+    expect(decision.scopeRatio).toBe(1);
+    expect(decision.timeoutSeconds).toBe(364);
+    expect(decision.timeoutEstimate).toMatchObject({
+      dynamicTimeoutSeconds: 364,
+      reasoning: "4 files",
+    });
+  });
+
   test("adds compact retry evidence when checkpoint, prompt budget, and cache safety signals are complete", async () => {
     const mod = await loadLifecycleModule();
     expect(mod).not.toBeNull();

--- a/src/lib/review-continuation-lifecycle.ts
+++ b/src/lib/review-continuation-lifecycle.ts
@@ -358,7 +358,10 @@ export function planReviewContinuation(
   }
 
   const continuationFiles = retryScope.filesToReview.map((file) => file.filePath);
-  const continuationTimeoutSeconds = Math.max(30, Math.floor(params.timeoutSeconds / 2));
+  const retryCoversAllRemaining = retryScope.scopeRatio >= 1;
+  const continuationTimeoutSeconds = retryCoversAllRemaining
+    ? params.timeoutSeconds
+    : Math.max(30, Math.floor(params.timeoutSeconds / 2));
   const timeoutEstimate = params.estimateContinuationTimeout({
     timeoutSeconds: continuationTimeoutSeconds,
     files: continuationFiles,

--- a/src/review-orchestration/review-timeout-classification.test.ts
+++ b/src/review-orchestration/review-timeout-classification.test.ts
@@ -148,6 +148,29 @@ describe("classifyReviewTimeoutOutcome", () => {
     expect(JSON.stringify(result)).not.toContain("delivery-123");
   });
 
+  test("classifies retry checkpoint progress without findings as bounded retry output", () => {
+    const result = classify({
+      retry: { completed: true, hasResults: true, filesCount: 2 },
+      checkpoint: {
+        filesReviewed: 2,
+        filesInspected: 2,
+        findingCount: 0,
+        totalFiles: 4,
+      },
+    });
+
+    expect(result.mode).toBe("retry-completed");
+    expect(result.classification).toBe("expected-bounded-outcome");
+    expect(result.reasonCodes).toEqual(expect.arrayContaining(["retry-completed", "retry-has-results"]));
+    expect(result.counts).toMatchObject({
+      retryFilesCount: 2,
+      checkpointFilesReviewed: 2,
+      checkpointFilesInspected: 2,
+      checkpointFindingCount: 0,
+      checkpointTotalFiles: 4,
+    });
+  });
+
   test("returns only bounded count fields and clamps invalid optional counts", () => {
     const result = classify({
       outcome: { isTimeout: true },


### PR DESCRIPTION
## Summary
- reduce production warning noise for expected MCP retired-token calls and Slack `users.list` missing-scope responses
- keep small-PR timeout retries from over-reducing scope and preserve timeout budget when retrying all remaining files
- treat checkpoint-backed retry progress as useful even when it finds zero findings
- downgrade complete patch-backed diff fallback to info while preserving warnings for true filename-only/partial fallback
- add addon-check regression coverage that all-timeout runs emit structured classification instead of the legacy raw timeout warning

## Verification
- `bun test src/handlers/addon-check.test.ts src/lib/addon-check-classification.test.ts src/lib/addon-check-formatter.test.ts src/lib/addon-checker-runner.test.ts src/handlers/identity-suggest.test.ts src/execution/mcp/http-server.test.ts src/execution/executor.test.ts src/lib/retry-scope-reducer.test.ts src/lib/review-continuation-lifecycle.test.ts src/review-orchestration/review-timeout-classification.test.ts src/handlers/review.test.ts` → 227 pass, 0 fail
- `bun run lint` → pass
- `bun run verify:m075` → PASS

