### PR TITLE
fix: refuse to deploy while jobs are still in flight instead of killing them

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -816,6 +816,63 @@ az containerapp job secret set \
 # -- Deploy Container App -----------------------------------------------------
 echo "==> Deploying container app: $APP_NAME..."
 if az containerapp show --name "$APP_NAME" --resource-group "$RESOURCE_GROUP" --output none 2>/dev/null; then
+  # Single-revision mode means updating the app sends SIGTERM to the currently
+  # running revision. If jobs are still in flight when that happens, the
+  # process only gets a bounded grace window (SHUTDOWN_GRACE_MS +
+  # SHUTDOWN_MAX_TOTAL_GRACE_MS) before it force-exits and abandons them
+  # (see src/lifecycle/shutdown-manager.ts). Refuse to trigger the swap until
+  # the running revision reports zero in-flight work, so a deploy never kills
+  # in-flight jobs -- it waits, or it fails loudly and lets the operator retry.
+  DEPLOY_DRAIN_WAIT_TIMEOUT_SECONDS=${DEPLOY_DRAIN_WAIT_TIMEOUT_SECONDS:-900}
+  DEPLOY_DRAIN_POLL_INTERVAL_SECONDS=${DEPLOY_DRAIN_POLL_INTERVAL_SECONDS:-10}
+  EXISTING_FQDN=$(az containerapp show \
+    --name "$APP_NAME" \
+    --resource-group "$RESOURCE_GROUP" \
+    --query properties.configuration.ingress.fqdn \
+    --output tsv 2>/dev/null || true)
+  if [[ -z "$EXISTING_FQDN" ]]; then
+    echo "WARNING: Could not resolve the running revision's ingress FQDN; skipping the in-flight-job drain check." >&2
+  else
+    echo "==> Checking https://${EXISTING_FQDN}/internal/drain-status for in-flight jobs before deploying..."
+    waited_seconds=0
+    while true; do
+      drain_http_code=$(curl -sS -m 5 -o /tmp/kodiai-drain-status.json -w '%{http_code}' "https://${EXISTING_FQDN}/internal/drain-status" 2>/dev/null || echo 000)
+      if [[ "$drain_http_code" == "404" ]]; then
+        echo "WARNING: Running revision does not expose /internal/drain-status (pre-dates this check); proceeding without an in-flight-job guarantee." >&2
+        break
+      fi
+      if [[ "$drain_http_code" == "200" ]]; then
+        drain_status_json=$(cat /tmp/kodiai-drain-status.json 2>/dev/null || echo '{}')
+        active_total=$(python3 -c '
+import json, sys
+try:
+    print(int(json.loads(sys.argv[1]).get("activeTotal", 0)))
+except Exception:
+    print(-1)
+' "$drain_status_json" 2>/dev/null || echo -1)
+      else
+        active_total=-1
+      fi
+      rm -f /tmp/kodiai-drain-status.json
+      if [[ "$active_total" == "0" ]]; then
+        echo "==> Running revision is idle. Safe to deploy."
+        break
+      fi
+      if (( waited_seconds >= DEPLOY_DRAIN_WAIT_TIMEOUT_SECONDS )); then
+        echo "ERROR: Refusing to deploy -- the running revision still reports in-flight work (or was unreachable) after waiting ${DEPLOY_DRAIN_WAIT_TIMEOUT_SECONDS}s (last HTTP status: ${drain_http_code})." >&2
+        echo "        Re-run deploy.sh once the running revision is idle, or raise DEPLOY_DRAIN_WAIT_TIMEOUT_SECONDS if long-running jobs are expected." >&2
+        exit 1
+      fi
+      if [[ "$active_total" == "-1" ]]; then
+        echo "    Could not read drain-status from the running revision yet (HTTP ${drain_http_code}, ${waited_seconds}s/${DEPLOY_DRAIN_WAIT_TIMEOUT_SECONDS}s); retrying..."
+      else
+        echo "    Waiting for ${active_total} in-flight job(s)/request(s) to finish before deploying (${waited_seconds}s/${DEPLOY_DRAIN_WAIT_TIMEOUT_SECONDS}s)..."
+      fi
+      sleep "$DEPLOY_DRAIN_POLL_INTERVAL_SECONDS"
+      waited_seconds=$((waited_seconds + DEPLOY_DRAIN_POLL_INTERVAL_SECONDS))
+    done
+  fi
+
   REVISION_SUFFIX="deploy-${SOURCE_COMMIT_SHORT}-$(date +%Y%m%d-%H%M%S)"
   echo "==> Updating existing container app (revision: $REVISION_SUFFIX)..."
   APP_YAML=$(mktemp --suffix=.yaml)

--- a/scripts/deploy.test.ts
+++ b/scripts/deploy.test.ts
@@ -86,4 +86,17 @@ describe("deploy.sh", () => {
     expect(deployScript).toContain("ACA_CPU=${ACA_CPU:-1.75}");
     expect(deployScript).toContain("ACA_MEMORY=${ACA_MEMORY:-3.5Gi}");
   });
+
+  test("waits for the running revision to drain in-flight jobs before triggering a revision swap", () => {
+    const showIndex = deployScript.indexOf('if az containerapp show --name "$APP_NAME"');
+    const drainCheckIndex = deployScript.indexOf("/internal/drain-status");
+    const revisionSuffixIndex = deployScript.indexOf('REVISION_SUFFIX="deploy-${SOURCE_COMMIT_SHORT}-$(date +%Y%m%d-%H%M%S)"');
+
+    expect(showIndex).toBeGreaterThan(-1);
+    expect(drainCheckIndex).toBeGreaterThan(showIndex);
+    expect(revisionSuffixIndex).toBeGreaterThan(drainCheckIndex);
+    expect(deployScript).toContain('active_total=$(python3 -c');
+    expect(deployScript).toContain("Refusing to deploy -- the running revision still reports in-flight work");
+    expect(deployScript).toContain("DEPLOY_DRAIN_WAIT_TIMEOUT_SECONDS=${DEPLOY_DRAIN_WAIT_TIMEOUT_SECONDS:-900}");
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -650,7 +650,7 @@ app.route("/webhooks/slack/commands", createSlackCommandRoutes({
   logger,
   profileStore: contributorProfileStore,
 }));
-app.route("/", createHealthRoutes({ githubApp, logger, sql }));
+app.route("/", createHealthRoutes({ githubApp, logger, sql, requestTracker }));
 
 // MCP HTTP routes — internal endpoint for ACA agent jobs to call MCP tools
 app.route("/", createMcpHttpRoutes(mcpJobRegistry, logger));

--- a/src/routes/health.test.ts
+++ b/src/routes/health.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, mock, test } from "bun:test";
 import { createHealthRoutes } from "./health.ts";
 import type { GitHubApp } from "../auth/github-app.ts";
 import type { Sql } from "../db/client.ts";
+import type { RequestTracker } from "../lifecycle/types.ts";
 import type { Logger } from "pino";
 
 function createMockLogger(): Logger {
@@ -12,6 +13,15 @@ function createMockLogger(): Logger {
     error: mock(() => undefined),
     child: mock(() => createMockLogger()),
   } as unknown as Logger;
+}
+
+function createFakeRequestTracker(counts: { requests: number; jobs: number } = { requests: 0, jobs: 0 }): RequestTracker {
+  return {
+    trackRequest: () => () => undefined,
+    trackJob: () => () => undefined,
+    activeCount: () => ({ requests: counts.requests, jobs: counts.jobs, total: counts.requests + counts.jobs }),
+    waitForDrain: async () => undefined,
+  };
 }
 
 describe("createHealthRoutes", () => {
@@ -25,7 +35,7 @@ describe("createHealthRoutes", () => {
       }),
     } as unknown as GitHubApp;
 
-    const app = createHealthRoutes({ sql, githubApp, logger: createMockLogger() });
+    const app = createHealthRoutes({ sql, githubApp, logger: createMockLogger(), requestTracker: createFakeRequestTracker() });
     const response = await app.request("/healthz");
 
     expect(response.status).toBe(200);
@@ -41,7 +51,7 @@ describe("createHealthRoutes", () => {
       checkConnectivity: mock(async () => false),
     } as unknown as GitHubApp;
 
-    const app = createHealthRoutes({ sql, githubApp, logger });
+    const app = createHealthRoutes({ sql, githubApp, logger, requestTracker: createFakeRequestTracker() });
     const response = await app.request("/readiness");
 
     expect(response.status).toBe(200);
@@ -68,6 +78,7 @@ describe("createHealthRoutes", () => {
       sql,
       githubApp,
       logger,
+      requestTracker: createFakeRequestTracker(),
       readinessDependencyTimeoutMs: 1,
     });
     const response = await app.request("/readiness");
@@ -97,7 +108,7 @@ describe("createHealthRoutes", () => {
       }),
     } as unknown as GitHubApp;
 
-    const app = createHealthRoutes({ sql, githubApp, logger });
+    const app = createHealthRoutes({ sql, githubApp, logger, requestTracker: createFakeRequestTracker() });
     const response = await app.request("/readiness");
 
     expect(response.status).toBe(200);
@@ -118,5 +129,37 @@ describe("createHealthRoutes", () => {
     expect(serializedLogCall).not.toContain("failed");
     expect(serializedLogCall).not.toContain("error");
     expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  test("/internal/drain-status reports zero when idle so a deploy can proceed", async () => {
+    const sql = mock(async () => []) as unknown as Sql;
+    const githubApp = { checkConnectivity: mock(async () => true) } as unknown as GitHubApp;
+
+    const app = createHealthRoutes({
+      sql,
+      githubApp,
+      logger: createMockLogger(),
+      requestTracker: createFakeRequestTracker({ requests: 0, jobs: 0 }),
+    });
+    const response = await app.request("/internal/drain-status");
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ activeRequests: 0, activeJobs: 0, activeTotal: 0 });
+  });
+
+  test("/internal/drain-status reports in-flight jobs so a deploy waits instead of killing them", async () => {
+    const sql = mock(async () => []) as unknown as Sql;
+    const githubApp = { checkConnectivity: mock(async () => true) } as unknown as GitHubApp;
+
+    const app = createHealthRoutes({
+      sql,
+      githubApp,
+      logger: createMockLogger(),
+      requestTracker: createFakeRequestTracker({ requests: 1, jobs: 9 }),
+    });
+    const response = await app.request("/internal/drain-status");
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ activeRequests: 1, activeJobs: 9, activeTotal: 10 });
   });
 });

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -2,12 +2,14 @@ import { Hono } from "hono";
 import type { Logger } from "pino";
 import type { GitHubApp } from "../auth/github-app.ts";
 import type { Sql } from "../db/client.ts";
+import type { RequestTracker } from "../lifecycle/types.ts";
 import { raceWithTimeout } from "../lib/with-timeout.ts";
 
 interface HealthRouteDeps {
   githubApp: GitHubApp;
   logger: Logger;
   sql: Sql;
+  requestTracker: RequestTracker;
   readinessDependencyTimeoutMs?: number;
   readinessDependencyCacheTtlMs?: number;
 }
@@ -64,6 +66,7 @@ export function createHealthRoutes(deps: HealthRouteDeps): Hono {
   const {
     githubApp,
     logger,
+    requestTracker,
     readinessDependencyTimeoutMs = 1_000,
     readinessDependencyCacheTtlMs = DEFAULT_READINESS_DEPENDENCY_CACHE_TTL_MS,
   } = deps;
@@ -145,6 +148,19 @@ export function createHealthRoutes(deps: HealthRouteDeps): Hono {
           reason: "GitHub API connectivity check degraded",
         });
     }
+  });
+
+  // Drain status: exposes in-flight request/job counts so a deploy can wait
+  // for this revision to go idle before triggering a swap, instead of ever
+  // sending SIGTERM while work is still running. See deploy.sh's pre-deploy
+  // drain check.
+  app.get("/internal/drain-status", (c) => {
+    const counts = requestTracker.activeCount();
+    return c.json({
+      activeRequests: counts.requests,
+      activeJobs: counts.jobs,
+      activeTotal: counts.total,
+    });
   });
 
   return app;


### PR DESCRIPTION
## Summary
Prod log review of the last 2 weeks turned up two incidents (2026-07-19 with 12 jobs, 2026-07-27 with 9 jobs) where a deploy's SIGTERM landed while jobs were actively running. `shutdown-manager.ts`'s bounded grace window (180s + 360s extended) expired and the process force-exited, logging "work abandoned" and dropping that in-flight work.

- Adds `GET /internal/drain-status` exposing the running revision's in-flight request/job counts from `RequestTracker.activeCount()`.
- `deploy.sh` now polls that endpoint on the currently-running revision *before* triggering a revision swap (single-revision mode), and waits for it to report zero in-flight work. If it never drains within `DEPLOY_DRAIN_WAIT_TIMEOUT_SECONDS` (default 900s), the deploy fails loudly instead of proceeding and abandoning jobs.
- A running revision that pre-dates this endpoint (404) logs a warning and proceeds — there was never any visibility into its job state either way, so this is a purely additive safety improvement with no worse behavior on rollout.
- The in-process `shutdown-manager.ts` force-exit fallback is left in place as a last-resort safety net for shutdowns outside deploy.sh's control (e.g. platform-initiated), but normal deploys should never reach it anymore.

## Test plan
- [x] `bun test src/routes/health.test.ts scripts/deploy.test.ts` — new drain-status endpoint tests + deploy.sh drain-check assertions pass
- [x] `bun run test:unit` — 6869 pass
- [x] `bun run check:orphaned-tests` passes
- [x] `tsc --noEmit` clean
- [x] `bash -n deploy.sh` — syntax OK