### PR TITLE
Extract mention state stores

### DIFF
--- a/src/handlers/mention.ts
+++ b/src/handlers/mention.ts
@@ -107,6 +107,11 @@ import { createGuardrailAuditStore } from "../lib/guardrail/audit-store.ts";
 import { mentionAdapter } from "../lib/guardrail/adapters/mention-adapter.ts";
 import { FORK_WRITE_POLICY_INSTRUCTIONS } from "../execution/prompts.ts";
 import { buildWritePolicyRefusalMessage } from "../lib/mention-utils.ts";
+import {
+  createConversationTurnStore,
+  createTriageCooldownStore,
+  createWriteRateLimitStore,
+} from "../lib/mention-state-stores.ts";
 import { splitGitLines } from "../lib/review-utils.ts";
 import {
   buildApprovedReviewBody,
@@ -354,81 +359,12 @@ export function createMentionHandler(deps: {
     },
   });
 
-  // Basic in-memory rate limiter for write-mode requests.
-  // Keyed by installation+repo; resets on process restart.
-  const lastWriteAt = new Map<string, number>();
-  const prConversationTurns = new Map<string, number>();
-  const prConversationTouchedAt = new Map<string, number>();
+  const writeRateLimitStore = createWriteRateLimitStore();
+  const conversationTurnStore = createConversationTurnStore();
 
   const inFlightWriteKeys = new Set<string>();
 
-  // Per-issue triage cooldown: prevents repeated triage nudges.
-  // Keyed by "{owner}/{repo}#{issueNumber}". Resets when issue body hash changes.
-  const triageCooldowns = new Map<string, { lastTriagedAt: number; bodyHash: string }>();
-
-  function pruneTriageCooldowns(now: number): void {
-    const ttlMs = 24 * 60 * 60 * 1000; // 24h
-    for (const [key, entry] of triageCooldowns.entries()) {
-      if (now - entry.lastTriagedAt > ttlMs) {
-        triageCooldowns.delete(key);
-      }
-    }
-    // Hard cap
-    if (triageCooldowns.size > 1000) {
-      const sortedEntries = [...triageCooldowns.entries()]
-        .sort((a, b) => a[1].lastTriagedAt - b[1].lastTriagedAt);
-      const toDelete = sortedEntries.slice(0, triageCooldowns.size - 1000);
-      for (const [key] of toDelete) {
-        triageCooldowns.delete(key);
-      }
-    }
-  }
-
-
-  function pruneRateLimiter(now: number): void {
-    // Defense-in-depth: prevent unbounded growth in long-lived processes.
-    // Keep recent entries only; this limiter is best-effort and not durable.
-    const ttlMs = 24 * 60 * 60 * 1000; // 24h
-    for (const [key, ts] of lastWriteAt.entries()) {
-      if (now - ts > ttlMs) {
-        lastWriteAt.delete(key);
-      }
-    }
-
-    // Hard cap: if still large, drop oldest entries.
-    const maxEntries = 10_000;
-    if (lastWriteAt.size <= maxEntries) return;
-
-    const entries = [...lastWriteAt.entries()].sort((a, b) => a[1] - b[1]);
-    const toDelete = entries.length - maxEntries;
-    for (let i = 0; i < toDelete; i++) {
-      const k = entries[i]?.[0];
-      if (k) lastWriteAt.delete(k);
-    }
-  }
-
-  function pruneConversationTurns(now: number): void {
-    const ttlMs = 24 * 60 * 60 * 1000;
-    for (const [key, ts] of prConversationTouchedAt.entries()) {
-      if (now - ts > ttlMs) {
-        prConversationTurns.delete(key);
-        prConversationTouchedAt.delete(key);
-      }
-    }
-
-    const maxEntries = 10_000;
-    if (prConversationTurns.size <= maxEntries) return;
-
-    const entries = [...prConversationTouchedAt.entries()].sort((a, b) => a[1] - b[1]);
-    const toDelete = entries.length - maxEntries;
-    for (let i = 0; i < toDelete; i++) {
-      const k = entries[i]?.[0];
-      if (k) {
-        prConversationTurns.delete(k);
-        prConversationTouchedAt.delete(k);
-      }
-    }
-  }
+  const triageCooldownStore = createTriageCooldownStore();
 
 
 
@@ -1283,8 +1219,7 @@ export function createMentionHandler(deps: {
         if (writeEnabled && config.write.minIntervalSeconds > 0) {
           const key = `${event.installationId}:${mention.owner}/${mention.repo}`;
           const now = Date.now();
-          pruneRateLimiter(now);
-          const last = lastWriteAt.get(key);
+          const last = writeRateLimitStore.getLastWriteAt(key);
           const minMs = config.write.minIntervalSeconds * 1000;
 
           if (last !== undefined && now - last < minMs) {
@@ -1357,9 +1292,7 @@ export function createMentionHandler(deps: {
 
         if (mention.inReplyToId !== undefined) {
           const conversationKey = `${mention.owner}/${mention.repo}#${mention.prNumber ?? mention.issueNumber}`;
-          const now = Date.now();
-          pruneConversationTurns(now);
-          const turns = prConversationTurns.get(conversationKey) ?? 0;
+          const turns = conversationTurnStore.getTurns(conversationKey);
           if (turns >= config.mention.conversation.maxTurnsPerPr) {
             await postMentionReply(
               [
@@ -1524,8 +1457,7 @@ export function createMentionHandler(deps: {
             .digest("hex")
             .slice(0, 16);
           const now = Date.now();
-          pruneTriageCooldowns(now);
-          const cooldownEntry = triageCooldowns.get(cooldownKey);
+          const cooldownEntry = triageCooldownStore.get(cooldownKey);
           const cooldownMs = (config.triage.cooldownMinutes ?? 30) * 60 * 1000;
 
           const withinCooldown =
@@ -1558,7 +1490,7 @@ export function createMentionHandler(deps: {
               // If valid, triageContext stays empty -- no nudge needed
 
               // Update cooldown
-              triageCooldowns.set(cooldownKey, { lastTriagedAt: now, bodyHash });
+              triageCooldownStore.set(cooldownKey, { lastTriagedAt: now, bodyHash });
             } catch (err) {
               logger.warn(
                 { err, issueNumber: mention.issueNumber },
@@ -2596,8 +2528,7 @@ export function createMentionHandler(deps: {
 
         if (mention.inReplyToId !== undefined && result.conclusion === "success") {
           const conversationKey = `${mention.owner}/${mention.repo}#${mention.prNumber ?? mention.issueNumber}`;
-          prConversationTurns.set(conversationKey, (prConversationTurns.get(conversationKey) ?? 0) + 1);
-          prConversationTouchedAt.set(conversationKey, Date.now());
+          conversationTurnStore.recordSuccessfulTurn(conversationKey);
         }
 
         // Telemetry capture (TELEM-03, TELEM-05, CONFIG-10)
@@ -3409,7 +3340,7 @@ export function createMentionHandler(deps: {
           // Record successful publish time for rate limiting.
           if (config.write.minIntervalSeconds > 0) {
             const key = `${event.installationId}:${mention.owner}/${mention.repo}`;
-            lastWriteAt.set(key, Date.now());
+            writeRateLimitStore.recordWrite(key);
           }
 
           return;

--- a/src/lib/mention-state-stores.test.ts
+++ b/src/lib/mention-state-stores.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createConversationTurnStore,
+  createTriageCooldownStore,
+  createWriteRateLimitStore,
+} from "./mention-state-stores.ts";
+
+describe("mention state stores", () => {
+  test("write rate limit store records writes and expires old entries", () => {
+    let now = 1_000;
+    const store = createWriteRateLimitStore({
+      maxSize: 2,
+      ttlMs: 100,
+      now: () => now,
+    });
+
+    store.recordWrite("repo-a");
+
+    expect(store.getLastWriteAt("repo-a")).toBe(1_000);
+
+    now = 1_101;
+
+    expect(store.getLastWriteAt("repo-a")).toBeUndefined();
+  });
+
+  test("write rate limit store caps oldest entries", () => {
+    let now = 1_000;
+    const store = createWriteRateLimitStore({
+      maxSize: 2,
+      ttlMs: 10_000,
+      now: () => now,
+    });
+
+    store.recordWrite("oldest");
+    now += 1;
+    store.recordWrite("middle");
+    now += 1;
+    store.recordWrite("newest");
+
+    expect(store.getLastWriteAt("oldest")).toBeUndefined();
+    expect(store.getLastWriteAt("middle")).toBe(1_001);
+    expect(store.getLastWriteAt("newest")).toBe(1_002);
+  });
+
+  test("conversation turn store counts successful turns and expires inactive threads", () => {
+    let now = 1_000;
+    const store = createConversationTurnStore({
+      maxSize: 10,
+      ttlMs: 100,
+      now: () => now,
+    });
+
+    expect(store.getTurns("thread")).toBe(0);
+    expect(store.recordSuccessfulTurn("thread")).toBe(1);
+    expect(store.recordSuccessfulTurn("thread")).toBe(2);
+    expect(store.getTurns("thread")).toBe(2);
+
+    now = 1_101;
+
+    expect(store.getTurns("thread")).toBe(0);
+  });
+
+  test("triage cooldown store keeps body hash metadata behind cache policy", () => {
+    let now = 1_000;
+    const store = createTriageCooldownStore({
+      maxSize: 1,
+      ttlMs: 100,
+      now: () => now,
+    });
+
+    store.set("issue", { lastTriagedAt: now, bodyHash: "abc" });
+
+    expect(store.get("issue")).toEqual({ lastTriagedAt: 1_000, bodyHash: "abc" });
+
+    now = 1_101;
+
+    expect(store.get("issue")).toBeUndefined();
+  });
+});

--- a/src/lib/mention-state-stores.ts
+++ b/src/lib/mention-state-stores.ts
@@ -1,0 +1,86 @@
+import { createInMemoryCache } from "./in-memory-cache.ts";
+
+type MentionStateStoreOptions = {
+  maxSize?: number;
+  ttlMs?: number;
+  now?: () => number;
+};
+
+const MENTION_STATE_TTL_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_WRITE_RATE_LIMIT_MAX_SIZE = 10_000;
+const DEFAULT_CONVERSATION_TURN_MAX_SIZE = 10_000;
+const DEFAULT_TRIAGE_COOLDOWN_MAX_SIZE = 1_000;
+
+export type TriageCooldownEntry = {
+  lastTriagedAt: number;
+  bodyHash: string;
+};
+
+export type WriteRateLimitStore = {
+  getLastWriteAt(key: string): number | undefined;
+  recordWrite(key: string): void;
+};
+
+export type ConversationTurnStore = {
+  getTurns(key: string): number;
+  recordSuccessfulTurn(key: string): number;
+};
+
+export type TriageCooldownStore = {
+  get(key: string): TriageCooldownEntry | undefined;
+  set(key: string, entry: TriageCooldownEntry): void;
+};
+
+export function createWriteRateLimitStore(options: MentionStateStoreOptions = {}): WriteRateLimitStore {
+  const cache = createInMemoryCache<string, number>({
+    maxSize: options.maxSize ?? DEFAULT_WRITE_RATE_LIMIT_MAX_SIZE,
+    ttlMs: options.ttlMs ?? MENTION_STATE_TTL_MS,
+    now: options.now,
+  });
+  const now = options.now ?? Date.now;
+
+  return {
+    getLastWriteAt(key) {
+      return cache.get(key);
+    },
+    recordWrite(key) {
+      cache.set(key, now());
+    },
+  };
+}
+
+export function createConversationTurnStore(options: MentionStateStoreOptions = {}): ConversationTurnStore {
+  const cache = createInMemoryCache<string, number>({
+    maxSize: options.maxSize ?? DEFAULT_CONVERSATION_TURN_MAX_SIZE,
+    ttlMs: options.ttlMs ?? MENTION_STATE_TTL_MS,
+    now: options.now,
+  });
+
+  return {
+    getTurns(key) {
+      return cache.get(key) ?? 0;
+    },
+    recordSuccessfulTurn(key) {
+      const nextTurns = (cache.get(key) ?? 0) + 1;
+      cache.set(key, nextTurns);
+      return nextTurns;
+    },
+  };
+}
+
+export function createTriageCooldownStore(options: MentionStateStoreOptions = {}): TriageCooldownStore {
+  const cache = createInMemoryCache<string, TriageCooldownEntry>({
+    maxSize: options.maxSize ?? DEFAULT_TRIAGE_COOLDOWN_MAX_SIZE,
+    ttlMs: options.ttlMs ?? MENTION_STATE_TTL_MS,
+    now: options.now,
+  });
+
+  return {
+    get(key) {
+      return cache.get(key);
+    },
+    set(key, entry) {
+      cache.set(key, entry);
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Move mention rate-limit, conversation-turn, and triage cooldown state behind focused mention state stores.
- Reuse the existing in-memory cache for TTL and max-size cleanup instead of keeping local prune helpers in the handler.
- Keep `mention-utils` focused on write-policy refusal messaging and add focused store coverage.

## Verification
- `bun test src/lib/mention-state-stores.test.ts src/handlers/mention.test.ts`
- `bun run lint`
- `git diff --check`

Note: local untracked `kodiai-main-review/` remains intentionally untouched.