### PR TITLE
Bound shadow specialist diff snippet

### DIFF
--- a/src/handlers/review.test.ts
+++ b/src/handlers/review.test.ts
@@ -17022,6 +17022,7 @@ describe("createReviewHandler ReviewPlan wiring", () => {
     directReviewComments?: Array<Record<string, unknown>>;
     executorPublished?: boolean;
     exposeSummaryComment?: boolean;
+    featureFiles?: Record<string, string>;
     shadowSpecialistSubflow?: (input: ShadowSpecialistSubflowInput) => Promise<ShadowSpecialistSubflowResult>;
     createReviewComment?: (commentParams: Record<string, unknown>) => Promise<{ data: Record<string, unknown> }>;
   } = {}) {
@@ -17030,6 +17031,7 @@ describe("createReviewHandler ReviewPlan wiring", () => {
       graphValidationEnabled: params.graphValidationEnabled,
       extraChangedFiles: params.extraChangedFiles,
       maxComments: params.maxComments,
+      featureFiles: params.featureFiles,
     });
     const { logger, entries } = createCaptureLogger();
 
@@ -17308,6 +17310,33 @@ describe("createReviewHandler ReviewPlan wiring", () => {
 
     const detailsBlock = extractReviewDetailsBlock(updatedSummaryBody ?? "");
     expect(detailsBlock).toContain("candidates=preferred");
+  });
+
+  test("passes a bounded diff snippet to shadow specialist instead of duplicating the full diff", async () => {
+    let capturedInput: ShadowSpecialistSubflowInput | undefined;
+    const shadowSubflow = buildCandidateVerificationShadowSubflow("verified");
+    const largeDocsChange = Array.from({ length: 1_200 }, (_, index) => `docs line ${index}`).join("\n");
+
+    await runReviewPlanScenario({
+      featureFiles: {
+        "docs/large.md": `${largeDocsChange}\n`,
+      },
+      shadowSpecialistSubflow: async (input) => {
+        capturedInput = input;
+        return shadowSubflow(input);
+      },
+    });
+
+    expect(capturedInput).toBeDefined();
+    const diffText = String(capturedInput?.diffText ?? "");
+    const diffSnippet = String(capturedInput?.diffSnippet ?? "");
+
+    expect(diffText.length).toBeGreaterThan(12_000);
+    expect(diffSnippet.length).toBeGreaterThan(0);
+    expect(diffSnippet.length).toBeLessThan(diffText.length);
+    expect(diffSnippet).toContain("docs line 0");
+    expect(diffText).toContain("docs line 1199");
+    expect(diffSnippet).not.toContain("docs line 1199");
   });
 
   test("candidate finding result is projected once into Review Details, logs, and safe snapshots", async () => {

--- a/src/handlers/review.ts
+++ b/src/handlers/review.ts
@@ -363,7 +363,16 @@ import {
   type AttachReviewValidationTruthResult,
 } from "../review-lifecycle/handler-lifecycle.ts";
 
+const SHADOW_SPECIALIST_DIFF_SNIPPET_MAX_CHARS = 12_000;
 
+function buildShadowSpecialistDiffSnippet(diffText: string): string {
+  if (diffText.length <= SHADOW_SPECIALIST_DIFF_SNIPPET_MAX_CHARS) return diffText;
+
+  const prefix = diffText.slice(0, SHADOW_SPECIALIST_DIFF_SNIPPET_MAX_CHARS);
+  const lastNewline = prefix.lastIndexOf("\n");
+  const bounded = lastNewline > 0 ? prefix.slice(0, lastNewline) : prefix;
+  return `${bounded}\n...(shadow specialist diff snippet truncated)`;
+}
 
 
 type ProcessedFinding = ExtractedFinding & {
@@ -1895,7 +1904,7 @@ export function createReviewHandler(deps: {
           shadowSpecialistResult = await shadowSpecialistSubflow({
             changedPaths: changedFiles,
             diffText: diffContext.diffContent,
-            diffSnippet: diffContext.diffContent,
+            diffSnippet: buildShadowSpecialistDiffSnippet(diffContext.diffContent),
             workspaceDir: workspace.dir,
             deliveryId: event.id,
             reviewOutputKey,


### PR DESCRIPTION
## Summary
- Keep the full PR diff available as `diffText` for the shadow specialist boundary.
- Pass a bounded excerpt as `diffSnippet` instead of duplicating the full diff into both fields.
- Add a handler regression test that captures the shadow input for a large diff.

## Verification
- `bun test src/handlers/review.test.ts --test-name-pattern "bounded diff snippet"`
- `bun test src/handlers/review.test.ts --test-name-pattern "ReviewPlan wiring|shadow specialist"`
- `bun test src/specialists src/handlers/review-shadow-specialist.test.ts src/handlers/review-shadow-specialist-metrics.test.ts src/handlers/review-shadow-specialist-publication.test.ts`
- `bun run lint`
- `git diff --check`

Note: `bun test src scripts --reporter=dots` was started but produced no progress for ~2 minutes in this workspace and was terminated; PR CI should provide the broad remote check.