### PR TITLE
Clarify candidate publication observability

### DIFF
--- a/src/handlers/addon-check.test.ts
+++ b/src/handlers/addon-check.test.ts
@@ -420,7 +420,7 @@ describe("createAddonCheckHandler", () => {
 
   // ── Findings logged with structured bindings ──────────────────────────
 
-  it("findings logged with addonId, level, message bindings", async () => {
+  it("findings logged with addonId, findingLevel, and message bindings without clobbering logger severity", async () => {
     const files = ["plugin.video.foo/addon.xml"];
     const { app } = createMockGithubApp(files);
     const { logger, infoCalls } = createMockLogger();
@@ -444,9 +444,11 @@ describe("createAddonCheckHandler", () => {
 
     const findingLogs = infoCalls.filter((c) => c.message === "addon-check: finding");
     expect(findingLogs.length).toBe(2);
-    expect(findingLogs[0]!.bindings.level).toBe("ERROR");
+    expect(findingLogs[0]!.bindings.findingLevel).toBe("ERROR");
+    expect(findingLogs[0]!.bindings.level).toBeUndefined();
     expect(findingLogs[0]!.bindings.message).toBe("missing changelog");
-    expect(findingLogs[1]!.bindings.level).toBe("WARN");
+    expect(findingLogs[1]!.bindings.findingLevel).toBe("WARN");
+    expect(findingLogs[1]!.bindings.level).toBeUndefined();
     expect(findingLogs[1]!.bindings.message).toBe("old icon");
   });
 

--- a/src/handlers/addon-check.ts
+++ b/src/handlers/addon-check.ts
@@ -276,7 +276,7 @@ export function createAddonCheckHandler(deps: {
 
               for (const finding of result.findings) {
                 handlerLogger.info(
-                  { addonId: finding.addonId, level: finding.level, message: finding.message },
+                  { addonId: finding.addonId, findingLevel: finding.level, message: finding.message },
                   "addon-check: finding",
                 );
                 allFindings.push(finding);

--- a/src/handlers/review.test.ts
+++ b/src/handlers/review.test.ts
@@ -17851,6 +17851,85 @@ describe("createReviewHandler ReviewPlan wiring", () => {
     }));
   });
 
+  test("missing-replacement candidates are expected policy blocks with reason-aware Review Details", async () => {
+    const { updatedSummaryBody, recordReviewEntries, recordFindingEntries, logEntries } = await runReviewPlanScenario({
+      executorPublished: false,
+      exposeSummaryComment: true,
+      candidateFindingResult: {
+        status: "shadow",
+        repo: "acme/repo",
+        pullNumber: 101,
+        reviewOutputKey: "rk_safe",
+        deliveryId: "delivery-123",
+        artifactPresent: true,
+        findings: [
+          {
+            filePath: "README.md",
+            startLine: 2,
+            endLine: 2,
+            severity: "major",
+            category: "correctness",
+            title: "Candidate without replacement",
+            body: "This candidate has no safe replacement text and must stay private.",
+          },
+        ],
+        rejections: [],
+      },
+      reviewReducer: async (input) => ({
+        status: "ready",
+        findings: input.findings,
+        visibleFindings: input.findings,
+        filteredInlineFindings: [],
+        lowConfidenceFindings: [],
+        suppressionMatchCounts: new Map(),
+        filterRecords: [],
+        counts: {
+          input: input.findings.length,
+          kept: input.findings.length,
+          suppressed: 0,
+          rewritten: 0,
+          deprioritized: 0,
+          lowConfidence: 0,
+          auditEvents: 0,
+          severityDemoted: 0,
+          graphValidated: 0,
+          graphUncertain: 0,
+        },
+        audit: [],
+        detailsSummary: {
+          label: "Review reducer",
+          status: "ready",
+          text: "Review reducer: ready input=1 kept=1 suppressed=0 rewritten=0 deprioritized=0 lowConfidence=0 auditEvents=0 severityDemoted=0 graphValidated=0 graphUncertain=0",
+        },
+      }),
+    });
+
+    expect(recordReviewEntries[0]?.findingsTotal).toBe(0);
+    expect(recordFindingEntries).toHaveLength(0);
+
+    const detailsBlock = extractReviewDetailsBlock(updatedSummaryBody ?? "");
+    expect(detailsBlock).toContain("Review candidate publication: mode=blocked");
+    expect(detailsBlock).toContain("approved=1");
+    expect(detailsBlock).toContain("publishable=0");
+    expect(detailsBlock).toContain("nonPublishable=1");
+    expect(detailsBlock).toContain("fixBlocked=1");
+    expect(detailsBlock).toContain("reasons=fix-eligibility-blocked");
+    expect(detailsBlock).toContain("buckets=blocked:1:fix-eligibility-blocked+missing-replacement");
+    expect(detailsBlock).not.toContain("This candidate has no safe replacement text");
+
+    const publicationLog = logEntries.find((entry) => entry.data?.gate === "review-candidate-publication");
+    expect(publicationLog?.level).toBe("info");
+    expect(publicationLog?.message).toBe("Review candidate publication completed with expected policy block");
+    expect(publicationLog?.data?.counts).toEqual(expect.objectContaining({
+      approvedReferences: 1,
+      candidatePublishable: 0,
+      candidatePublished: 0,
+      fixEligibilityBlocked: 1,
+      nonPublishableReferences: 1,
+    }));
+    expect(publicationLog?.data?.reasons).toEqual(["fix-eligibility-blocked"]);
+  });
+
   test("candidate draft prioritization respects maxComments before inline publication", async () => {
     const { createdReviewComments, recordReviewEntries, recordFindingEntries, logEntries } = await runReviewPlanScenario({
       executorPublished: false,

--- a/src/handlers/review.ts
+++ b/src/handlers/review.ts
@@ -213,6 +213,7 @@ import {
 import {
   classifyReviewCandidatePublicationRuntime,
   createCandidatePublicationFlowEvidence,
+  isExpectedCandidatePublicationPolicyBlock,
   type ReviewCandidatePublicationRuntimeResult,
 } from "../review-orchestration/review-candidate-publication-runtime.ts";
 import { classifyReviewTimeoutOutcome } from "../review-orchestration/review-timeout-classification.ts";
@@ -2729,23 +2730,6 @@ function logReviewCandidatePublicationRuntime(params: {
       "Review candidate publication runtime log degraded",
     );
   }
-}
-
-function isExpectedCandidatePublicationPolicyBlock(runtime: ReviewCandidatePublicationRuntimeResult): boolean {
-  if (runtime.mode !== "blocked") return false;
-  if (runtime.counts.candidateBlocked <= 0) return false;
-  if (runtime.counts.candidateFailed !== 0) return false;
-  if (runtime.counts.candidateMalformed !== 0) return false;
-  if (runtime.counts.directPublished !== 0) return false;
-  if (runtime.counts.malformed !== 0) return false;
-  if (!runtime.reasons.every((reason) => reason === "candidate-publisher-blocked")) return false;
-
-  const blockedBucket = runtime.outcomeBuckets.blocked;
-  return blockedBucket?.mode === "blocked"
-    && blockedBucket.count > 0
-    && Array.isArray(blockedBucket.reasons)
-    && blockedBucket.reasons.length > 0
-    && blockedBucket.reasons.every((reason) => typeof reason === "string" && reason.trim().length > 0);
 }
 
 export function createReviewHandler(deps: {

--- a/src/lib/review-utils.test.ts
+++ b/src/lib/review-utils.test.ts
@@ -487,7 +487,7 @@ describe("formatReviewDetailsSummary", () => {
 
     expect(reviewCandidatePublicationLineCount(result)).toBe(1);
     expect(result.indexOf("Review candidates:")).toBeLessThan(result.indexOf("Review candidate publication:"));
-    expect(result).toContain("- Review candidate publication: mode=candidate-approved approved=2 rewritten=1 published=3 directFallback=0 reasons=candidate-publisher-published");
+    expect(result).toContain("- Review candidate publication: mode=candidate-approved approved=2 rewritten=1 publishable=3 nonPublishable=0 fixBlocked=0 published=3 directFallback=0 reasons=candidate-publisher-published");
     expect(result).not.toContain("Review candidate publication runtime:");
   });
 
@@ -585,7 +585,7 @@ describe("formatReviewDetailsSummary", () => {
     });
 
     expect(reviewCandidatePublicationLineCount(result)).toBe(1);
-    expect(result).toContain("- Review candidate publication: mode=moved-to-details approved=1 rewritten=0 published=0 directFallback=0 reasons=candidate-moved-to-details,line-not-commentable-in-pr-diff movedToDetails=1 detailsOmitted=0");
+    expect(result).toContain("- Review candidate publication: mode=moved-to-details approved=1 rewritten=0 publishable=0 nonPublishable=0 fixBlocked=0 published=0 directFallback=0 reasons=candidate-moved-to-details,line-not-commentable-in-pr-diff movedToDetails=1 detailsOmitted=0");
     expect(result).toContain("- Moved review candidates preserved in details:");
     expect(result).toContain("  - [major/correctness] Guard null payload before enqueue (src/worker.ts:42, reason=line-not-commentable-in-pr-diff) — The enqueue path dereferences payload before validating it.");
     expect(result).not.toContain("direct-fallback-published");
@@ -689,7 +689,7 @@ describe("formatReviewDetailsSummary", () => {
     });
 
     expect(reviewCandidatePublicationLineCount(result)).toBe(1);
-    expect(result).toContain("- Review candidate publication: mode=direct-fallback approved=0 rewritten=0 published=0 directFallback=2 reasons=direct-fallback-attempted,direct-fallback-published");
+    expect(result).toContain("- Review candidate publication: mode=direct-fallback approved=0 rewritten=0 publishable=0 nonPublishable=0 fixBlocked=0 published=0 directFallback=2 reasons=direct-fallback-attempted,direct-fallback-published");
   });
 
   it("omits missing candidate publication metadata and degrades malformed metadata without breaking Review Details", () => {
@@ -704,7 +704,7 @@ describe("formatReviewDetailsSummary", () => {
 
     expect(reviewCandidatePublicationLineCount(omitted)).toBe(0);
     expect(reviewCandidatePublicationLineCount(malformed)).toBe(1);
-    expect(malformed).toContain("- Review candidate publication: mode=degraded approved=0 rewritten=0 published=0 directFallback=0 reasons=malformed-runtime-summary");
+    expect(malformed).toContain("- Review candidate publication: mode=degraded approved=0 rewritten=0 publishable=0 nonPublishable=0 fixBlocked=0 published=0 directFallback=0 reasons=malformed-runtime-summary");
     expect(malformed).toContain("buckets=degraded:1:malformed-runtime-summary");
     expect(malformed).toContain("<summary>Review Details</summary>");
     expect(malformed).toContain("<!-- kodiai:review-details:test-key-001 -->");
@@ -720,7 +720,7 @@ describe("formatReviewDetailsSummary", () => {
     });
 
     expect(reviewCandidatePublicationLineCount(result)).toBe(1);
-    expect(result).toContain("- Review candidate publication: mode=degraded approved=1 rewritten=0 published=0 directFallback=0 reasons=candidate-publisher-failed,redacted,redacted,prompt-redacted,diff-redacted,prompt-redacted");
+    expect(result).toContain("- Review candidate publication: mode=degraded approved=1 rewritten=0 publishable=1 nonPublishable=0 fixBlocked=0 published=0 directFallback=0 reasons=candidate-publisher-failed,redacted,redacted,prompt-redacted,diff-redacted,prompt-redacted");
     expect(result).toContain("+6 more");
     expect(result).not.toContain("sk-secret-value");
     expect(result).not.toContain("ghp_secret_token_value");

--- a/src/lib/review-utils.ts
+++ b/src/lib/review-utils.ts
@@ -460,6 +460,9 @@ function normalizeReviewCandidatePublicationDetailsText(
   const mode = REVIEW_CANDIDATE_PUBLICATION_MODES.has(rawMode) ? rawMode : "degraded";
   const approved = extractCandidatePublicationCount(text, "approvedRefs");
   const rewritten = extractCandidatePublicationCount(text, "rewrittenRefs");
+  const publishable = extractCandidatePublicationCount(text, "publishable");
+  const nonPublishable = extractCandidatePublicationCount(text, "nonPublishable");
+  const fixBlocked = extractCandidatePublicationCount(text, "fixBlocked");
   const published = extractCandidatePublicationCount(text, "candidatePublished");
   const movedToDetails = extractCandidatePublicationCount(text, "movedToDetails");
   const detailsOmitted = extractCandidatePublicationCount(text, "detailsOmitted");
@@ -470,7 +473,7 @@ function normalizeReviewCandidatePublicationDetailsText(
   const reasons = formatReviewCandidatePublicationReasons(text);
   const buckets = formatReviewCandidatePublicationOutcomeBuckets(reviewCandidatePublication);
 
-  return `Review candidate publication: mode=${mode} approved=${approved} rewritten=${rewritten} published=${published} directFallback=${directFallback} reasons=${reasons} movedToDetails=${movedToDetails} detailsOmitted=${detailsOmitted}${buckets ? ` buckets=${buckets}` : ""}`;
+  return `Review candidate publication: mode=${mode} approved=${approved} rewritten=${rewritten} publishable=${publishable} nonPublishable=${nonPublishable} fixBlocked=${fixBlocked} published=${published} directFallback=${directFallback} reasons=${reasons} movedToDetails=${movedToDetails} detailsOmitted=${detailsOmitted}${buckets ? ` buckets=${buckets}` : ""}`;
 }
 
 
@@ -613,7 +616,7 @@ function readPositiveInteger(value: unknown): number | null {
 }
 
 function formatMalformedReviewCandidatePublicationDetailsLine(): string {
-  return "- Review candidate publication: mode=degraded approved=0 rewritten=0 published=0 directFallback=0 reasons=malformed-runtime-summary movedToDetails=0 detailsOmitted=0 buckets=degraded:1:malformed-runtime-summary";
+  return "- Review candidate publication: mode=degraded approved=0 rewritten=0 publishable=0 nonPublishable=0 fixBlocked=0 published=0 directFallback=0 reasons=malformed-runtime-summary movedToDetails=0 detailsOmitted=0 buckets=degraded:1:malformed-runtime-summary";
 }
 
 function extractCandidatePublicationCount(text: string, key: string): number {

--- a/src/review-orchestration/review-candidate-publication-runtime.test.ts
+++ b/src/review-orchestration/review-candidate-publication-runtime.test.ts
@@ -8,6 +8,7 @@ import type {
 import {
   classifyReviewCandidatePublicationRuntime,
   createCandidatePublicationFlowEvidence,
+  isExpectedCandidatePublicationPolicyBlock,
   toReviewCandidatePublicationRuntimeConfigSnapshot,
   toReviewCandidatePublicationRuntimeDetailsSummary,
   type ReviewCandidatePublicationRuntimeInput,
@@ -169,6 +170,67 @@ describe("review candidate publication runtime classifier", () => {
 
     expect(blockedOnly.mode).toBe("blocked");
     expect(blockedOnly.counts.candidateBlocked).toBe(2);
+    expect(isExpectedCandidatePublicationPolicyBlock(blockedOnly)).toBe(true);
+  });
+
+  test("treats zero-candidate no-publication paths as expected policy blocks", () => {
+    const result = classifyReviewCandidatePublicationRuntime(input({
+      approval: approval({ approved: 0, suppressed: 0, rejected: 1 }),
+      adapter: adapter({ input: 0, publishable: 0, skipped: 0 }),
+      publisher: publisher([]),
+    }));
+
+    expect(result.mode).toBe("blocked");
+    expect(result.counts).toMatchObject({
+      approvedReferences: 0,
+      candidatePublishable: 0,
+      candidatePublished: 0,
+      candidateBlocked: 0,
+      candidateFailed: 0,
+      malformed: 0,
+    });
+    expect(result.reasons).toEqual(expect.arrayContaining(["no-candidate-publication-path", "approval-blocked"]));
+    expect(result.outcomeBuckets.blocked).toMatchObject({
+      mode: "blocked",
+      count: 1,
+      reasons: expect.arrayContaining(["approval-blocked", "no-candidate-publication-path"]),
+    });
+    expect(isExpectedCandidatePublicationPolicyBlock(result)).toBe(true);
+  });
+
+  test("surfaces approved but non-publishable fix candidates as expected fix eligibility blocks", () => {
+    const result = classifyReviewCandidatePublicationRuntime(input({
+      approval: approval({ approved: 3 }),
+      adapter: {
+        ...adapter({ input: 3, publishable: 0, approved: 0 }),
+        fixEligibility: {
+          ...emptyFixEligibilitySummary(),
+          status: "blocked",
+          counts: { input: 3, eligible: 0, blocked: 3, omitted: 0, capped: 0 },
+          reasonCounts: { "missing-replacement": 3 },
+        },
+      },
+      publisher: publisher([]),
+    }));
+
+    expect(result.mode).toBe("blocked");
+    expect(result.counts).toMatchObject({
+      approvedReferences: 3,
+      candidatePublishable: 0,
+      candidatePublished: 0,
+      candidateBlocked: 0,
+    });
+    expect(result.reasons).toContain("fix-eligibility-blocked");
+    expect(result.outcomeBuckets.blocked).toMatchObject({
+      mode: "blocked",
+      count: 3,
+      reasons: expect.arrayContaining(["fix-eligibility-blocked", "missing-replacement"]),
+    });
+    expect(result.detailsSummary.text).toContain("publishable=0");
+    expect(result.detailsSummary.text).toContain("nonPublishable=3");
+    expect(result.detailsSummary.text).toContain("fixBlocked=3");
+    expect(result.detailsSummary.text).toContain("reasons=fix-eligibility-blocked");
+    expect(isExpectedCandidatePublicationPolicyBlock(result)).toBe(true);
   });
 
   test("degrades instead of throwing on malformed summaries and unknown publisher status or reason values", () => {

--- a/src/review-orchestration/review-candidate-publication-runtime.ts
+++ b/src/review-orchestration/review-candidate-publication-runtime.ts
@@ -31,6 +31,7 @@ export type ReviewCandidatePublicationRuntimeReason =
   | "direct-fallback-published"
   | "direct-fallback-disallowed"
   | "fallback-policy-blocked"
+  | "fix-eligibility-blocked"
   | "no-candidate-publication-path"
   | "adapter-skipped-all"
   | "approval-blocked"
@@ -54,6 +55,8 @@ export type ReviewCandidatePublicationRuntimeCounts = {
   candidateMovedToDetails: number;
   candidateDetailsOnlyFindings: number;
   candidateDetailsOnlyOmitted: number;
+  fixEligibilityBlocked: number;
+  nonPublishableReferences: number;
   convertedProcessedFindings: number;
   directAttempted: number;
   directPublished: number;
@@ -162,6 +165,7 @@ export function classifyReviewCandidatePublicationRuntime(
 
   const approvedReferences = approvalCounts.approved + approvalCounts.rewritten;
   const candidatePublishable = adapterCounts.publishable;
+  const fixEligibilityBlocked = adapterCounts.fixEligibilityBlocked;
   const candidatePublished = publisher.published;
   const candidateSkipped = publisher.skipped + adapterCounts.skipped;
   const movedToDetails = adapterCounts.movedToDetails + publisher.movedToDetails;
@@ -194,6 +198,7 @@ export function classifyReviewCandidatePublicationRuntime(
   if (directPublished > 0) pushReason(reasons, "direct-fallback-published");
   if (direct.attempted && direct.allowed === false) pushReason(reasons, "direct-fallback-disallowed");
   if (!input.publisher && candidatePublishable > 0) pushReason(reasons, "missing-shared-publisher-results");
+  if (fixEligibilityBlocked > 0) pushReason(reasons, "fix-eligibility-blocked");
   if (candidatePublishable === 0 && approvedReferences === 0) pushReason(reasons, "no-candidate-publication-path");
   if (adapterCounts.input > 0 && candidatePublishable === 0 && adapterCounts.skipped > 0) pushReason(reasons, "adapter-skipped-all");
   if (approvalCounts.approved === 0 && approvalCounts.rewritten === 0 && approvalCounts.suppressed + approvalCounts.rejected > 0) {
@@ -216,6 +221,8 @@ export function classifyReviewCandidatePublicationRuntime(
     candidateMovedToDetails: movedToDetails,
     candidateDetailsOnlyFindings: detailsOnlyFindings,
     candidateDetailsOnlyOmitted: detailsOnlyOmitted,
+    fixEligibilityBlocked,
+    nonPublishableReferences: Math.max(0, approvedReferences - candidatePublishable),
     convertedProcessedFindings,
     directAttempted: direct.attempted ? 1 : 0,
     directPublished,
@@ -249,6 +256,8 @@ export function toReviewCandidatePublicationRuntimeDetailsSummary(result: Pick<R
     `approvedRefs=${formatCount(counts.approvedReferences)}`,
     `rewrittenRefs=${formatCount(counts.rewrittenReferences)}`,
     `publishable=${formatCount(counts.candidatePublishable)}`,
+    `nonPublishable=${formatCount(counts.nonPublishableReferences)}`,
+    `fixBlocked=${formatCount(counts.fixEligibilityBlocked)}`,
     `candidatePublished=${formatCount(counts.candidatePublished)}`,
     `skipped=${formatCount(counts.candidateSkipped)}`,
     `blocked=${formatCount(counts.candidateBlocked)}`,
@@ -312,13 +321,13 @@ function createOutcomeBuckets(
   bucketReasons: OutcomeBucketReasonCollector,
 ): ReviewCandidatePublicationRuntimeOutcomeBuckets {
   const buckets: ReviewCandidatePublicationRuntimeOutcomeBuckets = {};
-  const blockedCount = counts.candidateBlocked > 0 || hasAnyReason(reasons, ["adapter-skipped-all", "approval-blocked", "no-candidate-publication-path"])
-    ? Math.max(1, counts.candidateBlocked)
+  const blockedCount = counts.candidateBlocked > 0 || hasAnyReason(reasons, ["adapter-skipped-all", "approval-blocked", "no-candidate-publication-path", "fix-eligibility-blocked"])
+    ? Math.max(1, counts.candidateBlocked, counts.fixEligibilityBlocked)
     : 0;
 
   addOutcomeBucket(buckets, "published", "published", counts.candidatePublished, reasons, ["candidate-publisher-published"], bucketReasons.published);
   addOutcomeBucket(buckets, "skipped", "skipped", counts.candidateSkipped, reasons, ["candidate-publisher-skipped", "candidate-publisher-missing", "malformed-adapter-summary"], bucketReasons.skipped);
-  addOutcomeBucket(buckets, "blocked", "blocked", blockedCount, reasons, ["candidate-publisher-blocked", "adapter-skipped-all", "approval-blocked", "no-candidate-publication-path"], bucketReasons.blocked);
+  addOutcomeBucket(buckets, "blocked", "blocked", blockedCount, reasons, ["candidate-publisher-blocked", "adapter-skipped-all", "approval-blocked", "no-candidate-publication-path", "fix-eligibility-blocked"], bucketReasons.blocked);
   addOutcomeBucket(buckets, "failed", "failed", counts.candidateFailed, reasons, ["candidate-publisher-failed"], bucketReasons.failed);
   addOutcomeBucket(buckets, "movedToDetails", "moved-to-details", counts.candidateMovedToDetails, reasons, ["candidate-moved-to-details"], bucketReasons.movedToDetails);
   addOutcomeBucket(buckets, "directFallback", "direct-fallback", counts.fallbackEvidence, reasons, ["direct-fallback-attempted", "direct-fallback-published", "missing-shared-publisher-results"], bucketReasons.directFallback);
@@ -392,6 +401,39 @@ function classifyMode(input: {
   return "blocked";
 }
 
+export function isExpectedCandidatePublicationPolicyBlock(runtime: Pick<ReviewCandidatePublicationRuntimeResult, "mode" | "counts" | "reasons" | "outcomeBuckets">): boolean {
+  if (runtime.mode !== "blocked") return false;
+  if (runtime.counts.candidateFailed !== 0) return false;
+  if (runtime.counts.candidateMalformed !== 0) return false;
+  if (runtime.counts.directPublished !== 0) return false;
+  if (runtime.counts.malformed !== 0) return false;
+
+  const publisherBlocked = runtime.counts.candidateBlocked > 0
+    && runtime.reasons.every((reason) => reason === "candidate-publisher-blocked")
+    && runtime.outcomeBuckets.blocked?.mode === "blocked"
+    && (runtime.outcomeBuckets.blocked?.count ?? 0) > 0;
+
+  const fixEligibilityBlocked = runtime.counts.fixEligibilityBlocked > 0
+    && runtime.counts.candidatePublishable === 0
+    && runtime.counts.candidatePublished === 0
+    && runtime.reasons.every((reason) => reason === "fix-eligibility-blocked")
+    && runtime.outcomeBuckets.blocked?.mode === "blocked"
+    && (runtime.outcomeBuckets.blocked?.count ?? 0) === runtime.counts.fixEligibilityBlocked;
+
+  const zeroCandidatePublicationPath = runtime.counts.approvedReferences === 0
+    && runtime.counts.rewrittenReferences === 0
+    && runtime.counts.candidatePublishable === 0
+    && runtime.counts.candidatePublished === 0
+    && runtime.counts.candidateBlocked === 0
+    && runtime.reasons.includes("approval-blocked")
+    && runtime.reasons.includes("no-candidate-publication-path")
+    && runtime.reasons.every((reason) => reason === "approval-blocked" || reason === "no-candidate-publication-path")
+    && runtime.outcomeBuckets.blocked?.mode === "blocked"
+    && (runtime.outcomeBuckets.blocked?.count ?? 0) === 1;
+
+  return publisherBlocked || fixEligibilityBlocked || zeroCandidatePublicationPath;
+}
+
 function normalizeApprovalCounts(
   approval: ReviewCandidateApprovalResult | null | undefined,
   reasons: ReviewCandidatePublicationRuntimeReason[],
@@ -429,12 +471,13 @@ function normalizeAdapterCounts(
   movedToDetails: number;
   detailsOnlyFindings: number;
   detailsOnlyOmitted: number;
+  fixEligibilityBlocked: number;
   malformed: number;
 } {
   const counts = adapter?.counts;
   if (!isRecord(counts)) {
     pushReason(reasons, "malformed-adapter-summary");
-    return { input: 0, publishable: 0, skipped: 0, movedToDetails: 0, detailsOnlyFindings: 0, detailsOnlyOmitted: 0, malformed: 1 };
+    return { input: 0, publishable: 0, skipped: 0, movedToDetails: 0, detailsOnlyFindings: 0, detailsOnlyOmitted: 0, fixEligibilityBlocked: 0, malformed: 1 };
   }
   const skippedItems = Array.isArray(adapter?.skipped) ? adapter.skipped : [];
   for (const item of skippedItems) {
@@ -442,6 +485,14 @@ function normalizeAdapterCounts(
   }
   const malformedSkipReasons = skippedItems.some((item) => !isRecord(item) || sanitizeSummaryToken(String(item.reason ?? "unknown")) === "unknown");
   if (malformedSkipReasons) pushReason(reasons, "malformed-adapter-summary");
+  const fixEligibilityBlocked = countBlockingFixEligibilityReasons(adapter?.fixEligibility?.reasonCounts);
+  if (fixEligibilityBlocked > 0 && isRecord(adapter?.fixEligibility?.reasonCounts)) {
+    for (const [reason, count] of Object.entries(adapter.fixEligibility.reasonCounts)) {
+      const normalizedReason = sanitizeSummaryToken(reason);
+      if (normalizedReason === "eligible" || normalizedReason === "line-not-commentable") continue;
+      if (normalizeCount(count) > 0) addBucketReason(bucketReasons.blocked, reason, "fix-eligibility-blocked");
+    }
+  }
   return {
     input: normalizeCount(counts.input),
     publishable: normalizeCount(counts.publishable),
@@ -449,8 +500,20 @@ function normalizeAdapterCounts(
     movedToDetails: normalizeCount(counts.movedToDetails),
     detailsOnlyFindings: normalizeCount(counts.detailsOnlyFindings),
     detailsOnlyOmitted: normalizeCount(counts.detailsOnlyOmitted),
+    fixEligibilityBlocked,
     malformed: hasMalformedCount([counts.input, counts.publishable, counts.skipped]) || hasOptionalMalformedCount([counts.movedToDetails, counts.detailsOnlyFindings, counts.detailsOnlyOmitted]) || malformedSkipReasons ? 1 : 0,
   };
+}
+
+function countBlockingFixEligibilityReasons(reasonCounts: unknown): number {
+  if (!isRecord(reasonCounts)) return 0;
+  let total = 0;
+  for (const [reason, count] of Object.entries(reasonCounts)) {
+    const normalizedReason = sanitizeSummaryToken(reason);
+    if (normalizedReason === "eligible" || normalizedReason === "line-not-commentable") continue;
+    total += normalizeCount(count);
+  }
+  return total;
 }
 
 function normalizePublisherSummary(


### PR DESCRIPTION
## Summary
- Treat approved-but-non-publishable `missing-replacement` candidates as expected policy blocks instead of warning-worthy publication failures.
- Treat zero-candidate/no-publication-path candidate-publication runs (`approval-blocked` + `no-candidate-publication-path`) as expected info-level policy telemetry when the public review still completes cleanly.
- Propagate bounded fix-eligibility reason counts into candidate-publication runtime evidence and Review Details (`publishable`, `nonPublishable`, `fixBlocked`).
- Keep `missing-replacement` candidates private while preserving safe `line-not-commentable` details-only projection.
- Rename addon-check finding log severity from `level` to `findingLevel` so Pino's numeric `level` stays parseable in Log Analytics.

## Verification
- `bun test src/handlers/addon-check.test.ts src/review-orchestration/review-candidate-publication-adapter.test.ts src/review-lifecycle/same-pr-fix-eligibility.test.ts src/review-orchestration/review-candidate-publication-runtime.test.ts src/lib/review-utils.test.ts src/handlers/review.test.ts`
- `bun run lint`
- `bun run verify:m075`
