### PR TITLE
Review handler slices (P2) and formatter argv sandbox (P3)

### DIFF
--- a/src/execution/formatter-command-sandbox.test.ts
+++ b/src/execution/formatter-command-sandbox.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import {
+  isAllowlistedFormatterExecutable,
+  planFormatterCommandExecution,
+  spawnArgsForFormatterCommand,
+  tokenizeFormatterCommand,
+} from "./formatter-command-sandbox.ts";
+
+describe("tokenizeFormatterCommand", () => {
+  test("splits whitespace and preserves quoted segments", () => {
+    expect(tokenizeFormatterCommand(`git clang-format --diff origin/main HEAD`)).toEqual([
+      "git",
+      "clang-format",
+      "--diff",
+      "origin/main",
+      "HEAD",
+    ]);
+    expect(tokenizeFormatterCommand(`bun run "format --check" feature`)).toEqual([
+      "bun",
+      "run",
+      "format --check",
+      "feature",
+    ]);
+  });
+});
+
+describe("planFormatterCommandExecution", () => {
+  test("uses argv mode for allowlisted default git clang-format command", () => {
+    expect(planFormatterCommandExecution("git clang-format --diff origin/main HEAD")).toEqual({
+      mode: "argv",
+      argv: ["git", "clang-format", "--diff", "origin/main", "HEAD"],
+    });
+  });
+
+  test("falls back to shell for pipelines and substitutions", () => {
+    expect(planFormatterCommandExecution("git clang-format --diff origin/main HEAD | head")).toMatchObject({
+      mode: "shell-fallback",
+      reason: "shell-metacharacters",
+    });
+    expect(planFormatterCommandExecution("echo $(whoami)")).toMatchObject({
+      mode: "shell-fallback",
+      reason: "shell-metacharacters",
+    });
+  });
+
+  test("falls back to shell for non-allowlisted executables", () => {
+    expect(planFormatterCommandExecution("./scripts/custom-formatter.sh")).toMatchObject({
+      mode: "shell-fallback",
+      reason: "executable-not-allowlisted",
+    });
+  });
+
+  test("allowlists common formatter tooling", () => {
+    expect(isAllowlistedFormatterExecutable("prettier")).toBeTrue();
+    expect(isAllowlistedFormatterExecutable("python3")).toBeTrue();
+    expect(isAllowlistedFormatterExecutable("unknown-tool")).toBeFalse();
+  });
+});
+
+describe("spawnArgsForFormatterCommand", () => {
+  test("returns argv spawn args for safe commands", () => {
+    expect(spawnArgsForFormatterCommand("bun run format")).toEqual({
+      spawnArgs: ["bun", "run", "format"],
+      executionMode: "argv",
+    });
+  });
+
+  test("returns bash fallback args for shell pipelines", () => {
+    expect(spawnArgsForFormatterCommand("prettier --write . && git diff")).toEqual({
+      spawnArgs: ["bash", "-lc", "prettier --write . && git diff"],
+      executionMode: "shell-fallback",
+      fallbackReason: "shell-metacharacters",
+    });
+  });
+});

--- a/src/execution/formatter-command-sandbox.ts
+++ b/src/execution/formatter-command-sandbox.ts
@@ -1,0 +1,122 @@
+export type FormatterCommandExecutionMode = "argv" | "shell-fallback";
+
+export type FormatterCommandSpawnPlan =
+  | { mode: "argv"; argv: string[] }
+  | { mode: "shell-fallback"; reason: string; command: string };
+
+const FORMATTER_SHELL_METACHAR_RE = /[|&;<>$`\\]|\$\(|\r|\n/;
+
+const FORMATTER_ALLOWLISTED_EXECUTABLES = new Set([
+  "black",
+  "bun",
+  "clang-format",
+  "git",
+  "gofmt",
+  "node",
+  "npm",
+  "npx",
+  "prettier",
+  "python",
+  "python3",
+  "ruff",
+  "rustfmt",
+]);
+
+export function tokenizeFormatterCommand(command: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let quote: "'" | '"' | null = null;
+
+  for (let index = 0; index < command.length; index += 1) {
+    const char = command[index]!;
+
+    if (quote) {
+      if (char === quote) {
+        quote = null;
+        continue;
+      }
+      current += char;
+      continue;
+    }
+
+    if (char === "'" || char === '"') {
+      quote = char;
+      continue;
+    }
+
+    if (/\s/.test(char)) {
+      if (current.length > 0) {
+        tokens.push(current);
+        current = "";
+      }
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (current.length > 0) {
+    tokens.push(current);
+  }
+
+  return tokens;
+}
+
+function normalizeFormatterExecutable(token: string): string | null {
+  const trimmed = token.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const basename = trimmed.includes("/") ? trimmed.split("/").pop() ?? trimmed : trimmed;
+  return basename.toLowerCase();
+}
+
+export function isAllowlistedFormatterExecutable(token: string): boolean {
+  const normalized = normalizeFormatterExecutable(token);
+  return normalized !== null && FORMATTER_ALLOWLISTED_EXECUTABLES.has(normalized);
+}
+
+export function planFormatterCommandExecution(command: string): FormatterCommandSpawnPlan {
+  const trimmed = command.trim();
+  if (!trimmed) {
+    return { mode: "shell-fallback", reason: "empty-command", command: trimmed };
+  }
+
+  if (FORMATTER_SHELL_METACHAR_RE.test(trimmed)) {
+    return { mode: "shell-fallback", reason: "shell-metacharacters", command: trimmed };
+  }
+
+  const argv = tokenizeFormatterCommand(trimmed);
+  if (argv.length === 0) {
+    return { mode: "shell-fallback", reason: "empty-argv", command: trimmed };
+  }
+
+  const executable = argv[0]!;
+  if (!isAllowlistedFormatterExecutable(executable)) {
+    return { mode: "shell-fallback", reason: "executable-not-allowlisted", command: trimmed };
+  }
+
+  if (executable.includes("..")) {
+    return { mode: "shell-fallback", reason: "path-traversal", command: trimmed };
+  }
+
+  return { mode: "argv", argv };
+}
+
+export function spawnArgsForFormatterCommand(command: string): {
+  spawnArgs: string[];
+  executionMode: FormatterCommandExecutionMode;
+  fallbackReason?: string;
+} {
+  const plan = planFormatterCommandExecution(command);
+  if (plan.mode === "argv") {
+    return { spawnArgs: plan.argv, executionMode: "argv" };
+  }
+
+  return {
+    spawnArgs: ["bash", "-lc", plan.command],
+    executionMode: "shell-fallback",
+    fallbackReason: plan.reason,
+  };
+}

--- a/src/execution/formatter-suggestions.ts
+++ b/src/execution/formatter-suggestions.ts
@@ -1,4 +1,8 @@
 import { redactGitHubTokens } from "../lib/sanitizer.ts";
+import {
+  spawnArgsForFormatterCommand,
+  type FormatterCommandExecutionMode,
+} from "./formatter-command-sandbox.ts";
 
 export const FORMATTER_STDERR_SUMMARY_MAX_CHARS = 500;
 export const FORMATTER_PROCESS_STREAM_MAX_CHARS = 1_000_000;
@@ -29,6 +33,8 @@ export interface FormatterProcessResult {
   stderr: string;
   timedOut: boolean;
   durationMs: number;
+  executionMode?: FormatterCommandExecutionMode;
+  shellFallbackReason?: string;
 }
 
 export type FormatterProcessRunner = (
@@ -645,7 +651,8 @@ export const defaultFormatterProcessRunner: FormatterProcessRunner = async ({
   timeoutMs,
 }) => {
   const startedAt = performance.now();
-  const proc = Bun.spawn(["bash", "-lc", command], {
+  const { spawnArgs, executionMode, fallbackReason } = spawnArgsForFormatterCommand(command);
+  const proc = Bun.spawn(spawnArgs, {
     cwd,
     stdout: "pipe",
     stderr: "pipe",
@@ -681,6 +688,8 @@ export const defaultFormatterProcessRunner: FormatterProcessRunner = async ({
       stderr,
       timedOut,
       durationMs: Math.max(0, Math.round(performance.now() - startedAt)),
+      executionMode,
+      ...(fallbackReason ? { shellFallbackReason: fallbackReason } : {}),
     };
   } finally {
     if (timer !== undefined) {

--- a/src/handlers/review.ts
+++ b/src/handlers/review.ts
@@ -21,8 +21,6 @@ import type { PromptSectionRecord, ReviewCacheEventRecord, TelemetryStore } from
 import type {
   KnowledgeStore,
   PriorFinding,
-  ContinuationFamilyAuthoritativeOutcome,
-  ContinuationFamilyFinalStopReason,
   ContinuationFamilyProjectionStatus,
 } from "../knowledge/types.ts";
 import type { LearningMemoryStore, EmbeddingProvider } from "../knowledge/types.ts";
@@ -213,19 +211,16 @@ import {
 import {
   classifyReviewCandidatePublicationRuntime,
   createCandidatePublicationFlowEvidence,
-  isExpectedCandidatePublicationPolicyBlock,
   type ReviewCandidatePublicationRuntimeResult,
 } from "../review-orchestration/review-candidate-publication-runtime.ts";
+import { logReviewCandidatePublicationRuntime } from "../review-orchestration/review-candidate-publication-log.ts";
+import { createReviewContinuationFamilyStateManager } from "../review-orchestration/review-continuation-family-state.ts";
 import { classifyReviewTimeoutOutcome } from "../review-orchestration/review-timeout-classification.ts";
 import { logReviewTimeoutClassification } from "../review-orchestration/review-timeout-classification-log.ts";
 import {
   toProductionLogBudgetReasoning,
   toProductionLogCandidateFindingSnapshot,
   toProductionLogHunkEmbeddingCounts,
-  toProductionLogCandidatePublicationBuckets,
-  toProductionLogCandidatePublicationCounts,
-  toProductionLogCandidatePublicationPublisherSample,
-  toProductionLogCandidatePublicationReason,
   toProductionLogRuntimeBudgetFields,
   toProductionLogTurnBudgetFields,
 } from "../review-audit/production-log-projection.ts";
@@ -2713,52 +2708,6 @@ function reviewFindingIdentityKey(finding: ProcessedReviewFinding): string {
   ].join(":");
 }
 
-function logReviewCandidatePublicationRuntime(params: {
-  logger: Logger;
-  baseLog: Record<string, unknown>;
-  runtime: ReviewCandidatePublicationRuntimeResult;
-}): void {
-  try {
-    const payload = {
-      ...params.baseLog,
-      gate: "review-candidate-publication",
-      gateResult: params.runtime.mode,
-      mode: params.runtime.mode,
-      counts: toProductionLogCandidatePublicationCounts(params.runtime.counts),
-      reasons: params.runtime.reasons.map(toProductionLogCandidatePublicationReason),
-      outcomeBuckets: toProductionLogCandidatePublicationBuckets(params.runtime.outcomeBuckets),
-      publisherResultSample: toProductionLogCandidatePublicationPublisherSample(params.runtime.publisherResultSample),
-      movedToDetails: params.runtime.movedToDetails,
-    };
-
-    const expectedPolicyBlocked = isExpectedCandidatePublicationPolicyBlock(params.runtime);
-
-    if (expectedPolicyBlocked) {
-      params.logger.info(payload, "Review candidate publication completed with expected policy block");
-      return;
-    }
-
-    if (params.runtime.mode === "degraded" || params.runtime.mode === "blocked" || params.runtime.mode === "fallback-disallowed") {
-      params.logger.warn(payload, "Review candidate publication completed with non-approved mode");
-      return;
-    }
-
-    params.logger.info(payload, "Review candidate publication completed");
-  } catch (error) {
-    params.logger.warn(
-      {
-        ...params.baseLog,
-        gate: "review-candidate-publication",
-        gateResult: "degraded",
-        mode: "degraded",
-        reasons: ["malformed-runtime-summary"],
-        logError: error instanceof Error ? error.message : String(error),
-      },
-      "Review candidate publication runtime log degraded",
-    );
-  }
-}
-
 export function createReviewHandler(deps: {
   eventRouter: EventRouter;
   jobQueue: JobQueue;
@@ -3295,178 +3244,21 @@ export function createReviewHandler(deps: {
         setReviewWorkPhaseForAttempt(reviewWorkAttempt.attemptId, phase);
       }
 
-      function getBaseReviewOutputKey(currentReviewOutputKey: string): string {
-        return currentReviewOutputKey.replace(/-retry-\d+$/, "");
-      }
-
-      function getAttemptOrdinal(attemptId: string): number {
-        const match = /(?:^|[^\d])(\d+)$/.exec(attemptId);
-        return match ? Number.parseInt(match[1] ?? "0", 10) : 0;
-      }
-
-      async function persistContinuationFamilyState(params: {
-        authoritativeAttemptId: string;
-        authoritativeAttemptOrdinal?: number;
-        authoritativeOutcome: ContinuationFamilyAuthoritativeOutcome;
-        finalStopReason: ContinuationFamilyFinalStopReason;
-        projectionStatus: ContinuationFamilyProjectionStatus;
-        supersededByAttemptId?: string | null;
-        reviewOutputKey?: string;
-      }): Promise<void> {
-        if (!knowledgeStore?.upsertContinuationFamilyState) {
-          return;
-        }
-
-        const authoritativeAttemptOrdinal = params.authoritativeAttemptOrdinal
-          ?? getAttemptOrdinal(params.authoritativeAttemptId);
-        if (!Number.isFinite(authoritativeAttemptOrdinal) || authoritativeAttemptOrdinal < 1) {
-          logger.warn(
-            {
-              ...baseLog,
-              gate: "continuation-family-state",
-              gateResult: "skipped",
-              reason: "invalid-attempt-ordinal",
-              authoritativeAttemptId: params.authoritativeAttemptId,
-            },
-            "Skipping canonical continuation-family state write because the attempt ordinal was invalid",
-          );
-          return;
-        }
-
-        try {
-          await knowledgeStore.upsertContinuationFamilyState({
-            familyKey: reviewFamilyKey,
-            baseReviewOutputKey: getBaseReviewOutputKey(params.reviewOutputKey ?? reviewOutputKey),
-            authoritativeAttemptId: params.authoritativeAttemptId,
-            authoritativeAttemptOrdinal,
-            authoritativeOutcome: params.authoritativeOutcome,
-            finalStopReason: params.finalStopReason,
-            projectionStatus: params.projectionStatus,
-            supersededByAttemptId: params.supersededByAttemptId ?? null,
-          });
-        } catch (err) {
-          logger.warn(
-            {
-              ...baseLog,
-              gate: "continuation-family-state",
-              gateResult: "degraded",
-              authoritativeAttemptId: params.authoritativeAttemptId,
-              authoritativeOutcome: params.authoritativeOutcome,
-              finalStopReason: params.finalStopReason,
-              err,
-            },
-            "Failed to persist canonical continuation-family state",
-          );
-        }
-      }
-
-      async function persistDegradedContinuationFamilyState(params: {
-        authoritativeAttemptId: string;
-        authoritativeOutcome: ContinuationFamilyAuthoritativeOutcome;
-        finalStopReason: ContinuationFamilyFinalStopReason;
-        supersededByAttemptId?: string | null;
-        reviewOutputKey?: string;
-      }): Promise<void> {
-        await persistContinuationFamilyState({
-          ...params,
-          projectionStatus: "degraded",
-        });
-      }
-
-      async function settleRetryWithoutCanonicalUpdate(params: {
-        attemptId: string;
-        reviewOutputKey?: string;
-        deliveryId: string;
-        reason: string;
-        logMessage: string;
-      }): Promise<void> {
-        logger.warn(
-          {
-            deliveryId: params.deliveryId,
-            prNumber: pr.number,
-            reviewOutputKey: params.reviewOutputKey,
-            reason: params.reason,
-          },
-          params.logMessage,
-        );
-        await persistContinuationFamilyState({
-          authoritativeAttemptId: params.attemptId,
-          authoritativeOutcome: "quiet-settled",
-          finalStopReason: "settled-without-update",
-          projectionStatus: "canonical",
-          reviewOutputKey: params.reviewOutputKey,
-        });
-      }
-
-      async function finalizeContinuationAttempt(params: {
-        attemptId: string;
-        fallbackOutcome: ContinuationFamilyAuthoritativeOutcome;
-        fallbackStopReason: ContinuationFamilyFinalStopReason;
-        reviewOutputKey?: string;
-      }): Promise<void> {
-        const currentAttempt = reviewWorkCoordinator
-          .getSnapshot(reviewFamilyKey)
-          ?.attempts.find((attempt) => attempt.attemptId === params.attemptId);
-        const supersededByAttemptId = currentAttempt?.supersededByAttemptId ?? null;
-
-        if (supersededByAttemptId) {
-          await persistContinuationFamilyState({
-            authoritativeAttemptId: supersededByAttemptId,
-            authoritativeOutcome: "superseded",
-            finalStopReason: "superseded-by-newer-attempt",
-            projectionStatus: "canonical",
-            supersededByAttemptId,
-            reviewOutputKey: params.reviewOutputKey,
-          });
-          return;
-        }
-
-        await persistContinuationFamilyState({
-          authoritativeAttemptId: params.attemptId,
-          authoritativeOutcome: params.fallbackOutcome,
-          finalStopReason: params.fallbackStopReason,
-          projectionStatus: "canonical",
-          reviewOutputKey: params.reviewOutputKey,
-        });
-      }
-
-      function canPublishReviewWorkOutput(
-        attemptId: string,
-        outputLabel: string,
-        deliveryId: string,
-      ): boolean {
-        if (reviewWorkCoordinator.canPublish(attemptId)) {
-          return true;
-        }
-
-        const currentAttempt = reviewWorkCoordinator
-          .getSnapshot(reviewFamilyKey)
-          ?.attempts.find((attempt) => attempt.attemptId === attemptId);
-        const supersededByAttemptId = currentAttempt?.supersededByAttemptId ?? null;
-        if (supersededByAttemptId) {
-          void persistContinuationFamilyState({
-            authoritativeAttemptId: supersededByAttemptId,
-            authoritativeOutcome: "superseded",
-            finalStopReason: "superseded-by-newer-attempt",
-            projectionStatus: "canonical",
-            supersededByAttemptId,
-          });
-        }
-        logger.info(
-          {
-            ...baseLog,
-            deliveryId,
-            gate: "review-family-coordinator",
-            gateResult: "skipped",
-            skipReason: "publish-rights-lost",
-            reviewFamilyKey,
-            reviewWorkAttemptId: attemptId,
-            supersededByAttemptId,
-          },
-          `Skipping ${outputLabel} because publish rights were superseded`,
-        );
-        return false;
-      }
+      const continuationFamilyState = createReviewContinuationFamilyStateManager({
+        logger,
+        baseLog,
+        reviewFamilyKey,
+        reviewOutputKey,
+        knowledgeStore,
+        reviewWorkCoordinator,
+      });
+      const {
+        persistContinuationFamilyState,
+        persistDegradedContinuationFamilyState,
+        settleRetryWithoutCanonicalUpdate,
+        finalizeContinuationAttempt,
+        canPublishReviewWorkOutput,
+      } = continuationFamilyState;
 
       function canPublishVisibleOutput(outputLabel: string): boolean {
         return canPublishReviewWorkOutput(reviewWorkAttempt.attemptId, outputLabel, event.id);

--- a/src/review-orchestration/review-candidate-publication-log.test.ts
+++ b/src/review-orchestration/review-candidate-publication-log.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "bun:test";
+import type { Logger } from "pino";
+import type { ReviewCandidatePublicationRuntimeResult } from "./review-candidate-publication-runtime.ts";
+import { logReviewCandidatePublicationRuntime } from "./review-candidate-publication-log.ts";
+
+function createCaptureLogger() {
+  const entries: Array<{ level: "info" | "warn"; bindings: Record<string, unknown>; message: string }> = [];
+  const logger = {
+    info: (bindings: Record<string, unknown>, message: string) => {
+      entries.push({ level: "info", bindings, message });
+    },
+    warn: (bindings: Record<string, unknown>, message: string) => {
+      entries.push({ level: "warn", bindings, message });
+    },
+    error: () => undefined,
+    debug: () => undefined,
+    trace: () => undefined,
+    fatal: () => undefined,
+    child: () => logger,
+  };
+  return { logger: logger as unknown as Logger, entries };
+}
+
+const baseRuntime: ReviewCandidatePublicationRuntimeResult = {
+  mode: "approved",
+  counts: {
+    candidateInput: 1,
+    candidateRecorded: 1,
+    candidateRejected: 0,
+    candidatePublishable: 1,
+    candidatePublished: 1,
+    candidateBlocked: 0,
+    candidateFailed: 0,
+    candidateMalformed: 0,
+    fixEligibilityBlocked: 0,
+    directPublished: 0,
+    malformed: 0,
+  },
+  reasons: [],
+  outcomeBuckets: {},
+  publisherResultSample: [],
+  movedToDetails: [],
+};
+
+describe("logReviewCandidatePublicationRuntime", () => {
+  test("logs approved publication at info with projected counts", () => {
+    const { logger, entries } = createCaptureLogger();
+
+    logReviewCandidatePublicationRuntime({
+      logger,
+      baseLog: { repo: "xbmc/xbmc", prNumber: 1 },
+      runtime: baseRuntime,
+    });
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.level).toBe("info");
+    expect(entries[0]!.message).toBe("Review candidate publication completed");
+    expect(entries[0]!.bindings).toMatchObject({
+      gate: "review-candidate-publication",
+      gateResult: "approved",
+      counts: expect.objectContaining({ candidatePublished: 1 }),
+    });
+    expect(entries[0]!.bindings.classification).toBeUndefined();
+  });
+
+  test("logs expected policy blocks at info instead of warn", () => {
+    const { logger, entries } = createCaptureLogger();
+
+    logReviewCandidatePublicationRuntime({
+      logger,
+      baseLog: { repo: "xbmc/xbmc", prNumber: 1 },
+      runtime: {
+        ...baseRuntime,
+        mode: "blocked",
+        counts: {
+          ...baseRuntime.counts,
+          candidatePublishable: 0,
+          candidatePublished: 0,
+          candidateBlocked: 1,
+          fixEligibilityBlocked: 1,
+        },
+        reasons: ["fix-eligibility-blocked"],
+        outcomeBuckets: {
+          blocked: { mode: "blocked", count: 1, reasons: ["fix-eligibility-blocked"] },
+        },
+      },
+    });
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.level).toBe("info");
+    expect(entries[0]!.message).toBe("Review candidate publication completed with expected policy block");
+  });
+
+  test("logs degraded mode at warn", () => {
+    const { logger, entries } = createCaptureLogger();
+
+    logReviewCandidatePublicationRuntime({
+      logger,
+      baseLog: { repo: "xbmc/xbmc", prNumber: 1 },
+      runtime: { ...baseRuntime, mode: "degraded", reasons: ["publisher-unavailable"] },
+    });
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.level).toBe("warn");
+    expect(entries[0]!.message).toBe("Review candidate publication completed with non-approved mode");
+  });
+});

--- a/src/review-orchestration/review-candidate-publication-log.ts
+++ b/src/review-orchestration/review-candidate-publication-log.ts
@@ -1,0 +1,57 @@
+import type { Logger } from "pino";
+import {
+  toProductionLogCandidatePublicationBuckets,
+  toProductionLogCandidatePublicationCounts,
+  toProductionLogCandidatePublicationPublisherSample,
+  toProductionLogCandidatePublicationReason,
+} from "../review-audit/production-log-projection.ts";
+import {
+  isExpectedCandidatePublicationPolicyBlock,
+  type ReviewCandidatePublicationRuntimeResult,
+} from "./review-candidate-publication-runtime.ts";
+
+export function logReviewCandidatePublicationRuntime(params: {
+  logger: Logger;
+  baseLog: Record<string, unknown>;
+  runtime: ReviewCandidatePublicationRuntimeResult;
+}): void {
+  try {
+    const payload = {
+      ...params.baseLog,
+      gate: "review-candidate-publication",
+      gateResult: params.runtime.mode,
+      mode: params.runtime.mode,
+      counts: toProductionLogCandidatePublicationCounts(params.runtime.counts),
+      reasons: params.runtime.reasons.map(toProductionLogCandidatePublicationReason),
+      outcomeBuckets: toProductionLogCandidatePublicationBuckets(params.runtime.outcomeBuckets),
+      publisherResultSample: toProductionLogCandidatePublicationPublisherSample(params.runtime.publisherResultSample),
+      movedToDetails: params.runtime.movedToDetails,
+    };
+
+    const expectedPolicyBlocked = isExpectedCandidatePublicationPolicyBlock(params.runtime);
+
+    if (expectedPolicyBlocked) {
+      params.logger.info(payload, "Review candidate publication completed with expected policy block");
+      return;
+    }
+
+    if (params.runtime.mode === "degraded" || params.runtime.mode === "blocked" || params.runtime.mode === "fallback-disallowed") {
+      params.logger.warn(payload, "Review candidate publication completed with non-approved mode");
+      return;
+    }
+
+    params.logger.info(payload, "Review candidate publication completed");
+  } catch (error) {
+    params.logger.warn(
+      {
+        ...params.baseLog,
+        gate: "review-candidate-publication",
+        gateResult: "degraded",
+        mode: "degraded",
+        reasons: ["malformed-runtime-summary"],
+        logError: error instanceof Error ? error.message : String(error),
+      },
+      "Review candidate publication runtime log degraded",
+    );
+  }
+}

--- a/src/review-orchestration/review-continuation-family-state.test.ts
+++ b/src/review-orchestration/review-continuation-family-state.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from "bun:test";
+import type { Logger } from "pino";
+import { createReviewWorkCoordinator } from "../jobs/review-work-coordinator.ts";
+import {
+  createReviewContinuationFamilyStateManager,
+  extractBaseReviewOutputKey,
+  parseAttemptOrdinal,
+} from "./review-continuation-family-state.ts";
+
+describe("extractBaseReviewOutputKey", () => {
+  test("strips retry suffix from review output keys", () => {
+    expect(extractBaseReviewOutputKey("rk_main-retry-2")).toBe("rk_main");
+    expect(extractBaseReviewOutputKey("rk_main")).toBe("rk_main");
+  });
+});
+
+describe("parseAttemptOrdinal", () => {
+  test("reads trailing numeric ordinal from attempt ids", () => {
+    expect(parseAttemptOrdinal("family-attempt-3")).toBe(3);
+    expect(parseAttemptOrdinal("no-digits")).toBe(0);
+  });
+});
+
+describe("createReviewContinuationFamilyStateManager", () => {
+  test("skips publish when coordinator denies rights and logs supersession", async () => {
+    const coordinator = createReviewWorkCoordinator();
+    const automatic = coordinator.claim({
+      familyKey: "xbmc/xbmc#1",
+      source: "automatic-review",
+      lane: "review",
+      deliveryId: "delivery-1",
+      phase: "executor-dispatch",
+    });
+    const explicit = coordinator.claim({
+      familyKey: "xbmc/xbmc#1",
+      source: "explicit-review",
+      lane: "interactive-review",
+      deliveryId: "delivery-2",
+      phase: "executor-dispatch",
+    });
+
+    const infoEntries: Array<{ bindings: Record<string, unknown>; message: string }> = [];
+    const logger = {
+      info: (bindings: Record<string, unknown>, message: string) => {
+        infoEntries.push({ bindings, message });
+      },
+      warn: () => undefined,
+      error: () => undefined,
+      debug: () => undefined,
+      trace: () => undefined,
+      fatal: () => undefined,
+      child: () => logger,
+    } as unknown as Logger;
+
+    const manager = createReviewContinuationFamilyStateManager({
+      logger,
+      baseLog: { repo: "xbmc/xbmc", prNumber: 1 },
+      reviewFamilyKey: "xbmc/xbmc#1",
+      reviewOutputKey: "rk_test",
+      reviewWorkCoordinator: coordinator,
+    });
+
+    expect(manager.canPublishReviewWorkOutput(automatic.attemptId, "review output", "delivery-1")).toBeFalse();
+    expect(infoEntries).toHaveLength(1);
+    expect(infoEntries[0]!.message).toBe("Skipping review output because publish rights were superseded");
+    expect(infoEntries[0]!.bindings).toMatchObject({
+      gate: "review-family-coordinator",
+      gateResult: "skipped",
+      skipReason: "publish-rights-lost",
+      reviewWorkAttemptId: automatic.attemptId,
+      supersededByAttemptId: explicit.attemptId,
+    });
+
+    expect(manager.canPublishReviewWorkOutput(explicit.attemptId, "review output", "delivery-2")).toBeTrue();
+  });
+
+  test("persists canonical continuation-family state when knowledge store is available", async () => {
+    const writes: Record<string, unknown>[] = [];
+    const coordinator = createReviewWorkCoordinator();
+    const attempt = coordinator.claim({
+      familyKey: "xbmc/xbmc#2",
+      source: "explicit-review",
+      lane: "interactive-review",
+      deliveryId: "delivery-3",
+      phase: "claimed",
+    });
+
+    const manager = createReviewContinuationFamilyStateManager({
+      logger: {
+        info: () => undefined,
+        warn: () => undefined,
+        error: () => undefined,
+        debug: () => undefined,
+        trace: () => undefined,
+        fatal: () => undefined,
+        child: () => ({}),
+      } as unknown as Logger,
+      baseLog: { repo: "xbmc/xbmc", prNumber: 2 },
+      reviewFamilyKey: "xbmc/xbmc#2",
+      reviewOutputKey: "rk_base-retry-1",
+      knowledgeStore: {
+        upsertContinuationFamilyState: async (record) => {
+          writes.push(record);
+        },
+      },
+      reviewWorkCoordinator: coordinator,
+    });
+
+    await manager.finalizeContinuationAttempt({
+      attemptId: attempt.attemptId,
+      fallbackOutcome: "merged",
+      fallbackStopReason: "merged-continuation-results",
+      reviewOutputKey: "rk_base-retry-1",
+    });
+
+    expect(writes).toHaveLength(1);
+    expect(writes[0]).toMatchObject({
+      familyKey: "xbmc/xbmc#2",
+      baseReviewOutputKey: "rk_base",
+      authoritativeAttemptId: attempt.attemptId,
+      authoritativeOutcome: "merged",
+      finalStopReason: "merged-continuation-results",
+      projectionStatus: "canonical",
+    });
+  });
+});

--- a/src/review-orchestration/review-continuation-family-state.ts
+++ b/src/review-orchestration/review-continuation-family-state.ts
@@ -1,0 +1,219 @@
+import type { Logger } from "pino";
+import type { ReviewWorkCoordinator } from "../jobs/review-work-coordinator.ts";
+import type {
+  ContinuationFamilyAuthoritativeOutcome,
+  ContinuationFamilyFinalStopReason,
+  ContinuationFamilyProjectionStatus,
+  KnowledgeStore,
+} from "../knowledge/types.ts";
+
+export function extractBaseReviewOutputKey(reviewOutputKey: string): string {
+  return reviewOutputKey.replace(/-retry-\d+$/, "");
+}
+
+export function parseAttemptOrdinal(attemptId: string): number {
+  const match = /(?:^|[^\d])(\d+)$/.exec(attemptId);
+  return match ? Number.parseInt(match[1] ?? "0", 10) : 0;
+}
+
+type PersistContinuationFamilyStateParams = {
+  authoritativeAttemptId: string;
+  authoritativeAttemptOrdinal?: number;
+  authoritativeOutcome: ContinuationFamilyAuthoritativeOutcome;
+  finalStopReason: ContinuationFamilyFinalStopReason;
+  projectionStatus: ContinuationFamilyProjectionStatus;
+  supersededByAttemptId?: string | null;
+  reviewOutputKey?: string;
+};
+
+type ReviewContinuationFamilyStateManagerDeps = {
+  logger: Logger;
+  baseLog: Record<string, unknown>;
+  reviewFamilyKey: string;
+  reviewOutputKey: string;
+  knowledgeStore?: Pick<KnowledgeStore, "upsertContinuationFamilyState">;
+  reviewWorkCoordinator: Pick<ReviewWorkCoordinator, "getSnapshot" | "canPublish">;
+};
+
+export type ReviewContinuationFamilyStateManager = {
+  persistContinuationFamilyState: (params: PersistContinuationFamilyStateParams) => Promise<void>;
+  persistDegradedContinuationFamilyState: (params: Omit<PersistContinuationFamilyStateParams, "projectionStatus">) => Promise<void>;
+  settleRetryWithoutCanonicalUpdate: (params: {
+    attemptId: string;
+    reviewOutputKey?: string;
+    deliveryId: string;
+    reason: string;
+    logMessage: string;
+  }) => Promise<void>;
+  finalizeContinuationAttempt: (params: {
+    attemptId: string;
+    fallbackOutcome: ContinuationFamilyAuthoritativeOutcome;
+    fallbackStopReason: ContinuationFamilyFinalStopReason;
+    reviewOutputKey?: string;
+  }) => Promise<void>;
+  canPublishReviewWorkOutput: (attemptId: string, outputLabel: string, deliveryId: string) => boolean;
+};
+
+export function createReviewContinuationFamilyStateManager(
+  deps: ReviewContinuationFamilyStateManagerDeps,
+): ReviewContinuationFamilyStateManager {
+  async function persistContinuationFamilyState(params: PersistContinuationFamilyStateParams): Promise<void> {
+    if (!deps.knowledgeStore?.upsertContinuationFamilyState) {
+      return;
+    }
+
+    const authoritativeAttemptOrdinal = params.authoritativeAttemptOrdinal
+      ?? parseAttemptOrdinal(params.authoritativeAttemptId);
+    if (!Number.isFinite(authoritativeAttemptOrdinal) || authoritativeAttemptOrdinal < 1) {
+      deps.logger.warn(
+        {
+          ...deps.baseLog,
+          gate: "continuation-family-state",
+          gateResult: "skipped",
+          reason: "invalid-attempt-ordinal",
+          authoritativeAttemptId: params.authoritativeAttemptId,
+        },
+        "Skipping canonical continuation-family state write because the attempt ordinal was invalid",
+      );
+      return;
+    }
+
+    try {
+      await deps.knowledgeStore.upsertContinuationFamilyState({
+        familyKey: deps.reviewFamilyKey,
+        baseReviewOutputKey: extractBaseReviewOutputKey(params.reviewOutputKey ?? deps.reviewOutputKey),
+        authoritativeAttemptId: params.authoritativeAttemptId,
+        authoritativeAttemptOrdinal,
+        authoritativeOutcome: params.authoritativeOutcome,
+        finalStopReason: params.finalStopReason,
+        projectionStatus: params.projectionStatus,
+        supersededByAttemptId: params.supersededByAttemptId ?? null,
+      });
+    } catch (err) {
+      deps.logger.warn(
+        {
+          ...deps.baseLog,
+          gate: "continuation-family-state",
+          gateResult: "degraded",
+          authoritativeAttemptId: params.authoritativeAttemptId,
+          authoritativeOutcome: params.authoritativeOutcome,
+          finalStopReason: params.finalStopReason,
+          err,
+        },
+        "Failed to persist canonical continuation-family state",
+      );
+    }
+  }
+
+  async function persistDegradedContinuationFamilyState(
+    params: Omit<PersistContinuationFamilyStateParams, "projectionStatus">,
+  ): Promise<void> {
+    await persistContinuationFamilyState({
+      ...params,
+      projectionStatus: "degraded",
+    });
+  }
+
+  async function settleRetryWithoutCanonicalUpdate(params: {
+    attemptId: string;
+    reviewOutputKey?: string;
+    deliveryId: string;
+    reason: string;
+    logMessage: string;
+  }): Promise<void> {
+    deps.logger.warn(
+      {
+        deliveryId: params.deliveryId,
+        prNumber: deps.baseLog.prNumber,
+        reviewOutputKey: params.reviewOutputKey,
+        reason: params.reason,
+      },
+      params.logMessage,
+    );
+    await persistContinuationFamilyState({
+      authoritativeAttemptId: params.attemptId,
+      authoritativeOutcome: "quiet-settled",
+      finalStopReason: "settled-without-update",
+      projectionStatus: "canonical",
+      reviewOutputKey: params.reviewOutputKey,
+    });
+  }
+
+  async function finalizeContinuationAttempt(params: {
+    attemptId: string;
+    fallbackOutcome: ContinuationFamilyAuthoritativeOutcome;
+    fallbackStopReason: ContinuationFamilyFinalStopReason;
+    reviewOutputKey?: string;
+  }): Promise<void> {
+    const currentAttempt = deps.reviewWorkCoordinator
+      .getSnapshot(deps.reviewFamilyKey)
+      ?.attempts.find((attempt) => attempt.attemptId === params.attemptId);
+    const supersededByAttemptId = currentAttempt?.supersededByAttemptId ?? null;
+
+    if (supersededByAttemptId) {
+      await persistContinuationFamilyState({
+        authoritativeAttemptId: supersededByAttemptId,
+        authoritativeOutcome: "superseded",
+        finalStopReason: "superseded-by-newer-attempt",
+        projectionStatus: "canonical",
+        supersededByAttemptId,
+        reviewOutputKey: params.reviewOutputKey,
+      });
+      return;
+    }
+
+    await persistContinuationFamilyState({
+      authoritativeAttemptId: params.attemptId,
+      authoritativeOutcome: params.fallbackOutcome,
+      finalStopReason: params.fallbackStopReason,
+      projectionStatus: "canonical",
+      reviewOutputKey: params.reviewOutputKey,
+    });
+  }
+
+  function canPublishReviewWorkOutput(
+    attemptId: string,
+    outputLabel: string,
+    deliveryId: string,
+  ): boolean {
+    if (deps.reviewWorkCoordinator.canPublish(attemptId)) {
+      return true;
+    }
+
+    const currentAttempt = deps.reviewWorkCoordinator
+      .getSnapshot(deps.reviewFamilyKey)
+      ?.attempts.find((attempt) => attempt.attemptId === attemptId);
+    const supersededByAttemptId = currentAttempt?.supersededByAttemptId ?? null;
+    if (supersededByAttemptId) {
+      void persistContinuationFamilyState({
+        authoritativeAttemptId: supersededByAttemptId,
+        authoritativeOutcome: "superseded",
+        finalStopReason: "superseded-by-newer-attempt",
+        projectionStatus: "canonical",
+        supersededByAttemptId,
+      });
+    }
+    deps.logger.info(
+      {
+        ...deps.baseLog,
+        deliveryId,
+        gate: "review-family-coordinator",
+        gateResult: "skipped",
+        skipReason: "publish-rights-lost",
+        reviewFamilyKey: deps.reviewFamilyKey,
+        reviewWorkAttemptId: attemptId,
+        supersededByAttemptId,
+      },
+      `Skipping ${outputLabel} because publish rights were superseded`,
+    );
+    return false;
+  }
+
+  return {
+    persistContinuationFamilyState,
+    persistDegradedContinuationFamilyState,
+    settleRetryWithoutCanonicalUpdate,
+    finalizeContinuationAttempt,
+    canPublishReviewWorkOutput,
+  };
+}


### PR DESCRIPTION
## Summary
- Extract review candidate publication logging and continuation-family state wiring from `review.ts` into dedicated orchestration modules with unit tests.
- Add formatter command sandbox: allowlisted executables spawn via argv; shell metacharacters or unknown binaries fall back to `bash -lc` with bounded `executionMode` telemetry on process results.

## Test plan
- [x] `bun test src/review-orchestration/review-candidate-publication-log.test.ts`
- [x] `bun test src/review-orchestration/review-continuation-family-state.test.ts`
- [x] `bun test src/execution/formatter-command-sandbox.test.ts`
- [x] `bun run lint`


Made with [Cursor](https://cursor.com)