### PR TITLE
Deduplicate guardrail LLM claim classification

### DIFF
--- a/src/lib/guardrail/llm-classifier.test.ts
+++ b/src/lib/guardrail/llm-classifier.test.ts
@@ -213,4 +213,36 @@ describe("createLlmClassifier", () => {
     expect(prompt.match(/large shared issue body/g)).toHaveLength(1);
     expect(prompt.match(/large shared diff patch/g)).toHaveLength(1);
   });
+
+  test("deduplicates identical claim and context pairs before LLM classification", async () => {
+    const sharedContext = makeContext([
+      "large shared diff patch",
+    ]);
+    const response = JSON.stringify([
+      { label: "external-knowledge", confidence: 0.85, evidence: "version claim" },
+    ]);
+
+    const deps = createMockDeps(response);
+    const classifier = createLlmClassifier(deps);
+
+    const results = await classifier([
+      makeClaim("This requires version 21.", sharedContext),
+      makeClaim("This requires version 21.", sharedContext),
+    ]);
+
+    expect(results).toHaveLength(2);
+    expect(results.map((result) => result.text)).toEqual([
+      "This requires version 21.",
+      "This requires version 21.",
+    ]);
+    expect(results.map((result) => result.label)).toEqual([
+      "external-knowledge",
+      "external-knowledge",
+    ]);
+
+    expect(deps.generateWithFallback).toHaveBeenCalledTimes(1);
+    const prompt = String(deps.generateWithFallback.mock.calls[0]?.[0]?.prompt ?? "");
+    expect(prompt.match(/### Claim /g)).toHaveLength(1);
+    expect(prompt).toContain("Respond with a JSON array of exactly 1 objects");
+  });
 });

--- a/src/lib/guardrail/llm-classifier.ts
+++ b/src/lib/guardrail/llm-classifier.ts
@@ -121,6 +121,40 @@ type RawClassification = {
 
 const VALID_LABELS = new Set<ClaimLabel>(["diff-grounded", "external-knowledge", "inferential"]);
 
+function buildClaimCacheKey(claim: LlmClassifierClaim): string {
+  const contextText = claim.context.providedContext.length > 0
+    ? claim.context.providedContext.join("\n")
+    : "(no context provided)";
+  const contextSources = claim.context.contextSources.join("\n");
+  return JSON.stringify({
+    text: claim.text,
+    contextSources,
+    contextText,
+  });
+}
+
+function dedupeClaims(claims: LlmClassifierClaim[]): {
+  uniqueClaims: LlmClassifierClaim[];
+  originalToUniqueIndex: number[];
+} {
+  const uniqueClaims: LlmClassifierClaim[] = [];
+  const originalToUniqueIndex: number[] = [];
+  const indexByKey = new Map<string, number>();
+
+  for (const claim of claims) {
+    const key = buildClaimCacheKey(claim);
+    let uniqueIndex = indexByKey.get(key);
+    if (uniqueIndex === undefined) {
+      uniqueIndex = uniqueClaims.length;
+      indexByKey.set(key, uniqueIndex);
+      uniqueClaims.push(claim);
+    }
+    originalToUniqueIndex.push(uniqueIndex);
+  }
+
+  return { uniqueClaims, originalToUniqueIndex };
+}
+
 function parseClassifications(
   text: string,
   claimTexts: string[],
@@ -180,11 +214,12 @@ export function createLlmClassifier(deps: LlmClassifierDeps): LlmClassifier {
 
     try {
       const resolved = taskRouter.resolve(TASK_TYPES.GUARDRAIL_CLASSIFICATION);
+      const { uniqueClaims, originalToUniqueIndex } = dedupeClaims(claims);
 
       // Batch claims into chunks of MAX_CLAIMS_PER_BATCH
-      const results: ClaimClassification[] = [];
-      for (let i = 0; i < claims.length; i += MAX_CLAIMS_PER_BATCH) {
-        const batch = claims.slice(i, i + MAX_CLAIMS_PER_BATCH);
+      const uniqueResults: ClaimClassification[] = [];
+      for (let i = 0; i < uniqueClaims.length; i += MAX_CLAIMS_PER_BATCH) {
+        const batch = uniqueClaims.slice(i, i + MAX_CLAIMS_PER_BATCH);
         const batchTexts = batch.map((c) => c.text);
 
         try {
@@ -200,18 +235,22 @@ export function createLlmClassifier(deps: LlmClassifierDeps): LlmClassifier {
           });
 
           const classifications = parseClassifications(response.text, batchTexts);
-          results.push(...classifications);
+          uniqueResults.push(...classifications);
         } catch (batchErr) {
           // Fail-open per batch: if one batch fails, return all claims in that batch as grounded
           logger.warn(
             { err: batchErr, batchSize: batch.length },
             "LLM classifier batch failed, applying fail-open for batch",
           );
-          results.push(...batchTexts.map(failOpenClassification));
+          uniqueResults.push(...batchTexts.map(failOpenClassification));
         }
       }
 
-      return results;
+      return originalToUniqueIndex.map((uniqueIndex, originalIndex) => {
+        const claimText = claims[originalIndex]!.text;
+        const result = uniqueResults[uniqueIndex] ?? failOpenClassification(claimText);
+        return { ...result, text: claimText };
+      });
     } catch (err) {
       // Global fail-open: return all claims as grounded
       logger.warn(


### PR DESCRIPTION
## Summary
- Deduplicate identical claim/context pairs before guardrail LLM fallback classification.
- Fan unique classification results back to every original duplicate claim while preserving original result ordering and text.
- Avoid wasting fallback prompt tokens on repeated ambiguous claims with identical grounding context.

## Verification
- `bun test src/lib/guardrail/llm-classifier.test.ts`
- `bun test src/lib/guardrail`
- `bun run lint`
- `git diff --check`
- `bun test src scripts --reporter=dots`

Note: plain `bun test` still discovers ignored, untracked vendored tests under `tmp/claude-code-action` in this workspace. The explicit project-wide `src scripts` surface passed: 5424 pass, 145 skip, 0 fail.