### PR TITLE
Reduce ACA footprint and document receiver/worker split

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -113,13 +113,14 @@ fi
 # event loop that also serves the internal MCP callback server hit by agent jobs.
 # Under-provisioning starves the loop during review-time CPU bursts, which makes
 # in-flight MCP calls sit idle until the ACA ingress 240s stream_idle_timeout
-# resets them (504). 2 vCPU / 4Gi gives ample headroom on a single replica.
-# NOTE: ACA requires valid cpu/memory pairings (e.g. 1.0/2Gi, 2.0/4Gi). Keep
+# resets them (504). The 1.75 vCPU / 3.5Gi default is based on observed
+# 30-day utilization while preserving headroom above memory peaks.
+# NOTE: ACA requires valid cpu/memory pairings (e.g. 1.0/2Gi, 1.75/3.5Gi). Keep
 # ACA_MAX_REPLICAS=1 unless the MCP token registry is moved to shared durable
 # storage — agent MCP callbacks must reach a replica that can validate and
 # reconstruct the job token's server factories.
-ACA_CPU=${ACA_CPU:-2.0}
-ACA_MEMORY=${ACA_MEMORY:-4.0Gi}
+ACA_CPU=${ACA_CPU:-1.75}
+ACA_MEMORY=${ACA_MEMORY:-3.5Gi}
 if ! [[ "$ACA_CPU" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
   echo "ERROR: ACA_CPU must be a number (cores), e.g. 2.0." >&2
   exit 1

--- a/docs/runbooks/azure-cost-architecture-review.md
+++ b/docs/runbooks/azure-cost-architecture-review.md
@@ -1,0 +1,349 @@
+# Azure Cost & Architecture Review — Webhook/Worker Split
+
+Deep-dive requested to evaluate splitting `ca-kodiai` into a tiny always-on
+webhook receiver plus a queue-backed, scale-to-zero worker, comparing an
+ACA-only variant (Option 3) against an Azure Functions receiver variant
+(Option 4), against staying on the current reduced always-on app.
+
+All code references below were verified against this branch
+(`consolidated-review-fixes`) on 2026-07-08.
+
+## 0. Ground truth used for this review
+
+**Current spend (30-day, from cost export):**
+
+| Resource | Cost | Notes |
+| --- | --- | --- |
+| `ca-kodiai` (main app) | $46.31 | min=1, max=1, 1.75 vCPU / 3.5Gi (`deploy.sh:97-129`) |
+| `caj-kodiai-agent` (ACA job) | $1.61 | Manual trigger, no CPU/mem override → ACA default 0.5 vCPU/1Gi (`deploy.sh:504-561`) |
+| PostgreSQL `kodiai-pg` | $15.83 | Burstable B1ms, Premium SSD (P4, 32Gi) (`scripts/provision-postgres.sh:23-60`) |
+| Storage `kodiaistg` | $14.58 | Standard_LRS, ~11.1M transactions/mo |
+| ACR Basic | $6.05 | |
+| Key Vault / Log Analytics | ~$0 | |
+| **Total `rg-kodiai`** | **$84.43** | |
+
+**Utilization:** app CPU p95 2.23% / max 53.8%; app memory avg 38% / p95 70% /
+max 77.9%; ~17,389 HTTP requests/month (~24/hour average, so nearly all
+wall-clock time has zero in-flight requests); Postgres CPU avg 13% / p95
+14.8%; Postgres storage 16.7% of 32Gi (~5.3GB actually used).
+
+**Verified Azure pricing (fetched 2026-07-08, Microsoft Learn / azure.microsoft.com):**
+
+| Meter | Rate |
+| --- | --- |
+| ACA Consumption — active vCPU-second | $0.000024 |
+| ACA Consumption — active GiB-second | $0.000003 |
+| ACA Consumption — **idle** vCPU-second (min-replica app, no active request, CPU<0.01 vCPU, <1000B/s net) | $0.000008 |
+| ACA Consumption — **idle** GiB-second | $0.000001 |
+| ACA free grant (per subscription/month, shared across ALL apps+jobs) | 180,000 vCPU-s, 360,000 GiB-s, 2M requests |
+| ACA Jobs | **Always billed at active rate — no idle discount, no request charge (jobs have no ingress)** |
+| Azure Functions Consumption | $0.40/M executions, ~$0.000016–0.000020/GB-s (region-dependent); free grant 1M executions + 400,000 GB-s/month |
+| Storage Queue (LRS) | $0.0004/10,000 operations; storage $0.045/GB-month |
+| Service Bus Standard | **$10/month fixed base fee**, includes ~12.5M operations/month, then metered beyond |
+| Service Bus Basic | No base fee, ~$0.05/M operations, no sessions/dedup/topics |
+| Postgres Flexible Server storage | **Premium SSD or Premium SSD v2 only — confirmed no Standard HDD/SSD tier exists** (Microsoft Learn, `concepts-storage`) |
+
+**Load-bearing insight — the idle-rate discount already did most of the "obvious" work.**
+Back-calculating from the $46.31 observed bill against 1.75 vCPU/3.5Gi
+allocated 24/7 (~4.60M vCPU-s, ~9.20M GiB-s/month) only reconciles if the
+active/idle split is roughly **2–3% active, 97–98% idle** — which lines up
+almost exactly with the observed CPU p95 of 2.23%. In other words, ACA is
+already billing this app at the cheap idle rate essentially all the time it
+isn't actively handling a request or polling a job. This changes the framing
+of the whole exercise: **the win from Option 3/4 isn't "stop paying for idle
+time" (Azure already discounts that ~3x) — it's shrinking the *size* of the
+footprint that idle-rate billing applies to**, and moving the truly
+active-rate compute (LLM calls, job polling, MCP callback serving) onto a
+worker that can go to **zero** instead of merely idle.
+
+## 1. Current architecture (verified from code)
+
+- **GitHub webhook** (`src/routes/webhooks.ts:40-177`): sig verify →
+  in-memory delivery-ID dedup (`src/webhook/dedup.ts`, 24h TTL, 50k cap) →
+  fire-and-forget dispatch (`Promise.resolve().then(() =>
+  eventRouter.dispatch(event))`, `:171-174`) → **200 returned before the
+  handler runs**, explicitly to dodge GitHub's 10s webhook timeout (`:167`).
+  During shutdown, events are durably spilled into a Postgres `webhook_queue`
+  table (`:147`) — this is the closest existing primitive to a real queue.
+- **Slack Events API** (`src/routes/slack-events.ts:58-206`): same
+  ack-then-dispatch shape; also spills to `webhook_queue` on async failure.
+- **Event routing**: `src/webhook/router.ts` — in-process `Map` of handlers,
+  `Promise.allSettled` fan-out.
+- **MCP callback token registry** — `src/execution/mcp/http-server.ts:84-169`,
+  `createMcpJobRegistry()` — a plain `Map<string, McpJobEntry>`, **the actual
+  cause of `maxReplicas=1`** per the guard at `deploy.sh:107-121`. Each
+  dispatched review mints a random bearer token, registers it against
+  in-memory closures (`factories: Record<string, () => ...>` bound to
+  `getOctokit`/`onPublish`/etc. — **not serializable**), and the ACA agent
+  job calls back into `/internal/mcp/:serverName` with that token while it
+  runs. Unregistered on completion/failure/timeout (`src/execution/executor.ts:823-948`).
+- **ACA job dispatch** (`src/jobs/aca-launcher.ts`): hand-rolled Azure
+  Management REST calls (no `@azure/*` SDK in `package.json`) to start
+  `caj-kodiai-agent`, then `pollUntilComplete()` (`:395-524`) — **the
+  orchestrator process blocks/polls every 5s until the job finishes**, up to
+  a 1860s replica timeout. Result comes back two ways: `result.json` on the
+  shared Azure Files workspace, *and* live MCP callbacks during the poll.
+- **Azure Files cleanup**: already fixed to run in the background
+  (`src/index.ts:109-123`, `scheduleAzureFilesWorkspaceCleanup()`, not
+  awaited) — confirmed, not something this review needs to redo.
+- **Postgres**: `run_state` table (unique `run_key`) already durably tracks
+  review-run lifecycle/supersession — this is the one piece of session state
+  that's *already* multi-replica-safe. The genuinely process-local state is:
+  MCP token registry, `webhook/dedup.ts`, `jobs/review-work-coordinator.ts`
+  (per-PR attempt claims), and `jobs/queue.ts` (in-process `p-queue` lanes).
+- **Deploy**: no KEDA/custom scale rule exists anywhere — the app just runs
+  at a fixed replica count (`deploy.sh:862-864`). No `@azure/storage-queue`,
+  `@azure/service-bus`, or `@azure/functions` dependency exists yet.
+- Reconciling job spend: at ACA's default job size (0.5 vCPU/1Gi, no
+  override in `deploy.sh:504-561`) and the always-active job rate, $1.61/month
+  implies **~30 execution-hours/month**. At a plausible 5–10 min average job
+  wall time, that's **~180–360 review jobs/month (~6–12/day)** — useful for
+  sizing the worker below.
+
+## 2. Cost model for Option 3 (tiny ACA receiver + scale-to-zero ACA worker)
+
+**Receiver**: 0.25 vCPU / 0.5Gi, min=1/max=1, does only sig-verify + dedup +
+enqueue — no LLM/Octokit work, so it's active for milliseconds per request
+and idle-billed almost 100% of the time.
+
+- Idle compute (net of its share of the free grant): ≈ **$4–6/month**
+- Requests: 17,389/month is far under the 2M free grant → **$0**
+
+**Worker**: keep it sized like today (1.75 vCPU/3.5Gi) since it still runs
+LLM orchestration, Octokit calls, DB access, and serves MCP callbacks while
+blocking on `pollUntilComplete`. With `minReplicas=0`, it's billed **active
+rate only for the wall-clock time it's actually running** — which is
+dominated by review-processing time, not request count (KEDA queue scalers
+wake it on message arrival; it scales back to 0 after a cooldown once the
+queue drains).
+
+- At ~180–360 reviews/month and ~6–11 min of worker wall-time per review
+  (webhook handling + blocking-poll during the agent job): **≈ $3–15/month**
+  in active-rate compute, plus a cooldown-overhead buffer → **call it $5–16/month**.
+
+**Queue** (Storage Queue): ~3 operations/message (enqueue, dequeue, delete) ×
+17,389–35,000 messages/month → **well under $1/month**.
+
+**ACA agent jobs**: unchanged, **$1.61/month** (doubles with job volume).
+
+| Scenario | Receiver | Worker | Queue | Jobs | **Total** | vs. current $47.92 (app+jobs) |
+| --- | --- | --- | --- | --- | --- | --- |
+| Current baseline | — | — | — | — | $46.31 + $1.61 | — |
+| Option 3, current volume | ~$5 | ~$5–16 | <$1 | $1.61 | **~$12–23/mo** | ~50–75% lower |
+| Option 3, webhook volume ×2 | ~$5 | ~$5–16 (unchanged — receiver work is what scales, and it's ~free) | <$1 | $1.61 | **~$12–23/mo** | negligible extra cost |
+| Option 3, review/job volume ×2 | ~$5 | ~$10–30 | <$1 | $3.22 | **~$19–38/mo** | still well below baseline |
+
+Webhook-volume doubling is nearly free under this design because the
+receiver's cost driver is idle allocation size, not request count, and
+requests stay far under the 2M free grant either way. Review/job-volume
+doubling is the real cost driver, because that's what makes the worker
+actually run at the active rate.
+
+Net effect on the $84.43 total resource-group bill: roughly **$84 → $55–65/month**
+at current volume (app/job line drops ~$25–36; Postgres/Storage/ACR
+untouched by this specific change — see §9 for adjacent opportunities).
+
+## 3. Cost model for Option 4 (Azure Functions receiver + same worker)
+
+Functions Consumption pricing at this volume is essentially free: even at
+10x today's traffic (170k executions, ~200ms × 256MB each ≈ 8,700 GB-s),
+you're still inside the 1M-execution / 400,000 GB-s free grant. So Option 4
+saves the **receiver's ~$4–6/month** relative to Option 3 — a genuinely
+marginal difference — in exchange for meaningfully more engineering risk:
+
+- **Bun isn't a supported Azure Functions runtime.** The receiver would need
+  to be ported to Node.js (or run as a custom-container Functions app, which
+  gives back most of the cost/complexity advantage over just using a tiny
+  ACA app). This is real porting work for the signature-verify/dedup/enqueue
+  path specifically, not a config change.
+- **Cold starts.** Functions Consumption cold start is commonly 1–10s (more
+  under memory pressure or infrequent invocation, which is exactly this
+  traffic pattern — ~24 req/hour means the instance is very likely to have
+  gone cold between requests). That eats directly into GitHub's 10s and
+  especially Slack's **3-second** ack budget with much less margin than
+  today's warm always-on process.
+- Two deployment/build/observability surfaces instead of one, for a
+  single-digit-dollar delta.
+
+**Recommendation embedded in this section**: Option 4's receiver swap is not
+worth it at this traffic level. If Functions is adopted at all, it should be
+considered only if/when webhook volume grows enough that the *worker*
+(not the receiver) becomes the cost question — and even then, ACA Jobs
+already cover bursty/consumption-style execution for the heavy work, so
+there's no clear gap Functions fills here.
+
+## 4. Preserving webhook ack reliability
+
+Both options keep the exact same synchronous-checks-then-async-dispatch
+shape that exists today (`src/routes/webhooks.ts:40-177`,
+`src/routes/slack-events.ts:58-206`) — the only change is that "dispatch"
+becomes "enqueue" instead of an in-process `Promise.resolve().then(...)`:
+
+1. Rate limit → signature verify → delivery-ID dedup (unchanged, in-memory,
+   fine because the receiver stays a single min=max=1 instance).
+2. Enqueue to Storage Queue (typically <100ms) instead of firing the
+   in-process dispatch.
+3. Return 200 immediately — same GitHub 10s / Slack 3s ack margin as today,
+   arguably with *more* margin since the receiver no longer shares a process
+   with LLM/Octokit work that could momentarily starve the event loop.
+4. Keep the existing `webhook_queue` Postgres table as a shutdown-safety
+   fallback for the receiver itself (unchanged use case, just now guarding
+   queue-enqueue failures instead of dispatch failures).
+
+## 5. Idempotency, dedup, retry, dead-letter
+
+Most of this already exists and needs no redesign:
+
+- **Delivery-level dedup**: `src/webhook/dedup.ts` in-memory cache stays on
+  the receiver exactly as-is (receiver is still single-instance).
+- **Review-output idempotency**: `review-orchestration/review-idempotency.ts`
+  (`ensureReviewOutputNotPublished`) checks **GitHub itself** for the
+  published marker, not a local flag — this is already safe against a queue
+  redelivering a message and the worker reprocessing it. This is the
+  strongest existing asset for a queue-based redesign: **the worker can be
+  naively at-least-once and still be safe**, because the publish path is
+  self-deduplicating against GitHub state.
+- **`run_state` (unique `run_key`)** already gives durable run-lifecycle
+  tracking across restarts — reuse it as the queue-message idempotency key
+  rather than inventing a new one.
+- **Retry**: rely on Storage Queue visibility timeout — set it comfortably
+  above the max review wall-time (~35 min, matching the 1860s ACA job replica
+  timeout) so a crashed/killed worker replica's message becomes redeliverable
+  automatically, no custom retry scheduler needed.
+- **Dead-letter**: Storage Queue has no native DLQ — implement the standard
+  poison-message pattern using the queue message's `dequeueCount` (check on
+  dequeue, move to a `-poison` queue and alert after N attempts, e.g. 5).
+  This is a small, well-understood amount of new code, not a gap that
+  requires Service Bus.
+
+## 6. Storage Queue vs. Service Bus
+
+**Storage Queue is enough here.** At 17k–70k messages/month, either option's
+absolute cost is a rounding error — but Service Bus Standard's **$10/month
+fixed base fee** is bigger than the *entire* projected receiver+worker+queue
+cost of Option 3 at current volume. Service Bus's differentiators (sessions,
+built-in duplicate detection, native DLQ, guaranteed FIFO, larger 256KB
+messages) don't map to a real gap here:
+
+- Ordering: the repo already has supersession logic (`run_state.superseded_by`,
+  `review-work-coordinator.ts`) that tolerates out-of-order webhook delivery,
+  so Service Bus sessions/FIFO buy nothing.
+- Dedup: already solved at the GitHub-truth layer (§5), so Service Bus
+  duplicate detection is redundant.
+- DLQ: a `dequeueCount`-based poison queue is trivial to add to Storage Queue.
+- Message size: webhook payloads/queue messages here are small metadata
+  pointers (repo/PR/delivery-id), not full payloads — 64KB is not a
+  constraint.
+
+Service Bus becomes worth revisiting only if job/webhook volume grows by
+roughly two orders of magnitude (at which point its $10 base amortizes) or if
+a real need for sessions/guaranteed ordering emerges — neither is close today.
+
+## 7 & 8. MCP callback registry — what it actually constrains
+
+The registry constrains **replica count of whichever process serves
+`/internal/mcp/:serverName`**, not webhook throughput and not job count.
+Concretely:
+
+- The registry is a plain in-memory `Map` holding **non-serializable
+  closures** (`factories: Record<string, () => McpSdkServerConfigWithInstance>`
+  bound to live `getOctokit`/`onPublish` callbacks). A real move to shared
+  storage isn't "swap the Map for Redis" — it means persisting the *inputs*
+  to `buildMcpServerFactories` (owner/repo/PR/comment IDs, etc.) and
+  reconstructing factories on whichever replica receives a given callback,
+  plus either sticky-session ingress or replica-affinity so a job's callbacks
+  keep landing on a replica that can serve them.
+- **This migration is NOT required for the first milestone.** If the worker's
+  scale rule is capped at `maxReplicas=1` (scale strictly 0↔1, KEDA queue
+  trigger with `activationConcurrency`/cooldown ensuring only one instance is
+  ever up at a time), the exact single-instance assumption the registry
+  relies on today is preserved — you get 100% of the scale-to-zero savings
+  in §2 with **zero changes to `http-server.ts`**.
+- The registry migration **only becomes mandatory** if you later want the
+  worker to run more than one concurrent replica (e.g. to parallelize
+  multiple simultaneous reviews beyond what one process + `p-queue` lanes
+  handle). Given current volume (~6–12 reviews/day), there's no throughput
+  case for that yet.
+- **Real risk to watch, independent of the registry**: KEDA's queue-depth
+  scaler has no visibility into "a review is still blocking on
+  `pollUntilComplete` waiting for an agent job callback." The worker's
+  `scaleDownDelay`/cooldown must be set to at least the max review wall-time
+  (~35 min) so KEDA doesn't scale the single active replica to zero **while
+  it's mid-review and still expected to serve MCP callbacks** — that failure
+  mode would orphan a running ACA job with no one able to receive its
+  callbacks. This is the sharpest correctness risk in Option 3/4 and needs
+  explicit scale-rule tuning, not just "min=0, max=1."
+
+## 9. Operational risks, rollout, rollback
+
+**Risks, ranked:**
+
+1. Premature scale-to-zero mid-review (above) — mitigate with conservative
+   cooldown + integration test that holds a fake long-running job open and
+   asserts the worker replica survives.
+2. Receiver/worker split turns one deploy into two — `deploy.sh` needs real
+   changes (two container app definitions, queue provisioning, KEDA scale
+   rule, env wiring for queue connection). Budget this as the bulk of the
+   actual engineering cost, not the Azure resource cost.
+3. Queue-enqueue failure path needs the same shutdown-safety treatment the
+   receiver already has for direct dispatch (§4) — don't regress the
+   existing `webhook_queue` fallback.
+4. Cold-start-adjacent latency on worker wake from zero — first message
+   after idle period will see queue-poll-interval + container cold start
+   added to review latency (Slack UX may notice this on `/kodiai` commands
+   more than GitHub review latency, which is already async).
+
+**Rollout plan:**
+
+1. Ship the queue plumbing and worker split with `ACA_MAX_REPLICAS=1` fixed
+   (no registry change) and `minReplicas=1` on the worker initially — i.e.,
+   validate the receiver/queue/worker wiring *before* touching scale-to-zero
+   at all. This isolates "did the split work" from "does scale-to-zero work."
+2. Flip the worker to `minReplicas=0` behind an env flag, with the cooldown
+   tuned per §8, and watch a full week of real review traffic (including at
+   least one job that runs close to the 1860s timeout) before calling it done.
+3. Only then consider shrinking the receiver's resources further or
+   revisiting Service Bus/registry migration if volume has grown.
+
+**Rollback plan:** because `deploy.sh` is already idempotent/re-runnable,
+rollback is redeploying the current single-app topology with
+`ACA_MIN_REPLICAS=1`/`ACA_MAX_REPLICAS=1` — keep the pre-split `deploy.sh`
+and app image buildable from the previous tag until the split has run
+cleanly in production for a full billing cycle. Postgres `run_state`/`webhook_queue`
+schemas are additive, so no migration rollback is needed either direction.
+
+## 10. Recommendation
+
+**Do Option 3 first, with the registry migration deferred and worker capped
+at `maxReplicas=1`. Do not do Option 4** at current or 2x traffic — the
+Functions receiver saves roughly $4–6/month over a tiny ACA receiver while
+adding a real Bun→Node port, cold-start risk against Slack's 3s ack budget,
+and a second deployment surface. That trade isn't close.
+
+**Smallest safe first milestone**: split the receiver and worker into two
+ACA apps talking over a Storage Queue, with the worker pinned to
+`minReplicas=1, maxReplicas=1` (no scale-to-zero yet, no MCP registry
+change). This alone validates the queue plumbing, idempotency reuse
+(`run_state` + GitHub-truth publish checks), and dead-letter handling with
+zero blast-radius change to the callback model — and it's the prerequisite
+for the scale-to-zero step in §2, which is where the real savings are.
+Only after that milestone is stable in production should `minReplicas=0`
+be enabled on the worker.
+
+**Stay on the current reduced always-on app** only if the team isn't willing
+to absorb the two-deploy operational overhead in §9 for a ~$25–36/month
+saving on the app/job line (~30–40% of total `rg-kodiai` spend) — that's a
+legitimate call if this isn't a priority right now, but the cost case for
+doing it, once the queue split lands, is solid and low-risk **provided the
+scale-down-cooldown risk in §8 is respected**.
+
+**Adjacent, independent opportunity (not part of Options 3/4):** Postgres
+storage is Premium SSD (P4, 32Gi) at 16.7% utilization (~5.3GB actual).
+Premium SSD v2 (confirmed available for Flexible Server, §0) allows granular
+capacity/IOPS sizing instead of the fixed P-series step, and Microsoft's own
+guidance is that it's "less costly as a general rule" than Premium SSD for
+general-purpose workloads. Worth a separate, low-risk pass independent of
+the webhook/worker split — note storage can only be scaled up, not down, so
+this needs sizing care up front, but switching storage *type* (Premium →
+Premium SSD v2) at the same or smaller capacity is a config change, not a
+migration.

--- a/docs/runbooks/codex-prompt-option3-milestone1.md
+++ b/docs/runbooks/codex-prompt-option3-milestone1.md
@@ -1,0 +1,167 @@
+# Codex prompt — Option 3, Milestone 1 (receiver/worker split, no scale-to-zero yet)
+
+Copy everything below the line into Codex.
+
+---
+
+You're working in the `kodiai` repo (Bun + Hono TypeScript app on Azure
+Container Apps). Full context and rationale for this change is in
+`docs/runbooks/azure-cost-architecture-review.md` — read that first,
+especially §1 (current architecture), §5 (idempotency/retry/DLQ), §7-8 (MCP
+callback registry constraints), and §9-10 (rollout plan and why this
+milestone is scoped the way it is). Don't re-derive the cost analysis; it's
+already done. Your job is the implementation.
+
+## Goal
+
+Split the current single `ca-kodiai` app into two Azure Container Apps
+talking over an Azure Storage Queue:
+
+1. **Receiver** (new, tiny): owns `/github`, `/events` (Slack), and the
+   Slack relay webhook routes. Does signature verification, delivery-ID
+   dedup, and rate limiting exactly as today — but instead of dispatching
+   the event in-process, it enqueues a message and returns 200/ack
+   immediately.
+2. **Worker** (the rest of today's app): dequeues messages and runs the
+   existing event router / review orchestration / ACA job dispatch / MCP
+   callback server exactly as it does today, unchanged in behavior.
+
+## Explicit scope boundaries — do not do these in this milestone
+
+- **Do NOT implement scale-to-zero.** The worker must be deployed with
+  `minReplicas=1, maxReplicas=1`, identical to today's scaling posture. This
+  milestone is only about proving the queue plumbing works; scale-to-zero is
+  a separate follow-up once this is stable in production (see runbook §9,
+  rollout step 1 vs step 2).
+- **Do NOT touch the MCP callback token registry**
+  (`src/execution/mcp/http-server.ts`). It stays exactly as-is, in-memory,
+  on the worker. This is safe because the worker stays single-replica.
+- **Do NOT introduce Service Bus.** Use Azure Storage Queue — the existing
+  `kodiaistg` storage account already used for Azure Files. See runbook §6
+  for why.
+- **Do NOT change review-idempotency logic.** The existing GitHub-truth-based
+  publish checks (`review-orchestration/review-idempotency.ts`,
+  `ensureReviewOutputNotPublished`) already make the worker safe against a
+  queue redelivering a message — reuse them, don't add a parallel mechanism.
+
+## What to build
+
+### 1. Queue client
+
+- Add `@azure/storage-queue` as a dependency.
+- New module, e.g. `src/queue/webhook-queue.ts`, exposing `enqueue(event)`
+  and a `dequeue`/`receiveMessages` + `deleteMessage` wrapper. Use managed
+  identity for auth (same pattern as the rest of the repo's Azure access —
+  check `src/jobs/aca-launcher.ts` for how managed identity tokens are
+  fetched via `IDENTITY_ENDPOINT`/`IDENTITY_HEADER`, or use
+  `@azure/identity`'s `DefaultAzureCredential` if that's cleaner with the
+  storage SDK — your call, but stay consistent with how the rest of the repo
+  authenticates to Azure).
+- Message payload: whatever `WebhookEvent` needs to be reconstructed
+  worker-side (source, delivery ID, event name, headers, body) — this is
+  almost exactly the shape already durably stored in the `webhook_queue`
+  Postgres table (`src/db/migrations/004-webhook-queue.sql`). Reuse that
+  shape/serialization rather than inventing a new one.
+- Visibility timeout: set comfortably above the max review wall-time —
+  match the existing `ACA_JOB_REPLICA_TIMEOUT` margin (1860s in
+  `deploy.sh`), so a crashed worker's message becomes redeliverable
+  automatically without a custom retry scheduler.
+- Dead-letter: implement the standard poison-message pattern using the
+  queue message's `dequeueCount` — after N attempts (start with 5), move the
+  message to a second queue (e.g. `webhook-queue-poison`) and log/alert.
+  Storage Queue has no native DLQ; this is the app-level equivalent.
+
+### 2. Receiver app
+
+- New entry point (or a build target driven by an env flag on the existing
+  entry point — pick whichever is less invasive given how `src/index.ts` is
+  currently wired) that mounts only:
+  - `createWebhookRoutes` (GitHub) — `src/routes/webhooks.ts`
+  - `createSlackEventRoutes` — `src/routes/slack-events.ts`
+  - `createSlackRelayWebhookRoutes` — `src/routes/slack-relay-webhooks.ts`
+    (note: this route currently awaits `onAcceptedRelay` synchronously,
+    `src/routes/slack-relay-webhooks.ts:104` — decide whether relay webhooks
+    also move to the queue or stay synchronous; read that file before
+    deciding, it may be intentionally synchronous for a reason)
+  - health/readiness probes
+- Replace the current fire-and-forget in-process dispatch
+  (`Promise.resolve().then(() => eventRouter.dispatch(event))` in
+  `src/routes/webhooks.ts:171-174`, and the equivalent in
+  `src/routes/slack-events.ts`) with `await webhookQueue.enqueue(event)`
+  before returning. Keep the existing shutdown-drain fallback to the
+  Postgres `webhook_queue` table for enqueue failures — don't regress that
+  safety net (runbook §9, risk #3).
+- Keep the in-memory delivery-ID dedup (`src/webhook/dedup.ts`) exactly as
+  today — it's correct here because the receiver stays a single
+  min=max=1 instance.
+- Does NOT need a Postgres connection, MCP server, ACA job launcher, or any
+  of the review orchestration code — strip those out of its dependency graph
+  so its container image and startup are genuinely minimal.
+
+### 3. Worker app
+
+- Everything currently in `src/index.ts` minus the webhook/Slack HTTP
+  routes (those moved to the receiver): DB connection + migrations, MCP
+  callback server, event router, review orchestration, ACA job dispatch,
+  Azure Files workspace cleanup.
+- New loop: instead of receiving events via HTTP, pull messages from the
+  Storage Queue, reconstruct the `WebhookEvent`, and feed it into the
+  existing `eventRouter.dispatch(event)` — the router and everything
+  downstream of it should need **zero changes**.
+- Delete the message only after `dispatch` resolves (success or
+  handled failure) — use `run_state`'s unique `run_key` as the natural
+  idempotency check if a message gets redelivered (visibility timeout
+  expiry, worker restart, etc.) rather than adding new dedup state.
+- Still needs `/healthz`/`/readiness` for ACA probes, and still serves
+  `/internal/mcp/:serverName` for agent job callbacks — unchanged.
+
+### 4. `deploy.sh` changes
+
+- Provision the Storage Queue (main + poison) on `kodiaistg`.
+- Split the current single Container App block (`deploy.sh:~800-965`) into
+  two: receiver (small resources — start with `0.25` vCPU / `0.5Gi`) and
+  worker (keep current `1.75` vCPU / `3.5Gi` via existing `ACA_CPU`/
+  `ACA_MEMORY` env vars). Worker keeps `minReplicas=1, maxReplicas=1`
+  (reuse the existing `ACA_MIN_REPLICAS`/`ACA_MAX_REPLICAS` guard logic at
+  `deploy.sh:97-121` — it should still refuse `ACA_MAX_REPLICAS > 1` for the
+  worker, since the MCP registry constraint hasn't changed).
+- Receiver needs its own ingress/probes; worker keeps ingress only for the
+  MCP callback path (`/internal/mcp/*`) plus probes — it no longer needs
+  public ingress for webhooks.
+- Both need the storage queue connection info wired in (managed identity,
+  matching how other Azure resource access is configured in this script).
+- Keep the whole script idempotent/re-runnable, matching its existing style
+  (see the header comment in `deploy.sh` — it explicitly documents this
+  property; don't break it).
+
+## Tests to add/update
+
+- Update whichever tests currently assert the fire-and-forget dispatch
+  behavior in `src/routes/webhooks.ts`/`src/routes/slack-events.ts` (check
+  `src/index.test.ts` and any route-level tests) to assert enqueue instead.
+- New test for the poison-queue/dequeue-count logic.
+- New test proving a redelivered message (simulate visibility-timeout
+  expiry) doesn't produce a duplicate published review comment — this
+  should be provable using the existing `run_state`/idempotency machinery,
+  which is the point of reusing it.
+- `scripts/deploy.test.ts` already exists and presumably asserts things
+  about the current single-app `deploy.sh` shape — update it for the
+  two-app topology.
+
+## Acceptance criteria
+
+- A GitHub or Slack webhook delivered to the receiver gets acked within the
+  same latency envelope as today (no LLM/Octokit work happens before the
+  200/ack).
+- The worker processes queued messages and produces identical review output
+  to today's in-process dispatch — no behavior change to review orchestration.
+- Killing the worker mid-processing and letting the queue redeliver the
+  message does not produce a duplicate published comment.
+- `deploy.sh` run twice in a row is a no-op the second time (idempotency
+  preserved).
+- Worker is provably capped at 1 replica (`ACA_MAX_REPLICAS` guard still
+  rejects >1).
+
+Do not implement `minReplicas=0` on the worker in this change — that's
+explicitly deferred to the next milestone per the rollout plan in
+`docs/runbooks/azure-cost-architecture-review.md` §9.

--- a/scripts/deploy.test.ts
+++ b/scripts/deploy.test.ts
@@ -81,4 +81,9 @@ describe("deploy.sh", () => {
     expect(deployScript).not.toContain("MCP_TOKEN_REGISTRY_BACKEND");
     expect(deployScript).toContain("ACA_MAX_REPLICAS > 1 is not supported");
   });
+
+  test("defaults the orchestrator to measured cost-conscious Container Apps resources", () => {
+    expect(deployScript).toContain("ACA_CPU=${ACA_CPU:-1.75}");
+    expect(deployScript).toContain("ACA_MEMORY=${ACA_MEMORY:-3.5Gi}");
+  });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -7,4 +7,12 @@ describe("production server entrypoint", () => {
     expect(source).toContain("Bun.serve");
     expect(source).not.toMatch(/export\s+default\s*\{/);
   });
+
+  test("does not block startup on Azure Files stale workspace cleanup", async () => {
+    const source = await Bun.file(new URL("./index.ts", import.meta.url)).text();
+
+    expect(source).toContain("scheduleAzureFilesWorkspaceCleanup");
+    expect(source).toContain("void cleanupStaleAzureFilesWorkspaceDirs");
+    expect(source).not.toContain("const azureFilesStaleCount = await cleanupStaleAzureFilesWorkspaceDirs");
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,25 +95,38 @@ const jobQueue = createJobQueue(logger, { requestTracker });
 const reviewWorkCoordinator = createReviewWorkCoordinator();
 const workspaceManager = createWorkspaceManager(githubApp, logger);
 
+function resolveAzureFilesWorkspaceStaleThresholdMs(): number {
+  const parsed = Number.parseInt(
+    process.env.AZURE_FILES_WORKSPACE_STALE_MS ?? String(AZURE_FILES_WORKSPACE_STALE_THRESHOLD_MS),
+    10,
+  );
+  return Number.isFinite(parsed) && parsed > 0
+    ? parsed
+    : AZURE_FILES_WORKSPACE_STALE_THRESHOLD_MS;
+}
+
+function scheduleAzureFilesWorkspaceCleanup(): void {
+  void cleanupStaleAzureFilesWorkspaceDirs({
+    mountBase: process.env.AZURE_FILES_WORKSPACE_MOUNT ?? "/mnt/kodiai-workspaces",
+    staleThresholdMs: resolveAzureFilesWorkspaceStaleThresholdMs(),
+    logger,
+  })
+    .then((staleCount) => {
+      if (staleCount > 0) {
+        logger.info({ staleCount }, "Cleaned up stale Azure Files workspaces");
+      }
+    })
+    .catch((err) => {
+      logger.warn({ err }, "Azure Files workspace cleanup failed (non-fatal)");
+    });
+}
+
 // Defense-in-depth: clean up any stale workspaces from previous runs
 const staleCount = await workspaceManager.cleanupStale();
 if (staleCount > 0) {
   logger.info({ staleCount }, "Cleaned up stale workspaces from previous run");
 }
-const azureFilesStaleThresholdMs = Number.parseInt(
-  process.env.AZURE_FILES_WORKSPACE_STALE_MS ?? String(AZURE_FILES_WORKSPACE_STALE_THRESHOLD_MS),
-  10,
-);
-const azureFilesStaleCount = await cleanupStaleAzureFilesWorkspaceDirs({
-  mountBase: process.env.AZURE_FILES_WORKSPACE_MOUNT ?? "/mnt/kodiai-workspaces",
-  staleThresholdMs: Number.isFinite(azureFilesStaleThresholdMs) && azureFilesStaleThresholdMs > 0
-    ? azureFilesStaleThresholdMs
-    : AZURE_FILES_WORKSPACE_STALE_THRESHOLD_MS,
-  logger,
-});
-if (azureFilesStaleCount > 0) {
-  logger.info({ staleCount: azureFilesStaleCount }, "Cleaned up stale Azure Files workspaces");
-}
+scheduleAzureFilesWorkspaceCleanup();
 
 // PostgreSQL connection (all stores share single connection pool)
 const { sql, close: closeDb } = createDbClient({ logger });


### PR DESCRIPTION
## Summary
- lower the default ACA orchestrator resource footprint to 1.75 vCPU / 3.5Gi based on observed utilization
- move Azure Files stale workspace cleanup out of the startup critical path so server bind/readiness is not blocked by share cleanup
- add the Azure cost architecture review and the scoped Option 3 milestone 1 implementation prompt

## Verification
- bun test src/index.test.ts scripts/deploy.test.ts
- bunx eslint scripts/deploy.test.ts src/index.test.ts src/index.ts
- git diff --check