### PR TITLE
fix: bound every job-queue job with a hard timeout so a stalled one can't block its lane forever

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -92,7 +92,8 @@ const gistPublisher = createGistPublisher(botUserClient, logger);
 const requestTracker = createRequestTracker();
 
 // Job infrastructure
-const jobQueue = createJobQueue(logger, { requestTracker });
+const jobQueueHardTimeoutMs = parseInt(process.env.JOB_QUEUE_HARD_TIMEOUT_MS ?? "", 10) || undefined;
+const jobQueue = createJobQueue(logger, { requestTracker, hardTimeoutMs: jobQueueHardTimeoutMs });
 const reviewWorkCoordinator = createReviewWorkCoordinator();
 const workspaceManager = createWorkspaceManager(githubApp, logger);
 

--- a/src/jobs/queue.test.ts
+++ b/src/jobs/queue.test.ts
@@ -262,3 +262,30 @@ test("createJobQueue releases drain tracking when a job throws", async () => {
 
   expect(counts.active).toBe(0);
 });
+
+test("createJobQueue abandons a job that stalls forever instead of blocking its lane forever", async () => {
+  const { tracker, counts } = createRequestTrackerFake();
+  const queue = createJobQueue(createNoopLogger(), { requestTracker: tracker, hardTimeoutMs: 20 });
+
+  const hungJob = queue.enqueue(
+    7,
+    () => new Promise<void>(() => undefined),
+    { key: "same-pr", jobType: "pull-request-review" },
+  );
+
+  await expect(hungJob).rejects.toThrow(/hard timeout/i);
+  expect(counts.active).toBe(0);
+
+  // The lane must be released so a later job for the same key can still run,
+  // instead of queuing forever behind the abandoned one.
+  const nextJobRan = await queue.enqueue(7, async () => "ran", { key: "same-pr" });
+  expect(nextJobRan).toBe("ran");
+});
+
+test("createJobQueue does not time out jobs that finish within the hard timeout budget", async () => {
+  const queue = createJobQueue(createNoopLogger(), { hardTimeoutMs: 10_000 });
+
+  const result = await queue.enqueue(7, async () => "done");
+
+  expect(result).toBe("done");
+});

--- a/src/jobs/queue.ts
+++ b/src/jobs/queue.ts
@@ -8,10 +8,20 @@ import type {
   JobSnapshot,
 } from "./types.ts";
 import type { RequestTracker } from "../lifecycle/types.ts";
+import { rejectWithTimeout } from "../lib/with-timeout.ts";
 
 const DEFAULT_JOB_LANE: JobLane = "review";
 const QUEUED_PHASE = "queued";
 const RUNNING_PHASE = "running";
+
+// Last-resort watchdog: a job whose work stalls on an unbounded I/O call (e.g.
+// a network-mounted workspace filesystem hang) would otherwise never settle,
+// permanently occupying its lane and its RequestTracker slot -- blocking every
+// later job for the same key forever and starving the deploy drain check
+// (see src/routes/health.ts's /internal/drain-status). This does not cancel
+// the stalled work (JS has no such mechanism); it abandons waiting on it so
+// the queue and the request tracker can move on.
+const DEFAULT_JOB_HARD_TIMEOUT_MS = 20 * 60 * 1000;
 
 type InstallationQueueScopes = Map<string, PQueue>;
 type InstallationActiveJobs = Map<string, JobSnapshot>;
@@ -28,8 +38,12 @@ type InstallationActiveJobs = Map<string, JobSnapshot>;
  * enqueue until completion, so graceful-shutdown drain waits for queued jobs
  * even when the caller fire-and-forgets the enqueue promise.
  */
-export function createJobQueue(logger: Logger, opts?: { requestTracker?: RequestTracker }): JobQueue {
+export function createJobQueue(
+  logger: Logger,
+  opts?: { requestTracker?: RequestTracker; hardTimeoutMs?: number },
+): JobQueue {
   const requestTracker = opts?.requestTracker;
+  const hardTimeoutMs = opts?.hardTimeoutMs ?? DEFAULT_JOB_HARD_TIMEOUT_MS;
   const queueScopes = new Map<number, InstallationQueueScopes>();
   const activeJobs = new Map<number, InstallationActiveJobs>();
   let nextJobId = 1;
@@ -239,7 +253,13 @@ export function createJobQueue(logger: Logger, opts?: { requestTracker?: Request
           );
 
           try {
-            const value = await fn(waitMetadata);
+            const value = await rejectWithTimeout(fn(waitMetadata), {
+              timeoutMs: hardTimeoutMs,
+              createTimeoutError: () =>
+                new Error(
+                  `Job exceeded hard timeout of ${hardTimeoutMs}ms and was abandoned (jobType=${context?.jobType ?? "unknown"}, key=${key}); likely stalled on an unbounded I/O call`,
+                ),
+            });
             logger.info(
               {
                 jobId,


### PR DESCRIPTION
## Summary
Follow-up investigation on the "8 jobs abandoned" event from the v0.50 deploy (#201). It turned out not to be 8 unrelated transient jobs that just hadn't finished yet -- log analysis of the old revision's full 61-hour lifetime found **2 `pull-request-review` jobs genuinely hung forever**:

- `xbmc/official-kodi-remote-ios#1503` -- started 2026-07-27T18:15:04, never completed (stuck >2 days)
- `xbmc/kodiai#199` (this session's own sweep PR) -- started 2026-07-29T15:40:18, never completed (stuck ~7h)

Because the job queue serializes jobs by PR key, 2 more review requests for `#1503` queued up behind the hung one and could never run either. Each of the 4 stuck jobs also holds the outer per-webhook-delivery tracker slot (since that dispatch chain awaits the hung job too) -- 4 x 2 = exactly the 8 `abandonedJobs` reported at force-exit.

The hang traces to unbounded filesystem I/O: the last log for the `#199` job was prompt-build completion: `executor.execute()` never even logged its first line (`loadRepoConfig`'s `Bun.file()` read against the Azure-Files-mounted workspace), meaning it stalled before doing anything else. JS has no way to cancel a stuck syscall once issued.

This isn't just "one review got lost" -- a permanently-stuck job also permanently occupies its `RequestTracker` slot, which means the drain check just shipped in #201 would never see `activeTotal` reach zero if this recurs, and every future deploy would hard-fail after 15 minutes instead of proceeding.

## Fix
Wrap every `jobs/queue.ts` job in a 20-minute hard timeout (configurable via `JOB_QUEUE_HARD_TIMEOUT_MS`), using the existing no-throw `rejectWithTimeout` primitive. On timeout, the queue stops waiting on the stalled work (it can't be cancelled, so it keeps running orphaned in the background) and settles the job as failed -- releasing its lane for the next same-key job and its tracker slot for the deploy drain check. This applies universally to every job type (`review`, `mention`, `feedback-sync`, `addon-check`, etc.), not just `pull-request-review`.

## Test plan
- [x] New test: a job that never resolves gets abandoned after the hard timeout, and a later job for the *same key* can still run afterward (proves the lane is released)
- [x] New test: a job finishing within budget is unaffected
- [x] `bun test src/jobs/queue.test.ts` -- 9 pass
- [x] `bun run test:unit` -- 6871 pass
- [x] `bun run check:orphaned-tests` passed
- [x] `bunx tsc --noEmit` clean
- [x] `bun run lint` clean