### PR TITLE
Reduce duplicate token work in review paths

### DIFF
--- a/src/knowledge/code-snippet-store.test.ts
+++ b/src/knowledge/code-snippet-store.test.ts
@@ -68,6 +68,23 @@ describe("createCodeSnippetStore", () => {
     expect(calls[0]!.values).toContain("abc123");
   });
 
+  test("hasSnippet checks for a non-stale content hash", async () => {
+    const calls: Array<{ query: string; values: unknown[] }> = [];
+    const sql = (strings: TemplateStringsArray, ...values: unknown[]) => {
+      calls.push({ query: strings.join("?"), values });
+      return Promise.resolve([{ "?column?": 1 }]);
+    };
+    const store = createCodeSnippetStore({
+      sql: sql as unknown as import("../db/client.ts").Sql,
+      logger: createMockLogger(),
+    });
+
+    await expect(store.hasSnippet!("abc123")).resolves.toBe(true);
+    expect(calls[0]!.query).toContain("content_hash");
+    expect(calls[0]!.query).toContain("stale = false");
+    expect(calls[0]!.values).toContain("abc123");
+  });
+
   test("writeOccurrence calls sql with occurrence data", async () => {
     const { sql, calls } = createMockSql();
     const store = createCodeSnippetStore({

--- a/src/knowledge/code-snippet-store.ts
+++ b/src/knowledge/code-snippet-store.ts
@@ -100,6 +100,17 @@ export function createCodeSnippetStore(opts: {
   const { sql, logger } = opts;
 
   const store: CodeSnippetStore = {
+    async hasSnippet(contentHash: string): Promise<boolean> {
+      const rows = await sql`
+        SELECT 1
+        FROM code_snippets
+        WHERE content_hash = ${contentHash}
+          AND stale = false
+        LIMIT 1
+      `;
+      return rows.length > 0;
+    },
+
     async writeSnippet(
       record: {
         contentHash: string;

--- a/src/knowledge/code-snippet-types.ts
+++ b/src/knowledge/code-snippet-types.ts
@@ -57,6 +57,8 @@ export type CodeSnippetRepairCandidate = {
 };
 
 export type CodeSnippetStore = {
+  hasSnippet?(contentHash: string): Promise<boolean>;
+
   writeSnippet(
     record: {
       contentHash: string;

--- a/src/knowledge/retrieval.test.ts
+++ b/src/knowledge/retrieval.test.ts
@@ -299,6 +299,38 @@ describe("createRetriever", () => {
     expect(result!.provenance.embeddingCacheHits).toBeGreaterThan(0);
   });
 
+  test("reuses request-scoped embedding cache for wiki retrieval when provider is shared", async () => {
+    let generateCalls = 0;
+    const embeddingProvider: EmbeddingProvider = {
+      async generate(_text: string, _inputType: "document" | "query"): Promise<EmbeddingResult> {
+        generateCalls += 1;
+        return {
+          embedding: new Float32Array(1024).fill(0.1),
+          model: "test-model",
+          dimensions: 1024,
+        };
+      },
+      get model() { return "test-model"; },
+      get dimensions() { return 1024; },
+    };
+
+    const retriever = createRetriever({
+      embeddingProvider,
+      isolationLayer: makeMockIsolationLayer([makeRetrievalResult(1, 0.2)]),
+      wikiPageStore: makeMockWikiStore([makeWikiSearchResult(10, 0.2, ["typescript"])]),
+      config: makeConfig({ adaptive: false }),
+    });
+
+    const result = await retriever.retrieve(makeBaseOpts({
+      queries: ["same shared query"],
+    }));
+
+    expect(result).not.toBeNull();
+    expect(generateCalls).toBe(1);
+    expect(result!.provenance.embeddingRequests).toBe(1);
+    expect(result!.provenance.embeddingCacheHits).toBeGreaterThanOrEqual(1);
+  });
+
   test("does not reuse embeddings across separate retrieve calls", async () => {
     let generateCalls = 0;
     const embeddingProvider: EmbeddingProvider = {

--- a/src/knowledge/retrieval.ts
+++ b/src/knowledge/retrieval.ts
@@ -506,10 +506,9 @@ export function createRetriever(deps: {
       embeddingProvider,
       requestScopedEmbeddingStats,
     );
-    const wikiProvider = createRequestScopedEmbeddingProvider(
-      deps.wikiEmbeddingProvider ?? deps.embeddingProvider,
-      requestScopedEmbeddingStats,
-    );
+    const wikiProvider = deps.wikiEmbeddingProvider
+      ? createRequestScopedEmbeddingProvider(deps.wikiEmbeddingProvider, requestScopedEmbeddingStats)
+      : requestScopedEmbeddingProvider;
     const topK = opts.topK ?? config.retrieval.topK;
     const distanceThreshold = opts.distanceThreshold ?? config.retrieval.distanceThreshold;
     const adaptive = opts.adaptive ?? config.retrieval.adaptive;

--- a/src/lib/guardrail/llm-classifier.test.ts
+++ b/src/lib/guardrail/llm-classifier.test.ts
@@ -188,4 +188,29 @@ describe("createLlmClassifier", () => {
 
     expect(results[0]!.text).toBe("CVE-2024-1234 is critical.");
   });
+
+  test("renders shared grounding context once per batch", async () => {
+    const sharedContext = makeContext([
+      "large shared issue body",
+      "large shared diff patch",
+    ]);
+    const response = JSON.stringify([
+      { label: "diff-grounded", confidence: 0.9, evidence: "first" },
+      { label: "inferential", confidence: 0.8, evidence: "second" },
+    ]);
+
+    const deps = createMockDeps(response);
+    const classifier = createLlmClassifier(deps);
+
+    await classifier([
+      makeClaim("First claim.", sharedContext),
+      makeClaim("Second claim.", sharedContext),
+    ]);
+
+    const prompt = String(deps.generateWithFallback.mock.calls[0]?.[0]?.prompt ?? "");
+    expect(prompt).toContain("First claim.");
+    expect(prompt).toContain("Second claim.");
+    expect(prompt.match(/large shared issue body/g)).toHaveLength(1);
+    expect(prompt.match(/large shared diff patch/g)).toHaveLength(1);
+  });
 });

--- a/src/lib/guardrail/llm-classifier.ts
+++ b/src/lib/guardrail/llm-classifier.ts
@@ -56,25 +56,47 @@ const SYSTEM_PROMPT =
 // ---------------------------------------------------------------------------
 
 function buildBatchPrompt(claims: LlmClassifierClaim[]): string {
-  const sections = claims.map((claim, i) => {
-    const contextText = claim.context.providedContext.length > 0
+  const contextBlocks = new Map<string, { index: number; sources: string; text: string }>();
+
+  const getContextIndex = (claim: LlmClassifierClaim): number => {
+    const text = claim.context.providedContext.length > 0
       ? claim.context.providedContext.join("\n")
       : "(no context provided)";
+    const sources = claim.context.contextSources.join(", ") || "none";
+    const key = JSON.stringify({ sources, text });
+    const existing = contextBlocks.get(key);
+    if (existing) return existing.index;
+
+    const index = contextBlocks.size + 1;
+    contextBlocks.set(key, { index, sources, text });
+    return index;
+  };
+
+  const sections = claims.map((claim, i) => {
+    const contextIndex = getContextIndex(claim);
 
     return [
       `### Claim ${i + 1}`,
       `Text: "${claim.text}"`,
-      `Context sources: ${claim.context.contextSources.join(", ") || "none"}`,
-      `Available context:`,
-      contextText,
+      `Use shared context: Context ${contextIndex}`,
     ].join("\n");
   });
+
+  const sharedContextSections = Array.from(contextBlocks.values()).map((block) => [
+    `### Context ${block.index}`,
+    `Context sources: ${block.sources}`,
+    "Available context:",
+    block.text,
+  ].join("\n"));
 
   return [
     "Classify each of the following claims. For each claim, determine whether it is:",
     '- "diff-grounded": directly supported by the provided context',
     '- "external-knowledge": asserts facts not present in the provided context (versions, dates, API behavior, CVEs)',
     '- "inferential": a logical deduction from the provided context',
+    "",
+    "Shared context blocks:",
+    ...sharedContextSections,
     "",
     ...sections,
     "",

--- a/src/review-orchestration/review-diff-hunk-embedding.test.ts
+++ b/src/review-orchestration/review-diff-hunk-embedding.test.ts
@@ -1,7 +1,103 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
+import { embedReviewDiffHunks } from "./review-diff-hunk-embedding.ts";
+import type { CodeSnippetStore } from "../knowledge/code-snippet-types.ts";
+import type { EmbeddingProvider } from "../knowledge/types.ts";
+
+function createLogger() {
+  return {
+    info: mock(() => {}),
+    warn: mock(() => {}),
+    error: mock(() => {}),
+    debug: mock(() => {}),
+    child: () => createLogger(),
+  } as unknown as import("pino").Logger;
+}
+
+function createStore(existingHashes: Set<string> = new Set()): CodeSnippetStore {
+  return {
+    hasSnippet: mock(async (contentHash: string) => existingHashes.has(contentHash)),
+    writeSnippet: mock(async () => {}),
+    writeOccurrence: mock(async () => {}),
+    searchByEmbedding: mock(async () => []),
+    close: mock(() => {}),
+  } as unknown as CodeSnippetStore;
+}
 
 describe("embedReviewDiffHunks", () => {
-  test("module exports diff hunk embedding helper", () => {
-    expect(typeof Bun !== "undefined").toBe(true);
+  test("skips embedding generation for hunks whose content hash already exists", async () => {
+    const existingHashes = new Set<string>();
+    const store = createStore(existingHashes);
+    const embeddingProvider: EmbeddingProvider = {
+      generate: mock(async () => ({
+        embedding: new Float32Array([0.1, 0.2, 0.3]),
+        model: "test-model",
+        dimensions: 3,
+      })),
+      get model() { return "test-model"; },
+      get dimensions() { return 3; },
+    };
+
+    await embedReviewDiffHunks({
+      diffFiles: [{
+        filename: "src/example.ts",
+        patch: [
+          "@@ -1,2 +1,2 @@",
+          " export function example() {",
+          "-  return 1;",
+          "+  return 2;",
+          " }",
+        ].join("\n"),
+      }],
+      repo: "owner/repo",
+      owner: "owner",
+      prNumber: 123,
+      prTitle: "Change example",
+      codeSnippetStore: store,
+      embeddingProvider,
+      config: {
+        enabled: true,
+        maxHunksPerPr: 10,
+        minChangedLines: 1,
+        excludePatterns: [],
+      },
+      logger: createLogger(),
+    });
+
+    const contentHash = (store.writeSnippet as ReturnType<typeof mock>).mock.calls[0]?.[0]?.contentHash;
+    expect(typeof contentHash).toBe("string");
+    existingHashes.add(String(contentHash));
+    (embeddingProvider.generate as ReturnType<typeof mock>).mockClear();
+    (store.writeSnippet as ReturnType<typeof mock>).mockClear();
+    (store.writeOccurrence as ReturnType<typeof mock>).mockClear();
+
+    await embedReviewDiffHunks({
+      diffFiles: [{
+        filename: "src/example.ts",
+        patch: [
+          "@@ -1,2 +1,2 @@",
+          " export function example() {",
+          "-  return 1;",
+          "+  return 2;",
+          " }",
+        ].join("\n"),
+      }],
+      repo: "owner/repo",
+      owner: "owner",
+      prNumber: 124,
+      prTitle: "Change example",
+      codeSnippetStore: store,
+      embeddingProvider,
+      config: {
+        enabled: true,
+        maxHunksPerPr: 10,
+        minChangedLines: 1,
+        excludePatterns: [],
+      },
+      logger: createLogger(),
+    });
+
+    expect(embeddingProvider.generate).toHaveBeenCalledTimes(0);
+    expect(store.writeSnippet).toHaveBeenCalledTimes(0);
+    expect(store.writeOccurrence).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/review-orchestration/review-diff-hunk-embedding.ts
+++ b/src/review-orchestration/review-diff-hunk-embedding.ts
@@ -1,5 +1,6 @@
 import type { Logger } from "pino";
-import type { CodeSnippetStore, EmbeddingProvider } from "../knowledge/types.ts";
+import type { CodeSnippetStore } from "../knowledge/code-snippet-types.ts";
+import type { EmbeddingProvider } from "../knowledge/types.ts";
 import {
   applyHunkCap,
   buildEmbeddingText,
@@ -60,6 +61,22 @@ export async function embedReviewDiffHunks(params: {
       try {
         const embeddedText = buildEmbeddingText({ hunk, prTitle });
         const contentHash = computeContentHash(embeddedText);
+
+        const snippetExists = await codeSnippetStore.hasSnippet?.(contentHash);
+        if (snippetExists) {
+          await codeSnippetStore.writeOccurrence({
+            contentHash,
+            repo,
+            owner,
+            prNumber,
+            prTitle,
+            filePath: hunk.filePath,
+            startLine: hunk.startLine,
+            endLine: hunk.startLine + hunk.addedLines.length - 1,
+            functionContext: hunk.functionContext || null,
+          });
+          continue;
+        }
 
         const embeddingResult = await embeddingProvider.generate(embeddedText, "document");
         if (!embeddingResult) {


### PR DESCRIPTION
## Summary
- Deduplicate shared guardrail grounding context in classifier prompts so repeated claims reference one shared context block.
- Skip diff hunk embedding generation when a non-stale content hash already exists while still recording the PR occurrence.
- Reuse the retrieval request-scoped embedding cache for wiki search when no distinct wiki provider is configured.

## Verification
- `bun test src/lib/guardrail/llm-classifier.test.ts src/review-orchestration/review-diff-hunk-embedding.test.ts src/knowledge/retrieval.test.ts src/knowledge/code-snippet-store.test.ts`
- `bun test src/lib/guardrail src/review-orchestration src/knowledge/retrieval.test.ts src/knowledge/code-snippet-store.test.ts src/knowledge/code-snippet-retrieval.test.ts`
- `bun run lint`
- `git diff --check`
- `bun test src scripts --reporter=dots`

Note: plain `bun test` currently discovers ignored, untracked vendored tests under `tmp/claude-code-action` and fails on missing vendored deps (`@actions/core`). The explicit project-wide `src scripts` run passed: 5423 pass, 145 skip, 0 fail.