### PR TITLE
Skip Weblate-authored PR reviews

### DIFF
--- a/src/handlers/review-skip-author-gate.test.ts
+++ b/src/handlers/review-skip-author-gate.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import type { Logger } from "pino";
+import { evaluateReviewSkipAuthorGate } from "./review-skip-author-gate.ts";
+
+function makeLogger() {
+  const entries: Array<{ data: Record<string, unknown>; message: string }> = [];
+  return {
+    entries,
+    logger: {
+      info(data: Record<string, unknown>, message: string) {
+        entries.push({ data, message });
+      },
+    } as unknown as Pick<Logger, "info">,
+  };
+}
+
+describe("evaluateReviewSkipAuthorGate", () => {
+  test("continues when the PR author is not configured to skip", () => {
+    const { logger, entries } = makeLogger();
+
+    const decision = evaluateReviewSkipAuthorGate({
+      prNumber: 42,
+      authorLogin: "alice",
+      skipAuthors: ["dependabot[bot]"],
+      logger,
+    });
+
+    expect(decision).toEqual({ action: "continue" });
+    expect(entries).toEqual([]);
+  });
+
+  test("skips and logs when the PR author is configured to skip", () => {
+    const { logger, entries } = makeLogger();
+
+    const decision = evaluateReviewSkipAuthorGate({
+      prNumber: 42,
+      authorLogin: "dependabot[bot]",
+      skipAuthors: ["renovate[bot]", "dependabot[bot]"],
+      logger,
+    });
+
+    expect(decision).toEqual({ action: "skip" });
+    expect(entries).toEqual([
+      {
+        data: { prNumber: 42, author: "dependabot[bot]" },
+        message: "PR author in skipAuthors, skipping review",
+      },
+    ]);
+  });
+
+  test("skips Weblate PRs without requiring repo skipAuthors config", () => {
+    const { logger, entries } = makeLogger();
+
+    const decision = evaluateReviewSkipAuthorGate({
+      prNumber: 42,
+      authorLogin: "weblate",
+      skipAuthors: [],
+      logger,
+    });
+
+    expect(decision).toEqual({ action: "skip" });
+    expect(entries).toEqual([
+      {
+        data: { prNumber: 42, author: "weblate", skipReason: "weblate-author" },
+        message: "PR author is Weblate, skipping review",
+      },
+    ]);
+  });
+});

--- a/src/handlers/review-skip-author-gate.ts
+++ b/src/handlers/review-skip-author-gate.ts
@@ -1,0 +1,40 @@
+import type { Logger } from "pino";
+
+type ReviewSkipAuthorLogger = Pick<Logger, "info">;
+
+const DEFAULT_SKIPPED_AUTHORS = new Set(["weblate", "weblate[bot]"]);
+
+export type ReviewSkipAuthorGateDecision =
+  | { action: "continue" }
+  | { action: "skip" };
+
+export function evaluateReviewSkipAuthorGate(params: {
+  prNumber: number;
+  authorLogin: string;
+  skipAuthors: readonly string[];
+  logger: ReviewSkipAuthorLogger;
+}): ReviewSkipAuthorGateDecision {
+  const normalizedAuthorLogin = params.authorLogin.toLowerCase();
+
+  if (DEFAULT_SKIPPED_AUTHORS.has(normalizedAuthorLogin)) {
+    params.logger.info(
+      {
+        prNumber: params.prNumber,
+        author: params.authorLogin,
+        skipReason: "weblate-author",
+      },
+      "PR author is Weblate, skipping review",
+    );
+    return { action: "skip" };
+  }
+
+  if (params.skipAuthors.includes(params.authorLogin)) {
+    params.logger.info(
+      { prNumber: params.prNumber, author: params.authorLogin },
+      "PR author in skipAuthors, skipping review",
+    );
+    return { action: "skip" };
+  }
+
+  return { action: "continue" };
+}

--- a/src/handlers/review.ts
+++ b/src/handlers/review.ts
@@ -87,6 +87,7 @@ import {
 import {
   writeReviewLearningMemory,
 } from "./review-learning-memory.ts";
+import { evaluateReviewSkipAuthorGate } from "./review-skip-author-gate.ts";
 import {
   formatReviewDetailsSummary,
   classifyRetryFailure,
@@ -1226,12 +1227,13 @@ export function createReviewHandler(deps: {
           }
         }
 
-        // Check skipAuthors
-        if (config.review.skipAuthors.includes(pr.user.login)) {
-          logger.info(
-            { prNumber: pr.number, author: pr.user.login },
-            "PR author in skipAuthors, skipping review",
-          );
+        const skipAuthorGate = evaluateReviewSkipAuthorGate({
+          prNumber: pr.number,
+          authorLogin: pr.user.login,
+          skipAuthors: config.review.skipAuthors,
+          logger,
+        });
+        if (skipAuthorGate.action === "skip") {
           return;
         }
 


### PR DESCRIPTION
## Summary
- add a review skip-author gate around the existing skipAuthors check
- skip PRs authored by Weblate service accounts by default
- cover configured authors and Weblate default skips with focused tests

## Verification
- bun test src/handlers/review-skip-author-gate.test.ts
- bunx eslint src/handlers/review.ts src/handlers/review-skip-author-gate.ts src/handlers/review-skip-author-gate.test.ts
- git diff --cached --check