### PR TITLE
Reliability fixes, floating-promise lint, and prompt-assembly extraction

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,15 @@ BOT_ALLOW_LIST=                   # (optional) Comma-separated bot logins to all
 # ── Embeddings ───────────────────────────────────
 VOYAGE_API_KEY=                   # (optional) Voyage AI API key for embeddings
 
+# ── ACA Agent Job (defaults in src/config.ts target production) ──
+ACA_JOB_IMAGE=                    # (optional) Agent job image; default kodiairegistry.azurecr.io/kodiai-agent:latest
+ACA_JOB_NAME=                     # (optional) ACA job name; default caj-kodiai-agent
+ACA_RESOURCE_GROUP=               # (optional) Azure resource group; default rg-kodiai
+MCP_INTERNAL_BASE_URL=            # (optional) Internal MCP base URL for agent jobs; default http://ca-kodiai
+
+# ── Misc Behavior ────────────────────────────────
+ADDON_REPOS=                      # (optional) Comma-separated owner/repo list treated as Kodi addon repos
+DATABASE_POOL_MAX=                # (optional) Postgres pool size; default 10
+
 # ── Telemetry / Internal ─────────────────────────
 TELEMETRY_RATE_LIMIT_FAILURE_IDENTITIES=  # (optional) Comma-separated identities to rate-limit on failure
-CLAUDE_CODE_ENTRYPOINT=           # (internal) Set automatically by executor — do not configure manually

--- a/bun.lock
+++ b/bun.lock
@@ -27,6 +27,7 @@
         "@octokit/webhooks-types": "^7.6.1",
         "@types/bun": "latest",
         "@types/js-yaml": "^4.0.9",
+        "@typescript-eslint/eslint-plugin": "^8.61.0",
         "@typescript-eslint/parser": "^8.46.1",
         "eslint": "^9.38.0",
       },
@@ -174,19 +175,25 @@
 
     "@types/node": ["@types/node@25.2.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-BkmoP5/FhRYek5izySdkOneRyXYN35I860MFAGupTdebyE66uZaR+bXLHq8k4DirE5DwQi3NuhvRU1jqTVwUrQ=="],
 
+    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.61.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.61.0", "@typescript-eslint/type-utils": "8.61.0", "@typescript-eslint/utils": "8.61.0", "@typescript-eslint/visitor-keys": "8.61.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.61.0", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-bFNvl9ZczlVb+wR2Akszf3gHfKVj/8WanXaGJ3UstTA7brNKg0cNdk6X1Psu5V7MZ2oQtzZKOEzIUehaoxbDGw=="],
+
     "@typescript-eslint/parser": ["@typescript-eslint/parser@8.59.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.59.0", "@typescript-eslint/types": "8.59.0", "@typescript-eslint/typescript-estree": "8.59.0", "@typescript-eslint/visitor-keys": "8.59.0", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg=="],
 
     "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.59.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.59.0", "@typescript-eslint/types": "^8.59.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw=="],
 
-    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.59.0", "", { "dependencies": { "@typescript-eslint/types": "8.59.0", "@typescript-eslint/visitor-keys": "8.59.0" } }, "sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg=="],
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.61.0", "", { "dependencies": { "@typescript-eslint/types": "8.61.0", "@typescript-eslint/visitor-keys": "8.61.0" } }, "sha512-IWdXFHFSb6mlC3HPc7QsLDm5zYEbUla6trDEHf32D3/dnuUyXd87plScSNXSbm0/RxMvObpI17sv/EDTGrGZkA=="],
 
     "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.59.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg=="],
+
+    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.61.0", "", { "dependencies": { "@typescript-eslint/types": "8.61.0", "@typescript-eslint/typescript-estree": "8.61.0", "@typescript-eslint/utils": "8.61.0", "debug": "^4.4.3", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-TuBiQYIkd97yBfInHCTKVYMbX4kvEmpOEuixIuzCU9p8BGT1SfyyO0d0IfDMbPIHcjn/hWnusUX5e8v5Xg+X8A=="],
 
     "@typescript-eslint/types": ["@typescript-eslint/types@8.59.0", "", {}, "sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A=="],
 
     "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.59.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.59.0", "@typescript-eslint/tsconfig-utils": "8.59.0", "@typescript-eslint/types": "8.59.0", "@typescript-eslint/visitor-keys": "8.59.0", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw=="],
 
-    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.59.0", "", { "dependencies": { "@typescript-eslint/types": "8.59.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q=="],
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.61.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.61.0", "@typescript-eslint/types": "8.61.0", "@typescript-eslint/typescript-estree": "8.61.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-3bzFt7ImFMW/jVYwJamDoe/dMOdFLSC6pom6rRjdh4SZJEYupyMzem8e7vKZLclLfpHjlwSAXOUxtKxGXUiLqA=="],
+
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.61.0", "", { "dependencies": { "@typescript-eslint/types": "8.61.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ=="],
 
     "@vercel/oidc": ["@vercel/oidc@3.1.0", "", {}, "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w=="],
 
@@ -346,7 +353,7 @@
 
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
-    "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+    "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 
@@ -568,13 +575,35 @@
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
+    "@eslint/eslintrc/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
     "@modelcontextprotocol/sdk/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
+    "@typescript-eslint/parser/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.59.0", "", { "dependencies": { "@typescript-eslint/types": "8.59.0", "@typescript-eslint/visitor-keys": "8.59.0" } }, "sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg=="],
+
+    "@typescript-eslint/parser/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.59.0", "", { "dependencies": { "@typescript-eslint/types": "8.59.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q=="],
+
+    "@typescript-eslint/scope-manager/@typescript-eslint/types": ["@typescript-eslint/types@8.61.0", "", {}, "sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg=="],
+
+    "@typescript-eslint/type-utils/@typescript-eslint/types": ["@typescript-eslint/types@8.61.0", "", {}, "sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg=="],
+
+    "@typescript-eslint/type-utils/@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.61.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.61.0", "@typescript-eslint/tsconfig-utils": "8.61.0", "@typescript-eslint/types": "8.61.0", "@typescript-eslint/visitor-keys": "8.61.0", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-42zatd5qSvvcV1JdDBCLxYRznvP4eIHpPoZXdkPFnAmanA4FuZ5dibSnCBggY8hQnqajPpoGjXFdZ7fIJKQnlA=="],
+
+    "@typescript-eslint/typescript-estree/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.59.0", "", { "dependencies": { "@typescript-eslint/types": "8.59.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q=="],
+
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "@typescript-eslint/utils/@typescript-eslint/types": ["@typescript-eslint/types@8.61.0", "", {}, "sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg=="],
+
+    "@typescript-eslint/utils/@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.61.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.61.0", "@typescript-eslint/tsconfig-utils": "8.61.0", "@typescript-eslint/types": "8.61.0", "@typescript-eslint/visitor-keys": "8.61.0", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-42zatd5qSvvcV1JdDBCLxYRznvP4eIHpPoZXdkPFnAmanA4FuZ5dibSnCBggY8hQnqajPpoGjXFdZ7fIJKQnlA=="],
+
+    "@typescript-eslint/visitor-keys/@typescript-eslint/types": ["@typescript-eslint/types@8.61.0", "", {}, "sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg=="],
 
     "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 
     "ajv-formats/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
+
+    "eslint/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "ml-array-max/is-any-array": ["is-any-array@2.0.1", "", {}, "sha512-UtilS7hLRu++wb/WBAw9bNuP1Eg04Ivn1vERJck8zJthEvXCBEBpGR/33u/xLKWEQf95803oalHrVDptcAvFdQ=="],
 
@@ -590,12 +619,36 @@
 
     "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
+    "@typescript-eslint/parser/@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
+
+    "@typescript-eslint/type-utils/@typescript-eslint/typescript-estree/@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.61.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.61.0", "@typescript-eslint/types": "^8.61.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-DV42F7MLJO6Rax7SK1yg43tcnEfGUrurSpSxKuVX+a3RCTzBlH3fuxprrOJXKCJGAaw82xXocikJ0uQaqwXgGA=="],
+
+    "@typescript-eslint/type-utils/@typescript-eslint/typescript-estree/@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.61.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-O5Amvdv9ztMpxpf+vmFULGG78IE6Qwdr3bCGvqwG4nwc9H2qXkOYJJnRbRHyMkQTjv1d03olqwwwzHLMqpFePQ=="],
+
+    "@typescript-eslint/type-utils/@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "@typescript-eslint/typescript-estree/@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
+
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
+
+    "@typescript-eslint/utils/@typescript-eslint/typescript-estree/@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.61.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.61.0", "@typescript-eslint/types": "^8.61.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-DV42F7MLJO6Rax7SK1yg43tcnEfGUrurSpSxKuVX+a3RCTzBlH3fuxprrOJXKCJGAaw82xXocikJ0uQaqwXgGA=="],
+
+    "@typescript-eslint/utils/@typescript-eslint/typescript-estree/@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.61.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-O5Amvdv9ztMpxpf+vmFULGG78IE6Qwdr3bCGvqwG4nwc9H2qXkOYJJnRbRHyMkQTjv1d03olqwwwzHLMqpFePQ=="],
+
+    "@typescript-eslint/utils/@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
     "ajv-formats/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "@anthropic-ai/claude-agent-sdk/@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
+    "@typescript-eslint/type-utils/@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
+
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "@typescript-eslint/utils/@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
+
+    "@typescript-eslint/type-utils/@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "@typescript-eslint/utils/@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
   }
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,4 +1,5 @@
 import tsParser from "@typescript-eslint/parser";
+import tsPlugin from "@typescript-eslint/eslint-plugin";
 
 const typescriptFiles = ["src/**/*.ts", "scripts/**/*.ts"];
 const operatorFacingCliFiles = [
@@ -34,6 +35,23 @@ export default [
     rules: {
       // These surfaces intentionally communicate directly with operators.
       "no-console": "off",
+    },
+  },
+  {
+    // Floating promises in the service can become unhandledRejection, which
+    // the fatal-shutdown handlers turn into a full process exit. Type-aware
+    // linting is scoped to src/ — scripts/ is a large verifier tree where the
+    // added lint time buys little.
+    files: ["src/**/*.ts"],
+    languageOptions: {
+      parser: tsParser,
+      ecmaVersion: "latest",
+      sourceType: "module",
+      parserOptions: { projectService: true, tsconfigRootDir: import.meta.dirname },
+    },
+    plugins: { "@typescript-eslint": tsPlugin },
+    rules: {
+      "@typescript-eslint/no-floating-promises": "error",
     },
   },
 ];

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,6 +2,11 @@ import tsParser from "@typescript-eslint/parser";
 import tsPlugin from "@typescript-eslint/eslint-plugin";
 
 const typescriptFiles = ["src/**/*.ts", "scripts/**/*.ts"];
+const tsLanguageOptions = {
+  parser: tsParser,
+  ecmaVersion: "latest",
+  sourceType: "module",
+};
 const operatorFacingCliFiles = [
   // Migration progress and rollback status are intentionally printed for humans.
   "src/db/migrate.ts",
@@ -19,11 +24,7 @@ export default [
   },
   {
     files: typescriptFiles,
-    languageOptions: {
-      parser: tsParser,
-      ecmaVersion: "latest",
-      sourceType: "module",
-    },
+    languageOptions: tsLanguageOptions,
     rules: {
       // Start with the repo contract this slice actually needs: catch accidental
       // console usage in normal source files without introducing a noisy day-one gate.
@@ -44,9 +45,7 @@ export default [
     // added lint time buys little.
     files: ["src/**/*.ts"],
     languageOptions: {
-      parser: tsParser,
-      ecmaVersion: "latest",
-      sourceType: "module",
+      ...tsLanguageOptions,
       parserOptions: { projectService: true, tsconfigRootDir: import.meta.dirname },
     },
     plugins: { "@typescript-eslint": tsPlugin },

--- a/package.json
+++ b/package.json
@@ -151,6 +151,7 @@
     "@octokit/webhooks-types": "^7.6.1",
     "@types/bun": "latest",
     "@types/js-yaml": "^4.0.9",
+    "@typescript-eslint/eslint-plugin": "^8.61.0",
     "@typescript-eslint/parser": "^8.46.1",
     "eslint": "^9.38.0"
   },

--- a/src/auth/bot-user.ts
+++ b/src/auth/bot-user.ts
@@ -2,6 +2,7 @@ import { Octokit } from "@octokit/rest";
 import type { Logger } from "pino";
 import type { AppConfig } from "../config.ts";
 import { DEFAULT_GITHUB_REQUEST_TIMEOUT_MS } from "./github-app.ts";
+import { installOctokitRetry } from "./octokit-retry.ts";
 
 export interface BotUserClient {
   /** PAT-authenticated Octokit for fork/gist operations. */
@@ -18,10 +19,10 @@ export function createBotUserClient(config: AppConfig, logger: Logger): BotUserC
 
   if (pat && login) {
     logger.info({ login }, "Bot user client enabled for fork/gist operations");
-    const octokit = new Octokit({
+    const octokit = installOctokitRetry(new Octokit({
       auth: pat,
       request: { timeout: DEFAULT_GITHUB_REQUEST_TIMEOUT_MS },
-    });
+    }), logger);
     return { octokit, login, enabled: true };
   }
 

--- a/src/auth/github-app.ts
+++ b/src/auth/github-app.ts
@@ -2,6 +2,7 @@ import { Octokit } from "@octokit/rest";
 import { createAppAuth } from "@octokit/auth-app";
 import type { Logger } from "pino";
 import type { AppConfig } from "../config.ts";
+import { installOctokitRetry } from "./octokit-retry.ts";
 
 export const DEFAULT_GITHUB_REQUEST_TIMEOUT_MS = 30_000;
 
@@ -48,14 +49,14 @@ export function createGitHubApp(config: AppConfig, logger: Logger): GitHubApp {
   const CONNECTIVITY_CACHE_MS = 30_000;
 
   // App-level Octokit for non-installation API calls (getAuthenticated, connectivity)
-  const appOctokit = new Octokit({
+  const appOctokit = installOctokitRetry(new Octokit({
     authStrategy: createAppAuth,
     auth: {
       appId: config.githubAppId,
       privateKey: config.githubPrivateKey,
     },
     ...githubRequestOptions(),
-  });
+  }), logger);
 
   return {
     async getInstallationOctokit(
@@ -65,7 +66,7 @@ export function createGitHubApp(config: AppConfig, logger: Logger): GitHubApp {
       logger.debug({ installationId }, "Creating installation Octokit client");
 
       // Create a fresh Octokit per call; auth-app handles token caching internally
-      const octokit = new Octokit({
+      const octokit = installOctokitRetry(new Octokit({
         authStrategy: createAppAuth,
         auth: {
           appId: config.githubAppId,
@@ -73,7 +74,7 @@ export function createGitHubApp(config: AppConfig, logger: Logger): GitHubApp {
           installationId,
         },
         ...githubRequestOptions(options),
-      });
+      }), logger);
 
       return octokit;
     },

--- a/src/auth/octokit-retry.test.ts
+++ b/src/auth/octokit-retry.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from "bun:test";
+import { Octokit } from "@octokit/rest";
+import { installOctokitRetry } from "./octokit-retry.ts";
+
+function createNoopLogger() {
+  const noop = () => undefined;
+  return { info: noop, warn: noop, error: noop, debug: noop, child: () => createNoopLogger() } as never;
+}
+
+function httpError(status: number, message = "boom", headers?: Record<string, string>) {
+  return Object.assign(new Error(message), {
+    status,
+    ...(headers ? { response: { status, headers } } : {}),
+  });
+}
+
+/**
+ * Drive the hook through Octokit's real hook pipeline with a stubbed fetch
+ * so the retry policy is exercised exactly as production requests are.
+ */
+function createClient(responder: (attempt: number) => Response | Error) {
+  let attempts = 0;
+  const octokit = new Octokit({
+    request: {
+      fetch: async () => {
+        attempts++;
+        const result = responder(attempts);
+        if (result instanceof Error) throw result;
+        return result;
+      },
+    },
+  });
+  installOctokitRetry(octokit, createNoopLogger());
+  // Zero out retry sleep by intercepting timers is overkill here: delays come
+  // from retryGitHubTransient defaults (250ms initial), acceptable in tests.
+  return { octokit, getAttempts: () => attempts };
+}
+
+function jsonResponse(status: number, body: unknown, headers: Record<string, string> = {}) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json", ...headers },
+  });
+}
+
+describe("installOctokitRetry", () => {
+  test("retries GET on 500 and succeeds", async () => {
+    const { octokit, getAttempts } = createClient((attempt) =>
+      attempt === 1 ? jsonResponse(500, { message: "server error" }) : jsonResponse(200, { id: 1 }),
+    );
+
+    const result = await octokit.request("GET /repos/{owner}/{repo}", { owner: "x", repo: "y" });
+    expect(result.status).toBe(200);
+    expect(getAttempts()).toBe(2);
+  });
+
+  test("does NOT retry POST on 500 (could double-apply the mutation)", async () => {
+    const { octokit, getAttempts } = createClient(() => jsonResponse(500, { message: "server error" }));
+
+    await expect(
+      octokit.request("POST /repos/{owner}/{repo}/issues/{issue_number}/comments", {
+        owner: "x",
+        repo: "y",
+        issue_number: 1,
+        body: "hi",
+      }),
+    ).rejects.toMatchObject({ status: 500 });
+    expect(getAttempts()).toBe(1);
+  });
+
+  test("retries POST on 429 rate-limit rejection", async () => {
+    const { octokit, getAttempts } = createClient((attempt) =>
+      attempt === 1
+        ? jsonResponse(429, { message: "rate limited" }, { "retry-after": "0" })
+        : jsonResponse(201, { id: 2 }),
+    );
+
+    const result = await octokit.request("POST /repos/{owner}/{repo}/issues/{issue_number}/comments", {
+      owner: "x",
+      repo: "y",
+      issue_number: 1,
+      body: "hi",
+    });
+    expect(result.status).toBe(201);
+    expect(getAttempts()).toBe(2);
+  });
+
+  test("retries POST on 403 secondary rate limit", async () => {
+    const { octokit, getAttempts } = createClient((attempt) =>
+      attempt === 1
+        ? jsonResponse(403, { message: "You have exceeded a secondary rate limit" }, { "retry-after": "0" })
+        : jsonResponse(201, { id: 3 }),
+    );
+
+    const result = await octokit.request("POST /repos/{owner}/{repo}/issues/{issue_number}/comments", {
+      owner: "x",
+      repo: "y",
+      issue_number: 1,
+      body: "hi",
+    });
+    expect(result.status).toBe(201);
+    expect(getAttempts()).toBe(2);
+  });
+
+  test("does not retry GET on 404", async () => {
+    const { octokit, getAttempts } = createClient(() => jsonResponse(404, { message: "not found" }));
+
+    await expect(
+      octokit.request("GET /repos/{owner}/{repo}", { owner: "x", repo: "y" }),
+    ).rejects.toMatchObject({ status: 404 });
+    expect(getAttempts()).toBe(1);
+  });
+});
+
+// keep helper referenced for future direct-policy tests
+void httpError;

--- a/src/auth/octokit-retry.test.ts
+++ b/src/auth/octokit-retry.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, test } from "bun:test";
+import type { Logger } from "pino";
 import { Octokit } from "@octokit/rest";
 import { installOctokitRetry } from "./octokit-retry.ts";
 
-function createNoopLogger() {
+function createNoopLogger(): Logger {
   const noop = () => undefined;
-  return { info: noop, warn: noop, error: noop, debug: noop, child: () => createNoopLogger() } as never;
+  return { info: noop, warn: noop, error: noop, debug: noop, child: () => createNoopLogger() } as unknown as Logger;
 }
 
 /**

--- a/src/auth/octokit-retry.test.ts
+++ b/src/auth/octokit-retry.test.ts
@@ -7,13 +7,6 @@ function createNoopLogger() {
   return { info: noop, warn: noop, error: noop, debug: noop, child: () => createNoopLogger() } as never;
 }
 
-function httpError(status: number, message = "boom", headers?: Record<string, string>) {
-  return Object.assign(new Error(message), {
-    status,
-    ...(headers ? { response: { status, headers } } : {}),
-  });
-}
-
 /**
  * Drive the hook through Octokit's real hook pipeline with a stubbed fetch
  * so the retry policy is exercised exactly as production requests are.
@@ -111,6 +104,3 @@ describe("installOctokitRetry", () => {
     expect(getAttempts()).toBe(1);
   });
 });
-
-// keep helper referenced for future direct-policy tests
-void httpError;

--- a/src/auth/octokit-retry.ts
+++ b/src/auth/octokit-retry.ts
@@ -1,19 +1,8 @@
 import type { Octokit } from "@octokit/rest";
 import type { Logger } from "pino";
-import { isRetryableGitHubError, githubRetryAfterDelayMs, retryGitHubTransient } from "../lib/github-retry.ts";
+import { isRetryableGitHubError, isGitHubRateLimitRejection, retryGitHubTransient } from "../lib/github-retry.ts";
 
 const IDEMPOTENT_METHODS = new Set(["GET", "HEAD"]);
-
-function isRateLimitRejection(error: unknown): boolean {
-  if (!error || typeof error !== "object") return false;
-  const status = (error as { status?: unknown }).status;
-  if (status === 429) return true;
-  if (status === 403) {
-    return githubRetryAfterDelayMs(error) !== null
-      || /secondary rate|rate limit|abuse/i.test(String((error as { message?: unknown }).message ?? ""));
-  }
-  return false;
-}
 
 /**
  * Install transparent transient-error retry on every request an Octokit
@@ -27,7 +16,7 @@ function isRateLimitRejection(error: unknown): boolean {
 export function installOctokitRetry(octokit: Octokit, logger: Logger): Octokit {
   octokit.hook.wrap("request", (request, options) => {
     const method = String(options.method ?? "GET").toUpperCase();
-    const shouldRetry = IDEMPOTENT_METHODS.has(method) ? isRetryableGitHubError : isRateLimitRejection;
+    const shouldRetry = IDEMPOTENT_METHODS.has(method) ? isRetryableGitHubError : isGitHubRateLimitRejection;
     return retryGitHubTransient(() => Promise.resolve(request(options)), {
       shouldRetry,
       onRetry: ({ error, attempt, delayMs }) => {

--- a/src/auth/octokit-retry.ts
+++ b/src/auth/octokit-retry.ts
@@ -1,0 +1,48 @@
+import type { Octokit } from "@octokit/rest";
+import type { Logger } from "pino";
+import { isRetryableGitHubError, githubRetryAfterDelayMs, retryGitHubTransient } from "../lib/github-retry.ts";
+
+const IDEMPOTENT_METHODS = new Set(["GET", "HEAD"]);
+
+function isRateLimitRejection(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const status = (error as { status?: unknown }).status;
+  if (status === 429) return true;
+  if (status === 403) {
+    return githubRetryAfterDelayMs(error) !== null
+      || /secondary rate|rate limit|abuse/i.test(String((error as { message?: unknown }).message ?? ""));
+  }
+  return false;
+}
+
+/**
+ * Install transparent transient-error retry on every request an Octokit
+ * client makes, so individual call sites do not need per-call wrapping.
+ *
+ * Policy: idempotent requests (GET/HEAD) retry the full transient set
+ * (408/429/5xx/secondary-rate). Mutations retry only rate-limit rejections
+ * (403 secondary-rate / 429), where GitHub definitively did not apply the
+ * request — retrying a POST on a 5xx could double-apply it.
+ */
+export function installOctokitRetry(octokit: Octokit, logger: Logger): Octokit {
+  octokit.hook.wrap("request", (request, options) => {
+    const method = String(options.method ?? "GET").toUpperCase();
+    const shouldRetry = IDEMPOTENT_METHODS.has(method) ? isRetryableGitHubError : isRateLimitRejection;
+    return retryGitHubTransient(() => Promise.resolve(request(options)), {
+      shouldRetry,
+      onRetry: ({ error, attempt, delayMs }) => {
+        logger.warn(
+          {
+            attempt,
+            delayMs,
+            method,
+            route: `${method} ${String(options.url ?? "")}`,
+            status: (error as { status?: unknown })?.status,
+          },
+          "Retrying GitHub request after transient error",
+        );
+      },
+    });
+  });
+  return octokit;
+}

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -28,8 +28,11 @@ export function createDbClient(opts: {
     );
   }
 
+  const poolMaxRaw = Number.parseInt(process.env.DATABASE_POOL_MAX ?? "", 10);
+  const poolMax = Number.isFinite(poolMaxRaw) && poolMaxRaw > 0 ? poolMaxRaw : 10;
+
   const sql = postgres(connectionString, {
-    max: 10,
+    max: poolMax,
     idle_timeout: 20,
     connect_timeout: 10,
   });

--- a/src/db/migrations/047-webhook-queue-error-detail.down.sql
+++ b/src/db/migrations/047-webhook-queue-error-detail.down.sql
@@ -1,0 +1,4 @@
+-- Rollback: drop the webhook replay error detail column.
+
+ALTER TABLE webhook_queue
+  DROP COLUMN IF EXISTS error_message;

--- a/src/db/migrations/047-webhook-queue-error-detail.sql
+++ b/src/db/migrations/047-webhook-queue-error-detail.sql
@@ -1,0 +1,6 @@
+-- 047-webhook-queue-error-detail.sql
+-- Persist why a queued webhook replay failed. markFailed previously discarded
+-- the error, leaving failed rows with no diagnostic.
+
+ALTER TABLE webhook_queue
+  ADD COLUMN IF NOT EXISTS error_message TEXT;

--- a/src/execution/agent-entrypoint.ts
+++ b/src/execution/agent-entrypoint.ts
@@ -261,7 +261,13 @@ export async function main(deps?: Partial<EntrypointDeps>): Promise<void> {
   const diagnosticsLog = join(workspaceDir!, "agent-diagnostics.log");
 
   const appendDiagnostic = async (line: string): Promise<void> => {
-    await appendFileFn(diagnosticsLog, `${new Date().toISOString()} ${line}\n`);
+    try {
+      await appendFileFn(diagnosticsLog, `${new Date().toISOString()} ${line}\n`);
+    } catch {
+      // Diagnostics are best-effort; a failed append (disk full, workspace
+      // removed) must not surface as an unhandledRejection from the
+      // fire-and-forget call sites (e.g. the SDK stderr callback).
+    }
   };
 
   try {

--- a/src/execution/review-prompt.test.ts
+++ b/src/execution/review-prompt.test.ts
@@ -8,6 +8,7 @@ import {
   buildDeltaReviewContext,
   buildDeltaVerdictLogicSection,
   buildDiffAnalysisSection,
+  buildKnowledgeContextLines,
   buildLanguageGuidanceSection,
   buildOutputLanguageSection,
   buildPathInstructionsSection,
@@ -3381,5 +3382,58 @@ describe("buildReviewPrompt graph context integration", () => {
         continuation: scenario.firstPass,
       })
     ).toThrow();
+  });
+});
+
+describe("buildKnowledgeContextLines", () => {
+  test("unified results take precedence over the legacy retrieval stack", () => {
+    const lines = buildKnowledgeContextLines({
+      contextWindow: "Assembled cross-corpus context window.",
+      unifiedResults: [
+        {
+          id: "code:1",
+          text: "prior finding text",
+          source: "code",
+          sourceLabel: "[code: a.ts]",
+          sourceUrl: null,
+          vectorDistance: 0.1,
+          rrfScore: 0.5,
+          createdAt: null,
+        } as never,
+      ],
+      retrievalContext: {
+        findings: [{
+          findingText: "legacy finding",
+          severity: "major",
+          category: "bug",
+          path: "b.ts",
+          outcome: "accepted",
+          distance: 0.2,
+          sourceRepo: "xbmc/xbmc",
+        }],
+      },
+    });
+
+    const text = lines.join("\n");
+    expect(text.length).toBeGreaterThan(0);
+    expect(text).not.toContain("legacy finding");
+  });
+
+  test("legacy stack renders blocks separated by blank lines and skips empty inputs", () => {
+    const lines = buildKnowledgeContextLines({
+      retrievalContext: { findings: [] },
+      reviewPrecedents: [],
+      wikiKnowledge: [],
+      clusterPatterns: [],
+    });
+    expect(lines).toEqual([]);
+  });
+
+  test("language guidance renders standalone when no retrieval data exists", () => {
+    const lines = buildKnowledgeContextLines({
+      filesByLanguage: { Python: ["script.py"] },
+    });
+    expect(lines.length).toBeGreaterThan(0);
+    expect(lines[0]).not.toBe("");
   });
 });

--- a/src/execution/review-prompt.test.ts
+++ b/src/execution/review-prompt.test.ts
@@ -29,6 +29,7 @@ import {
   matchPathInstructions,
 } from "./review-prompt.ts";
 import type { ClusterPatternMatch } from "../knowledge/cluster-types.ts";
+import type { UnifiedRetrievalChunk } from "../knowledge/cross-corpus-rrf.ts";
 import { projectContributorExperienceContract } from "../contributor/experience-contract.ts";
 import type { StructuralImpactPayload } from "../structural-impact/types.ts";
 
@@ -3387,20 +3388,20 @@ describe("buildReviewPrompt graph context integration", () => {
 
 describe("buildKnowledgeContextLines", () => {
   test("unified results take precedence over the legacy retrieval stack", () => {
+    const unifiedChunk: UnifiedRetrievalChunk = {
+      id: "code:1",
+      text: "prior finding text",
+      source: "code",
+      sourceLabel: "[code: a.ts]",
+      sourceUrl: null,
+      vectorDistance: 0.1,
+      rrfScore: 0.5,
+      createdAt: null,
+      metadata: {},
+    };
     const lines = buildKnowledgeContextLines({
       contextWindow: "Assembled cross-corpus context window.",
-      unifiedResults: [
-        {
-          id: "code:1",
-          text: "prior finding text",
-          source: "code",
-          sourceLabel: "[code: a.ts]",
-          sourceUrl: null,
-          vectorDistance: 0.1,
-          rrfScore: 0.5,
-          createdAt: null,
-        } as never,
-      ],
+      unifiedResults: [unifiedChunk],
       retrievalContext: {
         findings: [{
           findingText: "legacy finding",

--- a/src/execution/review-prompt.ts
+++ b/src/execution/review-prompt.ts
@@ -1901,6 +1901,77 @@ function buildStandardSummaryInstructionLines(params: {
   ];
 }
 
+/** Retrieval/knowledge fields consumed by the knowledge-context prompt section. */
+export type KnowledgeContextInput = {
+  unifiedResults?: UnifiedRetrievalChunk[];
+  contextWindow?: string;
+  retrievalContext?: {
+    findings: Array<{
+      findingText: string;
+      severity: string;
+      category: string;
+      path: string;
+      line?: number;
+      snippet?: string;
+      outcome: string;
+      distance: number;
+      sourceRepo: string;
+    }>;
+    maxChars?: number;
+  } | null;
+  reviewPrecedents?: ReviewCommentMatch[];
+  wikiKnowledge?: WikiKnowledgeMatch[];
+  clusterPatterns?: ClusterPatternMatch[];
+  linkedIssues?: LinkResult;
+  filesByLanguage?: Record<string, string[]>;
+};
+
+/**
+ * Assemble the knowledge-context prompt section: unified cross-corpus results
+ * when available (KI-13), otherwise the legacy retrieval/precedent/wiki/cluster
+ * stack, plus linked issues and language guidance. Pure function of its input.
+ */
+export function buildKnowledgeContextLines(context: KnowledgeContextInput): string[] {
+  const lines: string[] = [];
+  const pushBlock = (block: string): void => {
+    if (!block) return;
+    if (lines.length > 0) lines.push("");
+    lines.push(block);
+  };
+
+  if (context.unifiedResults && context.unifiedResults.length > 0) {
+    pushBlock(formatUnifiedContext({
+      unifiedResults: context.unifiedResults,
+      contextWindow: context.contextWindow,
+    }));
+  } else {
+    if (context.retrievalContext && context.retrievalContext.findings.length > 0) {
+      pushBlock(buildRetrievalContextSection({
+        findings: context.retrievalContext.findings,
+        maxChars: context.retrievalContext.maxChars,
+      }));
+    }
+    if (context.reviewPrecedents && context.reviewPrecedents.length > 0) {
+      pushBlock(formatReviewPrecedents(context.reviewPrecedents));
+    }
+    if (context.wikiKnowledge && context.wikiKnowledge.length > 0) {
+      pushBlock(formatWikiKnowledge(context.wikiKnowledge));
+    }
+    if (context.clusterPatterns && context.clusterPatterns.length > 0) {
+      pushBlock(formatClusterPatterns(context.clusterPatterns));
+    }
+  }
+
+  if (context.linkedIssues) {
+    pushBlock(buildLinkedIssuesSection(context.linkedIssues));
+  }
+  if (context.filesByLanguage) {
+    pushBlock(buildLanguageGuidanceSection(context.filesByLanguage));
+  }
+
+  return lines;
+}
+
 export function buildReviewPromptDetails(context: {
   owner: string;
   repo: string;
@@ -2179,67 +2250,7 @@ export function buildReviewPromptDetails(context: {
   }
   pushSection("review-graph-context", graphContextLines, REVIEW_SECTION_BUDGETS.graphContext);
 
-  const knowledgeContextLines: string[] = [];
-  if (context.unifiedResults && context.unifiedResults.length > 0) {
-    const unifiedSection = formatUnifiedContext({
-      unifiedResults: context.unifiedResults,
-      contextWindow: context.contextWindow,
-    });
-    if (unifiedSection) {
-      knowledgeContextLines.push(unifiedSection);
-    }
-  } else {
-    if (context.retrievalContext && context.retrievalContext.findings.length > 0) {
-      const retrievalSection = buildRetrievalContextSection({
-        findings: context.retrievalContext.findings,
-        maxChars: context.retrievalContext.maxChars,
-      });
-      if (retrievalSection) {
-        knowledgeContextLines.push(retrievalSection);
-      }
-    }
-
-    if (context.reviewPrecedents && context.reviewPrecedents.length > 0) {
-      const precedentsSection = formatReviewPrecedents(context.reviewPrecedents);
-      if (precedentsSection) {
-        if (knowledgeContextLines.length > 0) knowledgeContextLines.push("");
-        knowledgeContextLines.push(precedentsSection);
-      }
-    }
-
-    if (context.wikiKnowledge && context.wikiKnowledge.length > 0) {
-      const wikiSection = formatWikiKnowledge(context.wikiKnowledge);
-      if (wikiSection) {
-        if (knowledgeContextLines.length > 0) knowledgeContextLines.push("");
-        knowledgeContextLines.push(wikiSection);
-      }
-    }
-
-    if (context.clusterPatterns && context.clusterPatterns.length > 0) {
-      const clusterPatternsSection = formatClusterPatterns(context.clusterPatterns);
-      if (clusterPatternsSection) {
-        if (knowledgeContextLines.length > 0) knowledgeContextLines.push("");
-        knowledgeContextLines.push(clusterPatternsSection);
-      }
-    }
-  }
-
-  if (context.linkedIssues) {
-    const linkedSection = buildLinkedIssuesSection(context.linkedIssues);
-    if (linkedSection) {
-      if (knowledgeContextLines.length > 0) knowledgeContextLines.push("");
-      knowledgeContextLines.push(linkedSection);
-    }
-  }
-
-  if (context.filesByLanguage) {
-    const langSection = buildLanguageGuidanceSection(context.filesByLanguage);
-    if (langSection) {
-      if (knowledgeContextLines.length > 0) knowledgeContextLines.push("");
-      knowledgeContextLines.push(langSection);
-    }
-  }
-  pushSection("review-knowledge-context", knowledgeContextLines, REVIEW_SECTION_BUDGETS.knowledgeContext);
+  pushSection("review-knowledge-context", buildKnowledgeContextLines(context), REVIEW_SECTION_BUDGETS.knowledgeContext);
 
   const gitDiffInstructionsAvailable = context.gitDiffInstructionsAvailable !== false;
   const candidateFindingMode = normalizePromptCandidateFindingMode(context.candidateFindingMode);

--- a/src/handlers/review.ts
+++ b/src/handlers/review.ts
@@ -358,6 +358,23 @@ import {
 
 const SHADOW_SPECIALIST_DIFF_SNIPPET_MAX_CHARS = 12_000;
 
+/**
+ * Best-effort checkpoint cleanup. deleteCheckpoint is raw SQL and can reject;
+ * a floating rejection here would trip the fatal unhandledRejection handler,
+ * so failures are logged and swallowed.
+ */
+function discardCheckpointsFailOpen(
+  knowledgeStore: KnowledgeStore | undefined,
+  logger: Logger,
+  reviewOutputKeys: string[],
+): void {
+  for (const reviewOutputKey of reviewOutputKeys) {
+    void knowledgeStore?.deleteCheckpoint?.(reviewOutputKey)?.catch((err) => {
+      logger.warn({ err, reviewOutputKey }, "Checkpoint cleanup failed (non-blocking)");
+    });
+  }
+}
+
 function buildShadowSpecialistDiffSnippet(diffText: string): string {
   if (diffText.length <= SHADOW_SPECIALIST_DIFF_SNIPPET_MAX_CHARS) return diffText;
 
@@ -4219,7 +4236,9 @@ export function createReviewHandler(deps: {
                   partialCommentId,
                 });
               } else {
-                knowledgeStore?.updateCheckpointCommentId?.(reviewOutputKey, partialCommentId);
+                void knowledgeStore?.updateCheckpointCommentId?.(reviewOutputKey, partialCommentId)?.catch((err) => {
+                  logger.warn({ err, reviewOutputKey }, "Checkpoint comment id update failed (non-blocking)");
+                });
               }
 
               publishedPartialReview = true;
@@ -4862,8 +4881,7 @@ export function createReviewHandler(deps: {
                             projectionStatus: "canonical",
                             reviewOutputKey: retryReviewOutputKey,
                           });
-                          knowledgeStore?.deleteCheckpoint?.(reviewOutputKey);
-                          knowledgeStore?.deleteCheckpoint?.(retryReviewOutputKey);
+                          discardCheckpointsFailOpen(knowledgeStore, logger, [reviewOutputKey, retryReviewOutputKey]);
                           return;
                         }
 
@@ -5053,8 +5071,7 @@ export function createReviewHandler(deps: {
                           });
 
                           // Cleanup checkpoint data after successful merge
-                          knowledgeStore?.deleteCheckpoint?.(reviewOutputKey);
-                          knowledgeStore?.deleteCheckpoint?.(retryReviewOutputKey);
+                          discardCheckpointsFailOpen(knowledgeStore, logger, [reviewOutputKey, retryReviewOutputKey]);
                         }
                       } else {
                         logger.info(
@@ -5158,8 +5175,7 @@ export function createReviewHandler(deps: {
                       // Best-effort checkpoint cleanup even on retry failure.
                       // Retry attempts are capped at 1, so leaving checkpoint rows
                       // behind provides little value and can accumulate stale state.
-                      knowledgeStore?.deleteCheckpoint?.(retryReviewOutputKey);
-                      knowledgeStore?.deleteCheckpoint?.(reviewOutputKey);
+                      discardCheckpointsFailOpen(knowledgeStore, logger, [retryReviewOutputKey, reviewOutputKey]);
                     }
                   }
                 }, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,8 +69,12 @@ const botUserClient = createBotUserClient(config, logger);
 const forkManager = createForkManager(botUserClient, logger, config.botUserPat || undefined);
 const gistPublisher = createGistPublisher(botUserClient, logger);
 
+// Lifecycle: request tracking (created before the job queue so every enqueued
+// job — including fire-and-forget retries — counts toward shutdown drain)
+const requestTracker = createRequestTracker();
+
 // Job infrastructure
-const jobQueue = createJobQueue(logger);
+const jobQueue = createJobQueue(logger, { requestTracker });
 const reviewWorkCoordinator = createReviewWorkCoordinator();
 const workspaceManager = createWorkspaceManager(githubApp, logger);
 
@@ -109,8 +113,7 @@ if (rateLimitFailureInjectionIdentities.length > 0) {
 // Cost tracker (shared across executor and scheduled jobs)
 const costTracker = createCostTracker({ telemetryStore, logger });
 
-// Lifecycle: request tracking, webhook queuing, shutdown management
-const requestTracker = createRequestTracker();
+// Lifecycle: webhook queuing, shutdown management
 const webhookQueueStore = createWebhookQueueStore({ sql, logger, telemetryStore });
 // Mutable reference for wiki sync scheduler (set later, stopped on shutdown)
 let _wikiSyncSchedulerRef: { stop: () => void } | null = null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -650,7 +650,7 @@ try {
       queuedWebhooksProcessed++;
     } catch (err) {
       logger.warn({ err, id: entryId, source: entry.source }, "Failed to replay queued webhook");
-      await webhookQueueStore.markFailed(entryId);
+      await webhookQueueStore.markFailed(entryId, err instanceof Error ? err.message : String(err));
       queuedWebhooksFailed++;
     }
   }

--- a/src/jobs/queue.test.ts
+++ b/src/jobs/queue.test.ts
@@ -2,6 +2,25 @@ import { expect, test } from "bun:test";
 import type { Logger } from "pino";
 import { createJobQueue } from "./queue.ts";
 import type { JobQueue, JobQueueRunMetadata } from "./types.ts";
+import type { RequestTracker } from "../lifecycle/types.ts";
+
+/** Fully-typed RequestTracker fake counting in-flight jobs. */
+function createRequestTrackerFake(): { tracker: RequestTracker; counts: { active: number; peak: number } } {
+  const counts = { active: 0, peak: 0 };
+  const tracker: RequestTracker = {
+    trackRequest: () => () => undefined,
+    trackJob: () => {
+      counts.active++;
+      counts.peak = Math.max(counts.peak, counts.active);
+      return () => {
+        counts.active--;
+      };
+    },
+    activeCount: () => ({ requests: 0, jobs: counts.active, total: counts.active }),
+    waitForDrain: async () => undefined,
+  };
+  return { tracker, counts };
+}
 
 const _enqueueCallbackRequiresMetadata: Parameters<JobQueue["enqueue"]>[1] = async (
   metadata: JobQueueRunMetadata,
@@ -210,22 +229,8 @@ test("createJobQueue updates active job snapshots when setPhase is called", asyn
 });
 
 test("createJobQueue counts jobs as in-flight work for shutdown drain from enqueue to completion", async () => {
-  let active = 0;
-  let peakActive = 0;
-  const requestTracker = {
-    trackRequest: () => () => undefined,
-    trackJob: () => {
-      active++;
-      peakActive = Math.max(peakActive, active);
-      return () => {
-        active--;
-      };
-    },
-    activeCount: () => ({ requests: 0, jobs: active, total: active }),
-    waitForDrain: async () => undefined,
-  } as never;
-
-  const queue = createJobQueue(createNoopLogger(), { requestTracker });
+  const { tracker, counts } = createRequestTrackerFake();
+  const queue = createJobQueue(createNoopLogger(), { requestTracker: tracker });
   const releaseFirst = Promise.withResolvers<void>();
 
   // Fire-and-forget enqueue (like the review timeout retry) plus a queued
@@ -235,31 +240,19 @@ test("createJobQueue counts jobs as in-flight work for shutdown drain from enque
   }, { lane: "review", key: "pr-7" });
   const second = queue.enqueue(7, async () => undefined, { lane: "review", key: "pr-7" });
 
-  expect(active).toBe(2);
+  expect(counts.active).toBe(2);
 
   releaseFirst.resolve();
   await first;
   await second;
 
-  expect(active).toBe(0);
-  expect(peakActive).toBe(2);
+  expect(counts.active).toBe(0);
+  expect(counts.peak).toBe(2);
 });
 
 test("createJobQueue releases drain tracking when a job throws", async () => {
-  let active = 0;
-  const requestTracker = {
-    trackRequest: () => () => undefined,
-    trackJob: () => {
-      active++;
-      return () => {
-        active--;
-      };
-    },
-    activeCount: () => ({ requests: 0, jobs: active, total: active }),
-    waitForDrain: async () => undefined,
-  } as never;
-
-  const queue = createJobQueue(createNoopLogger(), { requestTracker });
+  const { tracker, counts } = createRequestTrackerFake();
+  const queue = createJobQueue(createNoopLogger(), { requestTracker: tracker });
 
   await expect(
     queue.enqueue(7, async () => {
@@ -267,5 +260,5 @@ test("createJobQueue releases drain tracking when a job throws", async () => {
     }),
   ).rejects.toThrow("job failed");
 
-  expect(active).toBe(0);
+  expect(counts.active).toBe(0);
 });

--- a/src/jobs/queue.test.ts
+++ b/src/jobs/queue.test.ts
@@ -208,3 +208,64 @@ test("createJobQueue updates active job snapshots when setPhase is called", asyn
 
   expect(queue.getActiveJobs(42)).toHaveLength(0);
 });
+
+test("createJobQueue counts jobs as in-flight work for shutdown drain from enqueue to completion", async () => {
+  let active = 0;
+  let peakActive = 0;
+  const requestTracker = {
+    trackRequest: () => () => undefined,
+    trackJob: () => {
+      active++;
+      peakActive = Math.max(peakActive, active);
+      return () => {
+        active--;
+      };
+    },
+    activeCount: () => ({ requests: 0, jobs: active, total: active }),
+    waitForDrain: async () => undefined,
+  } as never;
+
+  const queue = createJobQueue(createNoopLogger(), { requestTracker });
+  const releaseFirst = Promise.withResolvers<void>();
+
+  // Fire-and-forget enqueue (like the review timeout retry) plus a queued
+  // second job behind it on the same lane: both must count as in-flight.
+  const first = queue.enqueue(7, async () => {
+    await releaseFirst.promise;
+  }, { lane: "review", key: "pr-7" });
+  const second = queue.enqueue(7, async () => undefined, { lane: "review", key: "pr-7" });
+
+  expect(active).toBe(2);
+
+  releaseFirst.resolve();
+  await first;
+  await second;
+
+  expect(active).toBe(0);
+  expect(peakActive).toBe(2);
+});
+
+test("createJobQueue releases drain tracking when a job throws", async () => {
+  let active = 0;
+  const requestTracker = {
+    trackRequest: () => () => undefined,
+    trackJob: () => {
+      active++;
+      return () => {
+        active--;
+      };
+    },
+    activeCount: () => ({ requests: 0, jobs: active, total: active }),
+    waitForDrain: async () => undefined,
+  } as never;
+
+  const queue = createJobQueue(createNoopLogger(), { requestTracker });
+
+  await expect(
+    queue.enqueue(7, async () => {
+      throw new Error("job failed");
+    }),
+  ).rejects.toThrow("job failed");
+
+  expect(active).toBe(0);
+});

--- a/src/jobs/queue.ts
+++ b/src/jobs/queue.ts
@@ -7,6 +7,7 @@ import type {
   JobQueueRunMetadata,
   JobSnapshot,
 } from "./types.ts";
+import type { RequestTracker } from "../lifecycle/types.ts";
 
 const DEFAULT_JOB_LANE: JobLane = "review";
 const QUEUED_PHASE = "queued";
@@ -22,8 +23,13 @@ type InstallationActiveJobs = Map<string, JobSnapshot>;
  * instances. Jobs in different lanes can run in parallel, while jobs in the
  * same lane remain serialized. Active job snapshots are tracked from enqueue
  * through completion so callers can inspect machine-readable queue state.
+ *
+ * When a RequestTracker is provided, every job counts as in-flight work from
+ * enqueue until completion, so graceful-shutdown drain waits for queued jobs
+ * even when the caller fire-and-forgets the enqueue promise.
  */
-export function createJobQueue(logger: Logger): JobQueue {
+export function createJobQueue(logger: Logger, opts?: { requestTracker?: RequestTracker }): JobQueue {
+  const requestTracker = opts?.requestTracker;
   const queueScopes = new Map<number, InstallationQueueScopes>();
   const activeJobs = new Map<number, InstallationActiveJobs>();
   let nextJobId = 1;
@@ -156,6 +162,7 @@ export function createJobQueue(logger: Logger): JobQueue {
         context,
       );
       getOrCreateActiveJobs(installationId).set(jobId, snapshot);
+      const untrackJob = requestTracker?.trackJob();
 
       logger.info(
         {
@@ -272,6 +279,7 @@ export function createJobQueue(logger: Logger): JobQueue {
           }
         });
       } finally {
+        untrackJob?.();
         deleteActiveJob(installationId, jobId);
         pruneQueueScope(installationId, lane, key);
       }

--- a/src/lib/github-retry.ts
+++ b/src/lib/github-retry.ts
@@ -25,16 +25,30 @@ export function githubRetryAfterDelayMs(error: unknown): number | null {
   );
 }
 
-export function isRetryableGitHubError(error: unknown): boolean {
+/**
+ * True when GitHub rejected the request for rate-limiting (429, or 403 with a
+ * retry-after header / secondary-rate message) — i.e. the request was
+ * definitively NOT applied and is always safe to retry, even for mutations.
+ */
+export function isGitHubRateLimitRejection(error: unknown): boolean {
   if (!error || typeof error !== "object") return false;
   const record = error as Record<string, unknown>;
   const status = Number(record.status ?? (record.response as Record<string, unknown> | undefined)?.status);
-  if (!Number.isFinite(status)) return false;
+  if (status === 429) return true;
   if (status === 403) {
     return githubRetryAfterDelayMs(error) !== null
       || /secondary rate|rate limit|abuse/i.test(String(record.message ?? ""));
   }
-  return status === 408 || status === 429 || (status >= 500 && status <= 599);
+  return false;
+}
+
+export function isRetryableGitHubError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  if (isGitHubRateLimitRejection(error)) return true;
+  const record = error as Record<string, unknown>;
+  const status = Number(record.status ?? (record.response as Record<string, unknown> | undefined)?.status);
+  if (!Number.isFinite(status)) return false;
+  return status === 408 || (status >= 500 && status <= 599);
 }
 
 export function retryGitHubTransient<T>(

--- a/src/lifecycle/webhook-queue-store.test.ts
+++ b/src/lifecycle/webhook-queue-store.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test";
+import { createWebhookQueueStore } from "./webhook-queue-store.ts";
+import type { Sql } from "../db/client.ts";
+import type { TelemetryStore } from "../telemetry/types.ts";
+
+function createNoopLogger() {
+  const noop = () => undefined;
+  return {
+    info: noop,
+    warn: noop,
+    error: noop,
+    debug: noop,
+    child: () => createNoopLogger(),
+  } as never;
+}
+
+const noopTelemetryStore = {
+  record: async () => undefined,
+} as unknown as TelemetryStore;
+
+type QueryLogEntry = { text: string; values: unknown[] };
+
+/**
+ * Fake postgres.js tagged-template client: records each query's text and
+ * returns canned rows matched by substring.
+ */
+function createFakeSql(responses: Array<{ match: string; rows: Record<string, unknown>[] }>) {
+  const queries: QueryLogEntry[] = [];
+  const run = (strings: TemplateStringsArray, ...values: unknown[]) => {
+    const text = strings.join("?").replace(/\s+/g, " ").trim();
+    queries.push({ text, values });
+    const hit = responses.find((r) => text.includes(r.match));
+    return Promise.resolve(hit?.rows ?? []);
+  };
+  const sqlWithBegin = Object.assign(run, {
+    begin: async (cb: (tx: unknown) => Promise<unknown>) => cb(run),
+  });
+  return { sql: sqlWithBegin as unknown as Sql, queries };
+}
+
+describe("webhook queue store crash recovery", () => {
+  test("dequeuePending resets stale 'processing' rows back to 'pending' before selecting", async () => {
+    const { sql, queries } = createFakeSql([
+      { match: "SET status = 'pending'", rows: [{ id: 7 }, { id: 9 }] },
+      {
+        match: "WHERE status = 'pending' ORDER BY",
+        rows: [
+          {
+            id: 7,
+            source: "github",
+            delivery_id: "d-7",
+            event_name: "issue_comment",
+            headers: {},
+            body: "{}",
+            queued_at: new Date("2026-06-11T00:00:00Z"),
+            processed_at: null,
+            status: "pending",
+          },
+        ],
+      },
+    ]);
+
+    const store = createWebhookQueueStore({ sql, logger: createNoopLogger(), telemetryStore: noopTelemetryStore });
+    const entries = await store.dequeuePending();
+
+    const recoveryQuery = queries.find((q) => q.text.includes("SET status = 'pending'"));
+    expect(recoveryQuery).toBeDefined();
+    expect(recoveryQuery!.text).toContain("WHERE status = 'processing'");
+    expect(recoveryQuery!.text).toContain("INTERVAL '60 seconds'");
+
+    const recoveryIndex = queries.findIndex((q) => q.text.includes("SET status = 'pending'"));
+    const selectIndex = queries.findIndex((q) => q.text.includes("WHERE status = 'pending' ORDER BY"));
+    expect(recoveryIndex).toBeGreaterThanOrEqual(0);
+    expect(selectIndex).toBeGreaterThan(recoveryIndex);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.deliveryId).toBe("d-7");
+  });
+
+  test("dequeuePending stays quiet when no rows are stuck", async () => {
+    const { sql, queries } = createFakeSql([]);
+    const store = createWebhookQueueStore({ sql, logger: createNoopLogger(), telemetryStore: noopTelemetryStore });
+
+    const entries = await store.dequeuePending();
+
+    expect(entries).toEqual([]);
+    // Recovery + select both ran inside the transaction even with nothing to do.
+    expect(queries.some((q) => q.text.includes("WHERE status = 'processing'"))).toBeTrue();
+  });
+});

--- a/src/lifecycle/webhook-queue-store.test.ts
+++ b/src/lifecycle/webhook-queue-store.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, test } from "bun:test";
+import type { Logger } from "pino";
 import { createWebhookQueueStore } from "./webhook-queue-store.ts";
 import type { Sql } from "../db/client.ts";
 import type { TelemetryStore } from "../telemetry/types.ts";
 
-function createNoopLogger() {
+function createNoopLogger(): Logger {
   const noop = () => undefined;
   return {
     info: noop,
@@ -11,7 +12,7 @@ function createNoopLogger() {
     error: noop,
     debug: noop,
     child: () => createNoopLogger(),
-  } as never;
+  } as unknown as Logger;
 }
 
 const noopTelemetryStore = {

--- a/src/lifecycle/webhook-queue-store.ts
+++ b/src/lifecycle/webhook-queue-store.ts
@@ -56,6 +56,24 @@ export function createWebhookQueueStore(opts: {
 
     async dequeuePending() {
       const entries = await sql.begin(async (tx) => {
+        // Recover rows orphaned in 'processing' by a crash mid-replay: nothing
+        // else ever resets that status, so without this they are lost forever.
+        // The age guard keeps a concurrently starting replica from stealing a
+        // row another instance claimed moments ago.
+        const recovered = await (tx as unknown as Sql)`
+          UPDATE webhook_queue
+          SET status = 'pending'
+          WHERE status = 'processing'
+            AND queued_at < NOW() - INTERVAL '60 seconds'
+          RETURNING id
+        `;
+        if (recovered.length > 0) {
+          logger.warn(
+            { count: recovered.length, ids: recovered.map((r: Record<string, unknown>) => r.id) },
+            "Recovered webhook_queue rows stuck in 'processing' from a prior crash",
+          );
+        }
+
         const rows = await (tx as unknown as Sql)`
           SELECT id, source, delivery_id, event_name, headers, body, queued_at, processed_at, status
           FROM webhook_queue

--- a/src/lifecycle/webhook-queue-store.ts
+++ b/src/lifecycle/webhook-queue-store.ts
@@ -135,10 +135,10 @@ export function createWebhookQueueStore(opts: {
       `;
     },
 
-    async markFailed(id, _error) {
+    async markFailed(id, error) {
       await sql`
         UPDATE webhook_queue
-        SET status = 'failed'
+        SET status = 'failed', error_message = ${error?.slice(0, 2_000) ?? null}
         WHERE id = ${id}
       `;
     },

--- a/src/llm/fallback.test.ts
+++ b/src/llm/fallback.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { isFallbackTrigger, getFallbackReason } from "./fallback.ts";
+
+describe("isFallbackTrigger", () => {
+  test("treats AbortSignal.timeout()'s TimeoutError as a fallback trigger", () => {
+    // AbortSignal.timeout aborts with a DOMException named "TimeoutError" whose
+    // message ("The operation timed out.") does NOT contain "timeout" — the
+    // name match is load-bearing.
+    const err = new DOMException("The operation timed out.", "TimeoutError");
+    expect(isFallbackTrigger(err)).toBeTrue();
+    expect(getFallbackReason(err)).toBe("timeout");
+  });
+
+  test("treats AbortError and message timeouts as triggers", () => {
+    expect(isFallbackTrigger(new DOMException("aborted", "AbortError"))).toBeTrue();
+    expect(isFallbackTrigger(new Error("connection timeout"))).toBeTrue();
+  });
+
+  test("rate limits and 5xx trigger, plain errors do not", () => {
+    const rateLimited = Object.assign(new Error("rate limited"), { status: 429 });
+    const serverError = Object.assign(new Error("boom"), { statusCode: 503 });
+    expect(isFallbackTrigger(rateLimited)).toBeTrue();
+    expect(isFallbackTrigger(serverError)).toBeTrue();
+    expect(isFallbackTrigger(new Error("validation failed"))).toBeFalse();
+    expect(isFallbackTrigger("not an error")).toBeFalse();
+  });
+});

--- a/src/llm/fallback.ts
+++ b/src/llm/fallback.ts
@@ -7,6 +7,15 @@
  */
 
 /**
+ * Timeout detection. AbortSignal.timeout() aborts with a DOMException named
+ * "TimeoutError" whose message is "The operation timed out." — match name,
+ * not just the "timeout" substring.
+ */
+function isTimeoutError(err: Error): boolean {
+  return err.message.includes("timeout") || err.name === "AbortError" || err.name === "TimeoutError";
+}
+
+/**
  * Determines whether an error should trigger fallback to alternative model.
  */
 export function isFallbackTrigger(err: unknown): boolean {
@@ -19,12 +28,7 @@ export function isFallbackTrigger(err: unknown): boolean {
   if (status === 429) return true; // Rate limit -> immediate fallback
   if (typeof status === "number" && status >= 500 && status < 600) return true;
 
-  // Timeout detection. AbortSignal.timeout() aborts with a DOMException named
-  // "TimeoutError" whose message is "The operation timed out." — match name,
-  // not just the "timeout" substring.
-  if (err.message.includes("timeout") || err.name === "AbortError" || err.name === "TimeoutError") return true;
-
-  return false;
+  return isTimeoutError(err);
 }
 
 /**
@@ -36,7 +40,6 @@ export function getFallbackReason(err: unknown): string {
   if (status === 429) return "rate limited (429)";
   if (typeof status === "number" && status >= 500)
     return `server error (${status})`;
-  if (err.message.includes("timeout") || err.name === "AbortError" || err.name === "TimeoutError")
-    return "timeout";
+  if (isTimeoutError(err)) return "timeout";
   return err.message;
 }

--- a/src/llm/fallback.ts
+++ b/src/llm/fallback.ts
@@ -19,8 +19,10 @@ export function isFallbackTrigger(err: unknown): boolean {
   if (status === 429) return true; // Rate limit -> immediate fallback
   if (typeof status === "number" && status >= 500 && status < 600) return true;
 
-  // Timeout detection
-  if (err.message.includes("timeout") || err.name === "AbortError") return true;
+  // Timeout detection. AbortSignal.timeout() aborts with a DOMException named
+  // "TimeoutError" whose message is "The operation timed out." — match name,
+  // not just the "timeout" substring.
+  if (err.message.includes("timeout") || err.name === "AbortError" || err.name === "TimeoutError") return true;
 
   return false;
 }
@@ -34,7 +36,7 @@ export function getFallbackReason(err: unknown): string {
   if (status === 429) return "rate limited (429)";
   if (typeof status === "number" && status >= 500)
     return `server error (${status})`;
-  if (err.message.includes("timeout") || err.name === "AbortError")
+  if (err.message.includes("timeout") || err.name === "AbortError" || err.name === "TimeoutError")
     return "timeout";
   return err.message;
 }

--- a/src/llm/generate.ts
+++ b/src/llm/generate.ts
@@ -16,6 +16,14 @@ import { createProviderModel } from "./providers.ts";
 import { isFallbackTrigger, getFallbackReason } from "./fallback.ts";
 import { buildAgentEnv } from "../execution/env.ts";
 
+/**
+ * Hard ceiling for a single AI SDK generateText call. Without it a hung
+ * connection blocks the calling job forever and the fallback never fires
+ * (fallback only triggers on a thrown error). Non-agentic tasks (labels,
+ * classification, synthesis) finish in well under this.
+ */
+export const GENERATE_TEXT_TIMEOUT_MS = 120_000;
+
 /** Result from generateWithFallback. */
 export interface GenerateResult {
   text: string;
@@ -182,6 +190,7 @@ export async function generateWithFallback(opts: {
       prompt: opts.prompt,
       system: opts.system,
       tools: opts.tools,
+      abortSignal: AbortSignal.timeout(GENERATE_TEXT_TIMEOUT_MS),
     });
 
     const durationMs = Date.now() - startTime;
@@ -240,6 +249,7 @@ export async function generateWithFallback(opts: {
           prompt: opts.prompt,
           system: opts.system,
           tools: opts.tools,
+          abortSignal: AbortSignal.timeout(GENERATE_TEXT_TIMEOUT_MS),
         });
 
         const fallbackDurationMs = Date.now() - fallbackStartTime;

--- a/src/llm/generate.ts
+++ b/src/llm/generate.ts
@@ -117,7 +117,7 @@ async function generateWithAgentSdk(opts: {
   const totalCacheCreation = modelEntries.reduce((sum, [, u]) => sum + u.cacheCreationInputTokens, 0);
 
   if (opts.costTracker && opts.repo && resultMessage) {
-    opts.costTracker.trackAgentSdkCall({
+    void opts.costTracker.trackAgentSdkCall({
       repo: opts.repo,
       taskType: opts.taskType,
       model: primaryModel,
@@ -201,7 +201,7 @@ export async function generateWithFallback(opts: {
 
     // Track cost (fire-and-forget)
     if (opts.costTracker && opts.repo) {
-      opts.costTracker.trackAiSdkCall({
+      void opts.costTracker.trackAiSdkCall({
         repo: opts.repo,
         taskType,
         model: resolved.modelId,
@@ -260,7 +260,7 @@ export async function generateWithFallback(opts: {
 
         // Track fallback cost
         if (opts.costTracker && opts.repo) {
-          opts.costTracker.trackAiSdkCall({
+          void opts.costTracker.trackAiSdkCall({
             repo: opts.repo,
             taskType,
             model: resolved.fallbackModelId,
@@ -295,7 +295,7 @@ export async function generateWithFallback(opts: {
 
         // Track error cost
         if (opts.costTracker && opts.repo) {
-          opts.costTracker.trackAiSdkCall({
+          void opts.costTracker.trackAiSdkCall({
             repo: opts.repo,
             taskType,
             model: resolved.fallbackModelId,
@@ -317,7 +317,7 @@ export async function generateWithFallback(opts: {
     // Not a fallback trigger or no fallback model -- rethrow
     // Track error cost
     if (opts.costTracker && opts.repo) {
-      opts.costTracker.trackAiSdkCall({
+      void opts.costTracker.trackAiSdkCall({
         repo: opts.repo,
         taskType,
         model: resolved.modelId,


### PR DESCRIPTION
## Summary
Verified-findings pass from the post-merge codebase analysis: four reliability bug fixes, a hygiene batch, and one structural extraction. Every change traces to a finding that was personally re-verified in code before implementation — and three recommended items were dropped when verification showed they would do harm (details below).

## Reliability fixes (Tier 1)
- **Webhook replay crash recovery** — `dequeuePending` only selected `'pending'` and nothing ever reset `'processing'`, so a crash mid-replay permanently lost those webhooks. Stale `processing` rows (>60s age guard) now flip back to `pending` inside the dequeue transaction.
- **Shutdown drain covers fire-and-forget jobs** — the request tracker only wrapped webhook dispatch, so the review timeout retry (`void jobQueue.enqueue(...)`) was invisible to `waitForDrain` and a deploy could kill it mid-review. Tracking now lives in the job-queue layer: every enqueue counts as in-flight work from acceptance to completion.
- **`generateText` timeout** — the AI SDK path had no `abortSignal`; a hung connection blocked the job forever and fallback never fired. Both primary and fallback calls now abort at 120s, and `isFallbackTrigger` recognizes the `TimeoutError` DOMException that `AbortSignal.timeout()` raises (it matched neither existing check).
- **Global Octokit retry** — only 13 of ~109 call sites used the retry wrappers. Retry is now installed once via `octokit.hook.wrap("request")` at all three client construction sites. Method-aware policy: GET/HEAD retry the full transient set; mutations retry only rate-limit rejections (403 secondary-rate/429) since retrying a POST on a 5xx could double-apply it.

## Hygiene (Tier 2)
- **`@typescript-eslint/no-floating-promises` enabled (error) for `src/`** with type-aware parsing; all 12 violations fixed. The review.ts checkpoint-cleanup calls were genuinely floating raw-SQL promises — in a process where unhandledRejection triggers fatal shutdown. New `discardCheckpointsFailOpen` helper logs and swallows.
- `markFailed` persists the replay failure reason (migration 047 + down: `webhook_queue.error_message`).
- `DATABASE_POOL_MAX` env (default 10); `appendDiagnostic` can no longer raise unhandledRejection from the SDK stderr callback; `.env.example` documents the ACA/MCP/addon vars `src/config.ts` actually reads and drops the never-read `CLAUDE_CODE_ENTRYPOINT`.

## Refactor (Tier 3)
- **`buildKnowledgeContextLines` extracted** from `buildReviewPromptDetails` — the largest remaining inline blob (~60 lines, six hand-rolled separator repetitions) is now a top-level pure function with a named input type and its first direct unit tests.

## Recommended items verified-then-dropped (with evidence)
- **package.json `verify:*` prune (~71 entries):** 97 verify scripts assert their own package.json wiring, and `verify-m054-s04` asserts specific entries including the `verify:m044` alias documented in runbooks. The entries are a self-enforcing registry; pruning breaks gates for zero behavioral gain.
- **Shared `initializeReviewWorkspace()` for review+mention:** the identical code is ~15 lines; the differences are load-bearing security posture (review loads `.kodiai.yml` from the trusted base before PR-head checkout; mention loads from the head). A helper would need ~8 divergence-encoding options and would obscure that distinction.
- **Retrieval-context extraction from review.ts:** 13 captured dependencies with output-state mutation into prompt-section records — a closure, not a seam. Deferred until the handler state model is reworked.

## Verification
- `bun run test`: **5750 pass, 0 fail** (470 files)
- `bunx tsc --noEmit`, `bun run lint` (incl. the new rule), `check:orphaned-tests`, `check:review-details-architecture`, `check:migrations-have-downs`, `verify:m056:s03`: all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
