### PR TITLE
fix: generalize semantic-fanout turn-budget scaling beyond xbmc/xbmc GUI paths

### DIFF
--- a/src/lib/review-routing.test.ts
+++ b/src/lib/review-routing.test.ts
@@ -96,6 +96,26 @@ describe("review-routing", () => {
     })).toBe(SEMANTIC_FANOUT_REVIEW_MAX_TURNS);
   });
 
+  test("raises low-risk full-review turn budget for any changed C/C++/Objective-C header, not just xbmc/xbmc GUI paths", () => {
+    expect(resolveReviewMaxTurnsOverride({
+      taskType: TASK_TYPES.REVIEW_FULL,
+      timeoutRiskLevel: "low",
+      baseMaxTurns: 25,
+      changedFiles: [
+        "XBMC Remote/AppDelegate.m",
+        "XBMC Remote/ECSlidingViewController/ECSlidingViewController.h",
+        "XBMC Remote/NowPlaying.h",
+      ],
+    })).toBe(SEMANTIC_FANOUT_REVIEW_MAX_TURNS);
+
+    expect(resolveReviewMaxTurnsOverride({
+      taskType: TASK_TYPES.REVIEW_FULL,
+      timeoutRiskLevel: "low",
+      baseMaxTurns: 25,
+      changedFiles: ["include/widget.hpp"],
+    })).toBe(SEMANTIC_FANOUT_REVIEW_MAX_TURNS);
+  });
+
   test("does not raise turn budget for unrelated event or message paths", () => {
     expect(resolveReviewMaxTurnsOverride({
       taskType: TASK_TYPES.REVIEW_FULL,

--- a/src/lib/review-routing.ts
+++ b/src/lib/review-routing.ts
@@ -73,6 +73,8 @@ export function resolveReviewTaskRouting(params: {
   };
 }
 
+const HEADER_FILE_EXTENSION_PATTERN = /\.(h|hh|hpp|hxx|h\+\+)$/;
+
 export function hasSemanticReviewFanout(changedFiles: readonly string[] | undefined): boolean {
   if (!changedFiles || changedFiles.length === 0) {
     return false;
@@ -81,8 +83,13 @@ export function hasSemanticReviewFanout(changedFiles: readonly string[] | undefi
   return changedFiles.some((filePath) => {
     const normalized = filePath.toLowerCase().replace(/\\/g, "/");
     const isGuiPath = normalized.includes("/guilib/") || normalized.startsWith("guilib/");
+    // A changed C/C++/Objective-C header is an interface change: every file
+    // that #includes it is a hidden reviewer of this diff, regardless of repo
+    // or naming convention -- not just xbmc/xbmc's own GUI subsystem.
+    const isHeaderFile = HEADER_FILE_EXTENSION_PATTERN.test(normalized);
 
     return isGuiPath
+      || isHeaderFile
       || normalized.includes("guiwindow")
       || normalized.includes("guicontrol")
       || normalized.includes("buttoncontrol")


### PR DESCRIPTION
## Summary
Root-caused why `@kodiai review` ran out of its turn budget on `xbmc/official-kodi-remote-ios#1503` -- a trivial 22-line, 8-file Objective-C diff (a clang-warnings cleanup) touching 4 header files. The model actually did real work (Read/Grep/Glob/ToolSearch, spawned a sub-`Agent`) but hit the 25-turn ceiling before finishing (`conclusion: "expected_bounded"`, `stopReason: "tool_use"`).

`hasSemanticReviewFanout` in `src/lib/review-routing.ts` only recognizes `xbmc/xbmc`-specific GUI substrings (`guilib`, `guiwindow`, `guicontrol`, `buttoncontrol`, `windowmanager`, `playercorefactory`) as fanout signals that scale up the turn budget. Every other installed repo -- including this one -- always gets the plain default budget with zero headroom, no matter what the diff actually touches.

A changed C/C++/Objective-C header is an interface change: every file that `#include`s it is effectively a hidden reviewer of the diff, in any repo, not just `xbmc/xbmc`. This generalizes the heuristic to detect `.h`/`.hh`/`.hpp`/`.hxx`/`.h++` changes generically (in addition to, not instead of, the existing `xbmc/xbmc`-specific signals) and scale the budget the same way.

## Test plan
- [x] New test: header changes in a non-`xbmc/xbmc` repo (mirroring `#1503`'s actual changed files) now raise the turn budget
- [x] New test: a generic `.hpp` change raises the budget too
- [x] Existing tests confirming `.ts`/unrelated paths still don't raise it, unaffected
- [x] `bun test src/lib/review-routing.test.ts` -- 14 pass
- [x] `bun run test:unit` -- 6872 pass
- [x] `bunx tsc --noEmit` clean
- [x] `bun run lint` clean