### PR TITLE
fix: clean up post-deploy warning followups

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -84,6 +84,13 @@ BUN_BASE_ACR_IMAGE=${BUN_BASE_ACR_IMAGE:-base/oven-bun:1-debian}
 BUN_BASE_IMAGE="${ACR_NAME}.azurecr.io/${BUN_BASE_ACR_IMAGE}"
 IDENTITY_NAME="id-kodiai"
 KEY_VAULT_NAME=${KEY_VAULT_NAME:-}
+SOURCE_COMMIT=${DEPLOY_SOURCE_COMMIT:-$(git rev-parse --verify HEAD)}
+if ! git rev-parse --verify "${SOURCE_COMMIT}^{commit}" >/dev/null 2>&1; then
+  echo "ERROR: DEPLOY_SOURCE_COMMIT '$SOURCE_COMMIT' is not a valid git commit." >&2
+  exit 1
+fi
+SOURCE_COMMIT=$(git rev-parse --verify "${SOURCE_COMMIT}^{commit}")
+SOURCE_COMMIT_SHORT=$(git rev-parse --short=12 "$SOURCE_COMMIT")
 BUILD_CONTEXT_DIR=$(mktemp -d)
 KEYVAULT_TEMP_FILES=()
 
@@ -99,11 +106,11 @@ prepare_build_context() {
   mkdir -p "$BUILD_CONTEXT_DIR"
   rm -rf "$BUILD_CONTEXT_DIR"/*
 
-  cp package.json bun.lock tsconfig.json Dockerfile Dockerfile.agent "$BUILD_CONTEXT_DIR"/
-  mkdir -p "$BUILD_CONTEXT_DIR/src"
-  cp -R src/. "$BUILD_CONTEXT_DIR/src/"
+  git archive --format=tar "$SOURCE_COMMIT" \
+    package.json bun.lock tsconfig.json Dockerfile Dockerfile.agent src \
+    | tar -x -C "$BUILD_CONTEXT_DIR"
 
-  echo "==> Prepared minimal build context at $BUILD_CONTEXT_DIR"
+  echo "==> Prepared git build context at $BUILD_CONTEXT_DIR from commit $SOURCE_COMMIT"
 }
 
 prepare_build_context
@@ -356,6 +363,9 @@ properties:
     containers:
       - name: "${ACA_JOB_NAME}"
         image: "${ACA_JOB_IMAGE}"
+        env:
+          - name: SOURCE_COMMIT
+            value: ${SOURCE_COMMIT}
         volumeMounts:
           - volumeName: kodiai-workspaces
             mountPath: /mnt/kodiai-workspaces
@@ -645,7 +655,7 @@ az containerapp job secret set \
 # -- Deploy Container App -----------------------------------------------------
 echo "==> Deploying container app: $APP_NAME..."
 if az containerapp show --name "$APP_NAME" --resource-group "$RESOURCE_GROUP" --output none 2>/dev/null; then
-  REVISION_SUFFIX="deploy-$(date +%Y%m%d-%H%M%S)"
+  REVISION_SUFFIX="deploy-${SOURCE_COMMIT_SHORT}-$(date +%Y%m%d-%H%M%S)"
   echo "==> Updating existing container app (revision: $REVISION_SUFFIX)..."
   APP_YAML=$(mktemp --suffix=.yaml)
   cat > "$APP_YAML" <<APPYAML
@@ -722,6 +732,8 @@ ${BOT_USER_ENV_YAML}
             value: "3000"
           - name: LOG_LEVEL
             value: info
+          - name: SOURCE_COMMIT
+            value: ${SOURCE_COMMIT}
         probes:
           - type: Liveness
             httpGet:
@@ -801,6 +813,7 @@ else
       SHUTDOWN_GRACE_MS="$SHUTDOWN_GRACE_MS" \
       PORT=3000 \
       LOG_LEVEL=info \
+      SOURCE_COMMIT="$SOURCE_COMMIT" \
       "${BOT_USER_CREATE_ENV_ARGS[@]}" \
     --output none
 
@@ -842,6 +855,8 @@ ${BOT_USER_ENV_YAML}
             value: "3000"
           - name: LOG_LEVEL
             value: info
+          - name: SOURCE_COMMIT
+            value: ${SOURCE_COMMIT}
         probes:
           - type: liveness
             httpGet:

--- a/scripts/deploy.test.ts
+++ b/scripts/deploy.test.ts
@@ -22,6 +22,25 @@ describe("deploy.sh", () => {
     expect(deployScript).toContain('revisionSuffix: ${REVISION_SUFFIX}');
   });
 
+  test("builds deployment context from an explicit git commit hash", () => {
+    expect(deployScript).toContain('SOURCE_COMMIT=${DEPLOY_SOURCE_COMMIT:-$(git rev-parse --verify HEAD)}');
+    expect(deployScript).toContain('git archive --format=tar "$SOURCE_COMMIT"');
+    expect(deployScript).toContain('SOURCE_COMMIT_SHORT=$(git rev-parse --short=12 "$SOURCE_COMMIT")');
+    expect(deployScript).not.toContain('cp -R src/. "$BUILD_CONTEXT_DIR/src/"');
+  });
+
+  test("injects source commit provenance into app and job runtime configuration", () => {
+    expect(deployScript).toContain('REVISION_SUFFIX="deploy-${SOURCE_COMMIT_SHORT}-$(date +%Y%m%d-%H%M%S)"');
+    expect(deployScript).toContain('- name: SOURCE_COMMIT');
+    expect(deployScript).toContain('value: ${SOURCE_COMMIT}');
+    expect(deployScript).toContain('SOURCE_COMMIT="$SOURCE_COMMIT"');
+  });
+
+  test("fails deploy when the selected git commit cannot be verified", () => {
+    expect(deployScript).toContain('git rev-parse --verify "${SOURCE_COMMIT}^{commit}"');
+    expect(deployScript).toContain('ERROR: DEPLOY_SOURCE_COMMIT');
+  });
+
   test("reports the traffic-bearing active revision before falling back to the newest active revision", () => {
     expect(deployScript).toContain('properties.trafficWeight > `0`');
     expect(deployScript).toContain('sort_by(@, &properties.createdTime) | [-1].name');

--- a/src/handlers/identity-suggest.test.ts
+++ b/src/handlers/identity-suggest.test.ts
@@ -265,6 +265,35 @@ describe("suggestIdentityLink", () => {
     expect(logger.warn).not.toHaveBeenCalled();
   });
 
+  test("production-shaped Slack users.list missing_scope response disables identity suggestions without warning", async () => {
+    const logger = createMockLogger();
+    const fetchMock = mock(async () =>
+      jsonResponse(
+        { ok: false, error: "missing_scope: users:read required" },
+        { status: 403 },
+      ),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+    await identitySuggest.suggestIdentityLink({
+      githubUsername: "scope-missing-production-shape",
+      githubDisplayName: "Scope Missing Production Shape",
+      slackBotToken: "xoxb-production-shape",
+      profileStore: createMockProfileStore(),
+      logger,
+    });
+
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: "missing_scope",
+        slackError: "missing_scope: users:read required",
+        httpStatus: 403,
+      }),
+      "Slack member lookup disabled; missing users.list scope",
+    );
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
   test("missing Slack users.list scope disable cache evicts old token entries", async () => {
     const logger = createMockLogger();
     const requests: string[] = [];

--- a/src/handlers/identity-suggest.ts
+++ b/src/handlers/identity-suggest.ts
@@ -36,6 +36,14 @@ export function resetIdentitySuggestionStateForTests(): void {
   suggestedUsernames.clear();
 }
 
+function normalizeSlackErrorCode(error: unknown): string {
+  return typeof error === "string" && error.length > 0 ? error : "unknown";
+}
+
+function isSlackMissingScopeError(error: unknown): boolean {
+  return /(?:^|\b)missing_scope(?:\b|$)/.test(normalizeSlackErrorCode(error));
+}
+
 async function fetchSlackMembers(
   botToken: string,
   logger: Logger,
@@ -83,14 +91,15 @@ async function fetchSlackMembers(
     throw new Error("Slack users.list returned malformed JSON");
   }
 
-  if (!response.ok && data?.error !== "missing_scope") {
+  if (!response.ok && !isSlackMissingScopeError(data?.error)) {
     throw new Error(`Slack users.list HTTP ${response.status}`);
   }
 
   if (!data?.ok) {
-    const errorCode = data?.error ?? "unknown";
-    if (errorCode === "missing_scope") {
-      slackMemberLookupDisabledReasonsByToken.set(botToken, errorCode);
+    const errorCode = normalizeSlackErrorCode(data?.error);
+    if (isSlackMissingScopeError(errorCode)) {
+      const disabledReason = "missing_scope";
+      slackMemberLookupDisabledReasonsByToken.set(botToken, disabledReason);
       if (slackMemberLookupDisabledReasonsByToken.size > MAX_DISABLED_SLACK_MEMBER_LOOKUP_TOKENS) {
         const oldestToken = slackMemberLookupDisabledReasonsByToken.keys().next().value;
         if (oldestToken !== undefined) {
@@ -98,7 +107,7 @@ async function fetchSlackMembers(
         }
       }
       logger.info(
-        { reason: errorCode, httpStatus: response.status },
+        { reason: disabledReason, slackError: errorCode, httpStatus: response.status },
         "Slack member lookup disabled; missing users.list scope",
       );
       return [];

--- a/src/handlers/mention.test.ts
+++ b/src/handlers/mention.test.ts
@@ -7837,6 +7837,8 @@ describe("createMentionHandler review command", () => {
       },
     };
 
+    const { logger, infoCalls } = createMockLogger();
+
     createMentionHandler({
       eventRouter,
       jobQueue,
@@ -7865,7 +7867,7 @@ describe("createMentionHandler review command", () => {
         }),
       } as never,
       telemetryStore: noopTelemetryStore,
-      logger: createNoopLogger(),
+      logger,
     });
 
     const handler = handlers.get("issue_comment.created");
@@ -7885,6 +7887,15 @@ describe("createMentionHandler review command", () => {
     expect(issueReplies[0]).not.toContain("Ask a more targeted question");
     expect(issueReplies[0]).not.toContain("This can happen on PRs with large or complex diffs");
     expect(issueReplies[0]).not.toContain("I completed the review run but couldn't publish a GitHub review/comment from it.");
+
+    const completionLog = infoCalls.find((entry) => entry.message === "Mention execution completed");
+    expect(completionLog?.bindings.conclusion).toBe("failure");
+    expect(completionLog?.bindings.failureSubtype).toBe("error_max_turns");
+    expect(completionLog?.bindings.stopReason).toBe("tool_use");
+    expect(completionLog?.bindings.executorPublished).toBe(false);
+    expect(completionLog?.bindings.published).toBe(true);
+    expect(completionLog?.bindings.publishResolution).toBe("turn-limit-fallback");
+    expect(completionLog?.bindings.publishFallbackDelivery).toBe("error-comment-created");
 
     await workspaceFixture.cleanup();
   });
@@ -9162,8 +9173,8 @@ describe("createMentionHandler review command", () => {
 
     expect(createdReviews).toHaveLength(1);
     expect(createdReviews[0]?.event).toBe("APPROVE");
-    expect(createdReviews[0]?.body).toContain("<details>");
-    expect(createdReviews[0]?.body).toContain("<summary>kodiai response</summary>");
+    expect(createdReviews[0]?.body).not.toContain("<summary>kodiai response</summary>");
+    expect(createdReviews[0]?.body).toStartWith("Decision: APPROVE\n\nIssues: none");
     expect(createdReviews[0]?.body).toContain("Decision: APPROVE");
     expect(createdReviews[0]?.body).toContain("Issues: none");
     expect(createdReviews[0]?.body).toContain("Evidence:");
@@ -9330,8 +9341,8 @@ describe("createMentionHandler review command", () => {
 
     expect(createdReviews).toHaveLength(0);
     expect(issueReplies).toHaveLength(1);
-    expect(issueReplies[0]).toContain("<details>");
-    expect(issueReplies[0]).toContain("<summary>kodiai response</summary>");
+    expect(issueReplies[0]).not.toContain("<summary>kodiai response</summary>");
+    expect(issueReplies[0]).toStartWith("Decision: APPROVE\n\nIssues: none");
     expect(issueReplies[0]).toContain("Decision: APPROVE");
     expect(issueReplies[0]).toContain("Issues: none");
     expect(issueReplies[0]).toContain("Evidence:");
@@ -13320,7 +13331,8 @@ describe("createMentionHandler formatter suggestion intent context", () => {
     );
     expect(completionLog?.bindings).toMatchObject({
       reviewConclusion: "error",
-      publishResolution: "none",
+      publishResolution: "error-fallback",
+      publishFallbackDelivery: "error-comment-created",
       formatterStatus: "posted",
       combinedPartialFailure: true,
     });

--- a/src/handlers/mention.ts
+++ b/src/handlers/mention.ts
@@ -122,7 +122,13 @@ type MentionPublishResolution =
   | "idempotency-skip"
   | "duplicate-suppressed"
   | "publish-failure-fallback"
-  | "publish-failure-comment-failed";
+  | "publish-failure-comment-failed"
+  | "error-fallback"
+  | "error-comment-failed"
+  | "turn-limit-fallback"
+  | "turn-limit-fallback-failed"
+  | "failure-fallback"
+  | "failure-fallback-failed";
 type MentionErrorDelivery =
   | "review-thread-reply"
   | "error-comment-created"
@@ -3375,41 +3381,50 @@ export function createMentionHandler(deps: {
         const mentionFailureSubtype = result.failureSubtype
           ?? classifyMentionExecutionFailureSubtype(result.errorMessage);
 
-        logger.info(
-          {
-            surface: mention.surface,
-            issueNumber: mention.issueNumber,
-            conclusion: result.conclusion,
-            published: mentionOutputPublished,
-            executorPublished: result.published,
-            publishResolution,
-            publishFailureCategory,
-            publishFallbackDelivery,
-            writeEnabled,
-            costUsd: result.costUsd,
-            numTurns: result.numTurns,
-            durationMs: result.durationMs,
-            sessionId: result.sessionId,
-            stopReason: result.stopReason,
-            failureSubtype: mentionFailureSubtype,
-            errorCategory: mentionExecutionErrorCategory,
-            usedRepoInspectionTools: result.usedRepoInspectionTools ?? false,
-            toolUseNames: result.toolUseNames ?? [],
-            mentionDerivedContextCacheStatus,
-            ...(mentionDerivedContextCacheReason
-              ? { mentionDerivedContextCacheReason }
-              : {}),
-            ...(explicitReviewRequest
-              ? {
-                explicitReviewRequest: true,
-                taskType: "review.full",
-                lane: "interactive-review",
-              }
-              : {}),
-            ...(reviewOutputKey ? { reviewOutputKey } : {}),
-          },
-          "Mention execution completed",
-        );
+        const logMentionExecutionCompleted = (): void => {
+          logger.info(
+            {
+              surface: mention.surface,
+              issueNumber: mention.issueNumber,
+              conclusion: result.conclusion,
+              published: mentionOutputPublished,
+              executorPublished: result.published,
+              publishResolution,
+              publishFailureCategory,
+              publishFallbackDelivery,
+              writeEnabled,
+              costUsd: result.costUsd,
+              numTurns: result.numTurns,
+              durationMs: result.durationMs,
+              sessionId: result.sessionId,
+              stopReason: result.stopReason,
+              failureSubtype: mentionFailureSubtype,
+              errorCategory: mentionExecutionErrorCategory,
+              usedRepoInspectionTools: result.usedRepoInspectionTools ?? false,
+              toolUseNames: result.toolUseNames ?? [],
+              mentionDerivedContextCacheStatus,
+              ...(mentionDerivedContextCacheReason
+                ? { mentionDerivedContextCacheReason }
+                : {}),
+              ...(explicitReviewRequest
+                ? {
+                  explicitReviewRequest: true,
+                  taskType: "review.full",
+                  lane: "interactive-review",
+                }
+                : {}),
+              ...(reviewOutputKey ? { reviewOutputKey } : {}),
+            },
+            "Mention execution completed",
+          );
+        };
+        const shouldDeferMentionCompletionLog =
+          !mentionOutputPublished
+          && !reviewPublishRightsLost
+          && (result.conclusion === "failure" || result.conclusion === "error");
+        if (!shouldDeferMentionCompletionLog) {
+          logMentionExecutionCompleted();
+        }
 
         if (mention.inReplyToId !== undefined && result.conclusion === "success") {
           const conversationKey = `${mention.owner}/${mention.repo}#${mention.prNumber ?? mention.issueNumber}`;
@@ -4307,7 +4322,15 @@ export function createMentionHandler(deps: {
             !explicitReviewRequest
             || canPublishExplicitReviewOutput("explicit mention review error fallback", reviewOutputKey)
           ) {
-            await postMentionError(errorBody);
+            const fallbackResult = await postMentionError(errorBody);
+            publishFallbackDelivery = fallbackResult.delivery;
+            if (fallbackResult.posted) {
+              mentionOutputPublished = true;
+              publishResolution = "error-fallback";
+            } else {
+              mentionOutputPublished = false;
+              publishResolution = "error-comment-failed";
+            }
           }
         }
 
@@ -4340,7 +4363,15 @@ export function createMentionHandler(deps: {
                 !explicitReviewRequest
                 || canPublishExplicitReviewOutput("explicit mention review failure fallback", reviewOutputKey)
               ) {
-                await postMentionError(turnLimitBody);
+                const fallbackResult = await postMentionError(turnLimitBody);
+                publishFallbackDelivery = fallbackResult.delivery;
+                if (fallbackResult.posted) {
+                  mentionOutputPublished = true;
+                  publishResolution = "turn-limit-fallback";
+                } else {
+                  mentionOutputPublished = false;
+                  publishResolution = "turn-limit-fallback-failed";
+                }
               }
             } catch (postErr) {
               logger.warn(
@@ -4368,7 +4399,15 @@ export function createMentionHandler(deps: {
                 !explicitReviewRequest
                 || canPublishExplicitReviewOutput("explicit mention review failure fallback", reviewOutputKey)
               ) {
-                await postMentionError(failureBody);
+                const fallbackResult = await postMentionError(failureBody);
+                publishFallbackDelivery = fallbackResult.delivery;
+                if (fallbackResult.posted) {
+                  mentionOutputPublished = true;
+                  publishResolution = "failure-fallback";
+                } else {
+                  mentionOutputPublished = false;
+                  publishResolution = "failure-fallback-failed";
+                }
               }
             } catch (postErr) {
               logger.warn(
@@ -4377,6 +4416,10 @@ export function createMentionHandler(deps: {
               );
             }
           }
+        }
+
+        if (shouldDeferMentionCompletionLog) {
+          logMentionExecutionCompleted();
         }
 
         if (isCombinedFormatterSuggestionRequest) {

--- a/src/handlers/review-idempotency.test.ts
+++ b/src/handlers/review-idempotency.test.ts
@@ -176,7 +176,7 @@ describe("review idempotency helpers", () => {
     expect(result).toBe(reviewOutputKey);
   });
 
-  test("buildApprovedReviewBody emits collapsed markdown with bounded evidence bullets and marker continuity", () => {
+  test("buildApprovedReviewBody emits visible response first with bounded evidence bullets and marker continuity", () => {
     const reviewOutputKey = buildReviewOutputKey({
       installationId: 42,
       owner: "acme",
@@ -199,10 +199,9 @@ describe("review idempotency helpers", () => {
       approvalConfidence: "  :green_circle: **Merge Confidence: High** — Safe to merge.  ",
     });
 
-    expect(result).toContain("<details>");
-    expect(result).toContain("<summary>kodiai response</summary>");
+    expect(result).not.toContain("<summary>kodiai response</summary>");
+    expect(result.trimStart()).toStartWith("Decision: APPROVE\n\nIssues: none");
     expect(result).toContain("Decision: APPROVE");
-    expect(result.indexOf("Decision: APPROVE")).toBeLessThan(result.indexOf("<details>"));
     expect(result).toContain("Issues: none");
     expect(result).toContain("Evidence:");
     expect(result).toContain(marker);
@@ -240,8 +239,8 @@ describe("review idempotency helpers", () => {
     expect(extractEvidenceBullets(result)).toEqual([
       "- No actionable issues were identified in the reviewed changes.",
     ]);
-    expect(result).toContain("<details>");
-    expect(result).toContain("<summary>kodiai response</summary>");
+    expect(result).not.toContain("<details>");
+    expect(result).not.toContain("<summary>kodiai response</summary>");
   });
 
   test("buildApprovedReviewBody can inline Review Details while preserving canonical marker discovery", () => {
@@ -272,6 +271,9 @@ describe("review idempotency helpers", () => {
     });
 
     expect(result).toContain("Decision: APPROVE");
+    expect(result.trimStart()).toStartWith("Decision: APPROVE\n\nIssues: none");
+    expect(result).not.toContain("<summary>kodiai response</summary>");
+    expect(result.indexOf("Decision: APPROVE")).toBeLessThan(result.indexOf("<summary>Review Details</summary>"));
     expect(result).toContain("<summary>Review Details</summary>");
     expect(result).toContain(`<!-- kodiai:review-details:${reviewOutputKey} -->`);
     expect(extractReviewOutputKey(result)).toBe(reviewOutputKey);
@@ -303,8 +305,8 @@ describe("review idempotency helpers", () => {
       "- Tests relevant to touched files are already green.",
     ]);
     expect(result).toContain(buildReviewOutputMarker(reviewOutputKey));
-    expect(result).toContain("<details>");
-    expect(result).toContain("<summary>kodiai response</summary>");
+    expect(result).not.toContain("<details>");
+    expect(result).not.toContain("<summary>kodiai response</summary>");
   });
 
   test("ensureReviewOutputNotPublished returns skip decision when marker exists in review comments", async () => {

--- a/src/handlers/review-idempotency.ts
+++ b/src/handlers/review-idempotency.ts
@@ -1,5 +1,4 @@
 import type { Octokit } from "@octokit/rest";
-import { wrapInDetails } from "../lib/formatting.ts";
 
 export type ReviewOutputKeyInput = {
   installationId: number;
@@ -302,18 +301,14 @@ export function buildApprovedReviewBody(params: {
 }): string {
   const marker = buildReviewOutputMarker(params.reviewOutputKey);
   const evidence = buildApprovedReviewEvidence(params);
-  const visibleDecisionLine = "Decision: APPROVE";
-  const collapsedBody = wrapInDetails(
-    [
-      visibleDecisionLine,
-      "Issues: none",
-      "",
-      "Evidence:",
-      ...evidence.map((line) => `- ${line}`),
-    ].join("\n"),
-    "kodiai response",
-  );
-  const approvalBody = `${visibleDecisionLine}\n\n${collapsedBody}`;
+  const approvalBody = [
+    "Decision: APPROVE",
+    "",
+    "Issues: none",
+    "",
+    "Evidence:",
+    ...evidence.map((line) => `- ${line}`),
+  ].join("\n");
   const reviewDetailsBlock = params.reviewDetailsBlock?.trim();
 
   return reviewDetailsBlock

--- a/src/handlers/review.test.ts
+++ b/src/handlers/review.test.ts
@@ -2597,6 +2597,8 @@ describe("createReviewHandler review_requested idempotency", () => {
     expect(issueCommentCreateCount).toBe(0);
     expect(existingApprovalReview.body).toStartWith("Decision: APPROVE");
     expect(existingApprovalReview.body.match(/Decision: APPROVE/g) ?? []).toHaveLength(1);
+    expect(existingApprovalReview.body).not.toContain("<summary>kodiai response</summary>");
+    expect(existingApprovalReview.body.indexOf("Issues: none")).toBeLessThan(existingApprovalReview.body.indexOf("<summary>Review Details</summary>"));
     expect(existingApprovalReview.body).toContain("<summary>Review Details</summary>");
     expect(existingApprovalReview.body).toContain("publication:");
   });
@@ -2719,6 +2721,8 @@ describe("createReviewHandler review_requested idempotency", () => {
     expect(issueCommentCreateCount).toBe(0);
     expect(existingApprovalReview.body).toStartWith("Decision: APPROVE");
     expect(existingApprovalReview.body.match(/Decision: APPROVE/g) ?? []).toHaveLength(1);
+    expect(existingApprovalReview.body).not.toContain("<summary>kodiai response</summary>");
+    expect(existingApprovalReview.body.indexOf("Issues: none")).toBeLessThan(existingApprovalReview.body.indexOf("<summary>Review Details</summary>"));
     expect(existingApprovalReview.body).toContain("<summary>Review Details</summary>");
     expect(existingApprovalReview.body).toContain("publication:");
   });
@@ -5462,8 +5466,10 @@ describe("createReviewHandler diff collection resilience", () => {
         entry.message === "Diff collection degraded to GitHub file-list fallback"
       );
       expect(fallbackLog).toBeDefined();
+      expect(fallbackLog?.level).toBe("info");
       expect(fallbackLog?.data?.stage).toBe("merge-base-recovery");
       expect(fallbackLog?.data?.strategy).toBe("github-file-list-fallback");
+      expect(fallbackLog?.data?.fallbackEvidenceQuality).toBe("filename-only-small");
     } finally {
       await workspaceFixture.cleanup();
     }
@@ -19304,6 +19310,132 @@ describe("createReviewHandler failure fallback publication", () => {
     expect(combinedBodies).not.toContain("**Bounded first-pass review**");
     expect(combinedBodies).not.toContain("stopped at max-turns");
     expect(combinedBodies).not.toContain("follow-up review is pending");
+
+    await workspaceFixture.cleanup();
+  });
+
+  test("logs turn-limit fallback publication after normal review fallback comment posts", async () => {
+    const handlers = new Map<string, (event: WebhookEvent) => Promise<void>>();
+    const workspaceFixture = await createWorkspaceFixture();
+    const createdCommentBodies: string[] = [];
+    const { logger, entries } = createCaptureLogger();
+
+    createReviewHandler({
+      eventRouter: {
+        register: (eventKey, handler) => {
+          handlers.set(eventKey, handler);
+        },
+        dispatch: async () => undefined,
+      },
+      jobQueue: {
+        enqueue: async <T>(
+          _installationId: number,
+          fn: (metadata: JobQueueRunMetadata) => Promise<T>,
+        ) => fn(createQueueRunMetadata()),
+        getQueueSize: () => 0,
+        getPendingCount: () => 0,
+        getActiveJobs: getEmptyActiveJobs,
+      } as unknown as JobQueue,
+      workspaceManager: {
+        create: async () => ({
+          dir: workspaceFixture.dir,
+          cleanup: async () => undefined,
+        }),
+        cleanupStale: async () => 0,
+      } as WorkspaceManager,
+      githubApp: {
+        getAppSlug: () => "kodiai",
+        getInstallationOctokit: async () => ({
+          rest: {
+            pulls: {
+              listReviewComments: async () => ({ data: [] }),
+              listReviews: async () => ({ data: [] }),
+              listCommits: async () => ({ data: [] }),
+              createReview: async () => ({ data: {} }),
+            },
+            issues: {
+              listComments: async () => ({ data: [] }),
+              createComment: async (params: { body: string }) => {
+                createdCommentBodies.push(params.body);
+                return { data: { id: 502 } };
+              },
+              updateComment: async (params: { body: string }) => {
+                createdCommentBodies.push(params.body);
+                return { data: {} };
+              },
+            },
+            reactions: {
+              createForIssue: async () => ({ data: {} }),
+            },
+            search: {
+              issuesAndPullRequests: async () => ({ data: { total_count: 0 } }),
+            },
+          },
+        }) as never,
+      } as unknown as GitHubApp,
+      executor: {
+        execute: async () => ({
+          conclusion: "failure",
+          published: false,
+          stopReason: "tool_use",
+          failureSubtype: "error_max_turns",
+          durationMs: 263_331,
+          numTurns: 26,
+          sessionId: "session-normal-review-turn-limit-fallback",
+          costUsd: 0,
+        }),
+      } as never,
+      telemetryStore: {
+        ...noopTelemetryStore,
+        countRecentTimeouts: async () => 3,
+      },
+      knowledgeStore: createKnowledgeStoreStub({
+        getCheckpoint: async () => null,
+        upsertContinuationFamilyState: async () => undefined,
+      }) as never,
+      diffContextCollector: async () => ({
+        changedFiles: ["README.md", "src/a.ts", "src/b.ts"],
+        numstatLines: [],
+        diffContent: undefined,
+        strategy: "github-file-list-fallback",
+        mergeBaseRecovered: false,
+        deepenAttempts: 0,
+        unshallowAttempted: false,
+        diffRange: "github-api:file-list",
+      }),
+      logger,
+    });
+
+    const handler = handlers.get("pull_request.review_requested");
+    expect(handler).toBeDefined();
+
+    await handler!(
+      buildReviewRequestedEvent({
+        requested_reviewer: { login: "kodiai[bot]" },
+      }),
+    );
+
+    expect(createdCommentBodies.join("\n")).toContain("Kodiai ran out of steps while reviewing this PR");
+
+    const completionLog = entries.find((entry) => entry.message === "Review execution completed");
+    expect(completionLog?.data).toMatchObject({
+      prNumber: 101,
+      conclusion: "failure",
+      executorPublished: false,
+      published: true,
+      publishResolution: "turn-limit-fallback",
+      publishFallbackDelivery: "error-comment-created",
+      failureSubtype: "error_max_turns",
+    });
+
+    const phaseSummaryLog = entries.find((entry) => entry.message === "Review phase timing summary");
+    expect(phaseSummaryLog?.data).toMatchObject({
+      prNumber: 101,
+      conclusion: "failure",
+      published: true,
+      publishResolution: "turn-limit-fallback",
+      publishFallbackDelivery: "error-comment-created",
+    });
 
     await workspaceFixture.cleanup();
   });

--- a/src/handlers/review.ts
+++ b/src/handlers/review.ts
@@ -1479,6 +1479,13 @@ async function upsertDegradedReviewDetailsFallbackComment(params: {
   return response.data.id;
 }
 
+function unwrapKodiaiResponseDetails(summaryBody: string): string {
+  return summaryBody.replace(
+    /\n?<details>\s*\n?<summary>kodiai response<\/summary>\s*\n+([\s\S]*?)\n<\/details>\n?/,
+    (_match, inner: string) => `\n${inner.trim()}\n`,
+  ).trim();
+}
+
 function ensureVisibleApprovalDecision(summaryBody: string): string {
   if (!summaryBody.includes("Decision: APPROVE")) {
     return summaryBody;
@@ -1505,9 +1512,11 @@ function mergeReviewDetailsIntoSummaryBody(params: {
 }): string {
   let updatedReviewDetails = params.reviewDetailsBlock;
   let summaryBody = ensureVisibleApprovalDecision(
-    ensureReviewBoundednessDisclosureInSummary(
-      params.summaryBody,
-      params.reviewBoundedness,
+    unwrapKodiaiResponseDetails(
+      ensureReviewBoundednessDisclosureInSummary(
+        params.summaryBody,
+        params.reviewBoundedness,
+      ),
     ),
   );
   if (params.requireDegradationDisclosure) {
@@ -1883,14 +1892,17 @@ async function buildDiffCollectionFallback(params: {
   }
 
   const changedFiles = Array.from(new Set(await fallbackFileProvider()));
+  const boundedFilenameOnlyFallback = changedFiles.length <= 10;
+  const logFallback = boundedFilenameOnlyFallback ? logger.info.bind(logger) : logger.warn.bind(logger);
 
-  logger.warn(
+  logFallback(
     {
       ...baseLog,
       gate: "diff-collection",
       stage,
       reason,
       strategy: "github-file-list-fallback",
+      fallbackEvidenceQuality: boundedFilenameOnlyFallback ? "filename-only-small" : "filename-only",
       deepenAttempts,
       unshallowAttempted,
       mergeBaseRecovered,
@@ -3208,6 +3220,38 @@ export function createReviewHandler(deps: {
         "executor phase timings unavailable",
       );
       let executorResult: Awaited<ReturnType<typeof executor.execute>> | undefined;
+      let reviewExecutionLogged = false;
+      let reviewOutputPublished = false;
+      let reviewExecutorPublished = false;
+      let reviewPublishResolution = "none";
+      let reviewPublishFallbackDelivery: string | undefined;
+
+      function describeErrorCommentDelivery(status: Awaited<ReturnType<typeof postOrUpdateErrorComment>>): string {
+        if (!status.ok) return "error-comment-failed";
+        return status.resolution === "updated" ? "error-comment-updated" : "error-comment-created";
+      }
+
+      function logReviewExecutionCompleted(): void {
+        if (!executorResult || reviewExecutionLogged) return;
+        reviewExecutionLogged = true;
+        logger.info(
+          {
+            prNumber: pr.number,
+            conclusion: executorResult.conclusion,
+            published: reviewOutputPublished,
+            executorPublished: reviewExecutorPublished,
+            publishResolution: reviewPublishResolution,
+            publishFallbackDelivery: reviewPublishFallbackDelivery,
+            failureSubtype: executorResult.failureSubtype,
+            stopReason: executorResult.stopReason,
+            costUsd: executorResult.costUsd,
+            numTurns: executorResult.numTurns,
+            durationMs: executorResult.durationMs,
+            sessionId: executorResult.sessionId,
+          },
+          "Review execution completed",
+        );
+      }
 
       function setReviewWorkPhaseForAttempt(
         attemptId: string,
@@ -5290,6 +5334,9 @@ export function createReviewHandler(deps: {
           maxTurnsOverride: reviewMaxTurnsOverride,
         });
         executorResult = result;
+        reviewExecutorPublished = result.published ?? false;
+        reviewOutputPublished = result.published ?? false;
+        reviewPublishResolution = reviewOutputPublished ? "executor" : "none";
         visiblePromptSectionRecords = result.promptSections ?? visiblePromptSectionRecords;
         refreshReviewVisibleBudgetProjection();
         executorPhaseTimings = result.executorPhaseTimings ?? buildExecutorUnavailablePhases(
@@ -5299,19 +5346,6 @@ export function createReviewHandler(deps: {
           reviewPhaseTimings.set(phase.name, phase);
         }
         publicationPhaseStartedAt = Date.now();
-
-        logger.info(
-          {
-            prNumber: pr.number,
-            conclusion: result.conclusion,
-            published: result.published,
-            costUsd: result.costUsd,
-            numTurns: result.numTurns,
-            durationMs: result.durationMs,
-            sessionId: result.sessionId,
-          },
-          "Review execution completed",
-        );
 
         if (result.candidateVerificationPublicationEvidence) {
           logger.info(
@@ -7869,11 +7903,18 @@ export function createReviewHandler(deps: {
             const octokit = await githubApp.getInstallationOctokit(event.installationId);
             if (canPublishVisibleOutput("error comment")) {
               setReviewWorkPhase("publish");
-              await postOrUpdateErrorComment(octokit, {
+              const publicationStatus = await postOrUpdateErrorComment(octokit, {
                 owner: apiOwner,
                 repo: apiRepo,
                 issueNumber: pr.number,
               }, sanitizeOutgoingMentions(errorBody, [githubApp.getAppSlug(), "claude"]), logger);
+              reviewPublishFallbackDelivery = describeErrorCommentDelivery(publicationStatus);
+              if (publicationStatus.ok) {
+                reviewOutputPublished = true;
+                reviewPublishResolution = exhaustedTurnBudget ? "turn-limit-fallback" : "error-fallback";
+              } else {
+                reviewPublishResolution = exhaustedTurnBudget ? "turn-limit-fallback-failed" : "error-comment-failed";
+              }
             }
           }
         }
@@ -7892,7 +7933,7 @@ export function createReviewHandler(deps: {
           const octokit = await githubApp.getInstallationOctokit(event.installationId);
           if (canPublishVisibleOutput("failure fallback comment")) {
             setReviewWorkPhase("publish");
-            await postOrUpdateErrorComment(
+            const publicationStatus = await postOrUpdateErrorComment(
               octokit,
               {
                 owner: apiOwner,
@@ -7902,6 +7943,13 @@ export function createReviewHandler(deps: {
               sanitizeOutgoingMentions(failureBody, [githubApp.getAppSlug(), "claude"]),
               logger,
             );
+            reviewPublishFallbackDelivery = describeErrorCommentDelivery(publicationStatus);
+            if (publicationStatus.ok) {
+              reviewOutputPublished = true;
+              reviewPublishResolution = "failure-fallback";
+            } else {
+              reviewPublishResolution = "failure-fallback-failed";
+            }
           }
         }
 
@@ -8082,6 +8130,9 @@ export function createReviewHandler(deps: {
               logCanonicalReviewDetailsPublicationCompleted(finalizedCleanReviewDetails);
             }
 
+            reviewOutputPublished = true;
+            reviewPublishResolution = config.review.autoApprove ? "auto-approval" : "clean-review-comment";
+
             logger.info(
               {
                 evidenceType: "review",
@@ -8208,6 +8259,8 @@ export function createReviewHandler(deps: {
           );
         }
 
+        logReviewExecutionCompleted();
+
         const shouldLogPhaseSummary =
           workspacePhaseStartedAt !== undefined ||
           retrievalPhaseStartedAt !== undefined ||
@@ -8231,7 +8284,9 @@ export function createReviewHandler(deps: {
                 repo: `${apiOwner}/${apiRepo}`,
                 prNumber: pr.number,
                 conclusion: executorResult?.conclusion,
-                published: executorResult?.published,
+                published: executorResult ? reviewOutputPublished : undefined,
+                publishResolution: executorResult ? reviewPublishResolution : undefined,
+                publishFallbackDelivery: reviewPublishFallbackDelivery,
                 totalDurationMs,
                 phases,
               },

--- a/src/knowledge/wiki-sync.test.ts
+++ b/src/knowledge/wiki-sync.test.ts
@@ -178,6 +178,47 @@ describe("createWikiSyncScheduler", () => {
     );
   });
 
+  test("skips null parse payloads as malformed without falling into page-level warning", async () => {
+    const store = createMockStore();
+    const logger = createMockLogger();
+
+    const fetchFn = mockFetch(async (url: string) => {
+      if (url.includes("list=recentchanges")) {
+        return new Response(JSON.stringify(buildRCResponse([
+          { pageid: 3500, title: "NullParsePage", revid: 200 },
+        ])));
+      }
+      if (url.includes("action=parse")) {
+        return new Response("null");
+      }
+      return new Response("", { status: 404 });
+    }) as typeof globalThis.fetch;
+
+    const scheduler = createWikiSyncScheduler({
+      store,
+      embeddingProvider: createMockEmbeddingProvider(),
+      source: "kodi.wiki",
+      delayMs: 0,
+      logger,
+      fetchFn,
+    });
+
+    const result = await scheduler.syncNow();
+
+    expect(result.pagesChecked).toBe(1);
+    expect(result.pagesUpdated).toBe(0);
+    expect(result.pagesDeleted).toBe(0);
+    expect(store.replacePageChunks).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ pageId: 3500, reason: "malformed-parse-response" }),
+      "Wiki sync parse response malformed, skipping page",
+    );
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      expect.objectContaining({ pageId: 3500 }),
+      "Wiki sync page processing failed, continuing",
+    );
+  });
+
   test("soft-deletes pages that become redirects", async () => {
     const store = createMockStore();
     // Page existed before (has a revision)

--- a/src/knowledge/wiki-sync.ts
+++ b/src/knowledge/wiki-sync.ts
@@ -194,17 +194,18 @@ async function runSync(opts: {
           continue;
         }
 
+        const parseRecord = parseData && typeof parseData === "object" ? parseData : undefined;
         if (
-          typeof parseData.parse?.title !== "string"
-          || typeof parseData.parse?.revid !== "number"
-          || typeof parseData.parse?.text?.["*"] !== "string"
+          typeof parseRecord?.parse?.title !== "string"
+          || typeof parseRecord.parse?.revid !== "number"
+          || typeof parseRecord.parse?.text?.["*"] !== "string"
         ) {
           logger.warn(
             {
               pageId: change.pageid,
               reason: "malformed-parse-response",
-              errorCode: parseData.error?.code,
-              errorInfo: parseData.error?.info,
+              errorCode: parseRecord?.error?.code,
+              errorInfo: parseRecord?.error?.info,
             },
             "Wiki sync parse response malformed, skipping page",
           );
@@ -213,7 +214,7 @@ async function runSync(opts: {
         }
 
         const namespace = namespaceIdToName(change.ns);
-        const pageTitle = parseData.parse.title;
+        const pageTitle = parseRecord.parse.title;
         const pageUrl = `${baseUrl}/view/${encodeURIComponent(pageTitle.replace(/ /g, "_"))}`;
 
         const pageInput: WikiPageInput = {
@@ -221,8 +222,8 @@ async function runSync(opts: {
           pageTitle,
           namespace,
           pageUrl,
-          htmlContent: parseData.parse.text["*"],
-          revisionId: parseData.parse.revid,
+          htmlContent: parseRecord.parse.text["*"],
+          revisionId: parseRecord.parse.revid,
         };
 
         // Chunk the page

--- a/src/review-audit/review-output-artifacts.test.ts
+++ b/src/review-audit/review-output-artifacts.test.ts
@@ -225,7 +225,7 @@ describe("review output artifact helpers", () => {
     } satisfies Partial<ReviewOutputArtifactCollectionError>);
   });
 
-  test("validateCollapsedApproveReviewBody accepts the shipped collapsed APPROVE grammar with 1-3 bullets", () => {
+  test("validateCollapsedApproveReviewBody accepts the shipped visible APPROVE grammar with 1-3 bullets", () => {
     const oneBulletKey = makeReviewOutputKey({ deliveryId: "delivery-one" });
     const threeBulletKey = makeReviewOutputKey({ deliveryId: "delivery-three" });
 
@@ -242,7 +242,7 @@ describe("review output artifact helpers", () => {
         reviewOutputKey: threeBulletKey,
         evidence: [
           "Reviewed the touched files and found no actionable issues.",
-          "The approval body matches the collapsed GitHub contract.",
+          "The approval body matches the visible GitHub contract.",
           "No visible approval body drift is present.",
         ],
       }),
@@ -251,7 +251,7 @@ describe("review output artifact helpers", () => {
     expect(oneBullet.valid).toBe(true);
     expect(oneBullet.evidenceBulletCount).toBe(1);
     expect(oneBullet.hasExactMarker).toBe(true);
-    expect(oneBullet.hasDetailsWrapper).toBe(true);
+    expect(oneBullet.hasDetailsWrapper).toBe(false);
 
     expect(threeBullets.valid).toBe(true);
     expect(threeBullets.evidenceBulletCount).toBe(3);
@@ -259,7 +259,7 @@ describe("review output artifact helpers", () => {
     expect(threeBullets.issues).toEqual([]);
   });
 
-  test("validateCollapsedApproveReviewBody rejects missing Evidence bullets, overflow bullets, and visible-body drift", () => {
+  test("validateCollapsedApproveReviewBody rejects missing Evidence bullets, overflow bullets, and legacy collapsed response wrappers", () => {
     const reviewOutputKey = makeReviewOutputKey();
 
     const zeroBullets = validateCollapsedApproveReviewBody({
@@ -288,14 +288,21 @@ describe("review output artifact helpers", () => {
         buildReviewOutputMarker(reviewOutputKey),
       ].join("\n"),
     });
-    const visible = validateCollapsedApproveReviewBody({
+    const legacyCollapsed = validateCollapsedApproveReviewBody({
       reviewOutputKey,
       body: [
+        "Decision: APPROVE",
+        "",
+        "<details>",
+        "<summary>kodiai response</summary>",
+        "",
         "Decision: APPROVE",
         "Issues: none",
         "",
         "Evidence:",
         "- Reviewed the changed files.",
+        "",
+        "</details>",
         "",
         buildReviewOutputMarker(reviewOutputKey),
       ].join("\n"),
@@ -309,12 +316,12 @@ describe("review output artifact helpers", () => {
     expect(fourBullets.evidenceBulletCount).toBe(4);
     expect(fourBullets.issues).toContain("Approval body must include 1-3 evidence bullets.");
 
-    expect(visible.valid).toBe(false);
-    expect(visible.hasDetailsWrapper).toBe(false);
-    expect(visible.issues).toContain("Approval body must use collapsed <details> wrapper text.");
+    expect(legacyCollapsed.valid).toBe(false);
+    expect(legacyCollapsed.hasDetailsWrapper).toBe(true);
+    expect(legacyCollapsed.issues).toContain("Approval body must keep the response visible; legacy <details> response wrappers are no longer allowed.");
   });
 
-  test("evaluateExactReviewOutputProof passes only for one APPROVED review with the shared collapsed body", async () => {
+  test("evaluateExactReviewOutputProof passes only for one APPROVED review with the shared visible body", async () => {
     const reviewOutputKey = makeReviewOutputKey();
     const { octokit } = createOctokitStub({
       reviews: [

--- a/src/review-audit/review-output-artifacts.ts
+++ b/src/review-audit/review-output-artifacts.ts
@@ -11,7 +11,7 @@ import {
 } from "./recent-review-sample.ts";
 
 const DEFAULT_PER_PAGE = 100;
-const REQUIRED_DETAILS_WRAPPER = "<summary>kodiai response</summary>";
+const LEGACY_DETAILS_WRAPPER = "<summary>kodiai response</summary>";
 
 export type ReviewOutputArtifact = {
   prNumber: number;
@@ -362,17 +362,23 @@ export function validateCollapsedApproveReviewBody(params: {
     };
   }
 
-  const hasDetailsWrapper = body.includes(REQUIRED_DETAILS_WRAPPER)
+  const hasDetailsWrapper = body.includes(LEGACY_DETAILS_WRAPPER)
     && body.includes("<details>")
     && body.includes("</details>");
   const hasExactMarker = body.includes(marker);
   const lines = body.split("\n");
   const start = lines.findIndex((line) => line.trim() === "<details>");
   const end = lines.findIndex((line) => line.trim() === "</details>");
-  const wrappedContent = start !== -1 && end !== -1 && end > start
+  const legacyWrappedContent = hasDetailsWrapper && start !== -1 && end !== -1 && end > start
     ? lines.slice(start + 1, end)
-    : lines;
-  const content = wrappedContent
+    : null;
+  const visibleResponseEnd = lines.findIndex((line) => {
+    const trimmed = line.trim();
+    return trimmed === "<details>" || trimmed === marker;
+  });
+  const visibleResponseContent = lines.slice(0, visibleResponseEnd === -1 ? lines.length : visibleResponseEnd);
+  const contentSource = legacyWrappedContent ?? visibleResponseContent;
+  const content = contentSource
     .map((line) => line.trimEnd())
     .filter((line) => line.trim().length > 0)
     .filter((line) => !line.trim().startsWith("<summary>"))
@@ -387,8 +393,8 @@ export function validateCollapsedApproveReviewBody(params: {
   const evidenceBulletCount = evidenceLines.filter((line) => line.startsWith("- ")).length;
 
   const issues: string[] = [];
-  if (!hasDetailsWrapper) {
-    issues.push("Approval body must use collapsed <details> wrapper text.");
+  if (hasDetailsWrapper) {
+    issues.push("Approval body must keep the response visible; legacy <details> response wrappers are no longer allowed.");
   }
   if (!hasDecisionApprove) {
     issues.push("Approval body must start with 'Decision: APPROVE'.");


### PR DESCRIPTION
## Summary
- handle non-object MediaWiki parse payloads as bounded malformed parse responses instead of broad page-processing warnings
- treat production-shaped Slack `missing_scope` errors as expected optional identity-lookup disablement
- make mention and normal PR review max-turn fallback publication visible in final completion/phase logs
- downgrade bounded small filename-only diff fallbacks to info while retaining evidence quality metadata
- make `deploy.sh` build from a verified git commit archive, include the commit in revision/runtime provenance, and avoid dirty working-tree build contexts
- render clean approval responses visible-first with `Decision: APPROVE` above collapsible Review Details, and normalize legacy collapsed response bodies when merging Review Details

## Verification
- `bash -n deploy.sh` → pass
- `bun test scripts/deploy.test.ts` → 12 pass, 0 fail
- `bun test src/handlers/review.test.ts -t "failure fallback publication"` → 12 pass, 0 fail
- `bun test src/handlers/review-idempotency.test.ts src/handlers/review.test.ts src/handlers/mention.test.ts src/review-audit/review-output-artifacts.test.ts && bun run lint` → 369 pass, 0 fail; lint pass
- `bun test src/handlers/review.test.ts scripts/deploy.test.ts src/knowledge/wiki-sync.test.ts src/handlers/identity-suggest.test.ts src/handlers/mention.test.ts src/execution/mcp/http-server.test.ts src/handlers/addon-check.test.ts src/lib/retry-scope-reducer.test.ts src/lib/review-continuation-lifecycle.test.ts src/review-orchestration/review-timeout-classification.test.ts && bun run lint` → 303 pass, 0 fail; lint pass
- `bun run verify:m075` → PASS

## Production context
Follow-up to the post-deploy log pass on `ca-kodiai--deploy-20260523-110439`, which showed wiki-sync parse warning, Slack `missing_scope`, small diff fallback warning, misleading max-turn publication state, split Review Details / response output, and later evidence that the active deploy image was built from stale working-tree source rather than the intended merged commit.
