### PR TITLE
Review quality overhaul: explore freely, report everything, publish prose findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project are documented in this file.
 
 ## Unreleased
 
+### Changed — review quality overhaul
+
+- Small-diff reviews ("tiny-diff" fast path) now get the full review tool set (`Read`/`Grep`/`Glob` plus git diff/log/show/status) and a prompt that requires tracing the blast radius of each change (callers, removed fallbacks, affected code paths) instead of forbidding exploration and demanding a merge decision "after one focused inspection pass". Small-diff reviews also participate in risk-based turn scaling.
+- The review prompt is now coverage-first: the model is told to report every issue it finds — including uncertain and low-severity ones, with confidence and severity stated — and let the downstream reducer rank and gate, instead of "ONLY report actionable issues" plus "silently omit what you cannot verify". The Epistemic Boundaries section became "Evidence and Verification": full repository read access, library/API behavior claims allowed (with version assumptions stated and verified against vendored sources when present), and unverified-but-plausible risks reported with explicit uncertainty.
+- Senior/expert contributor profiles no longer lower the reporting bar ("only flag issues you're highly confident about" removed); author experience now adapts tone and verbosity only.
+- Findings without a generated fix patch now publish as normal prose inline review comments. Previously an inline comment structurally required a ```suggestion``` patch, so confirmed findings without a safe autofix (e.g. a MAJOR undefined-behavior finding) were reduced to a truncated one-line stub inside the Review Details block.
+- Default model bumped to `claude-sonnet-5` (same list price as Sonnet 4.5, adaptive thinking on by default). Default `maxTurns` raised from 25 to 40, and review prompt section budgets raised (diff context 12k→32k chars, knowledge 3.6k→8k, instructions 16k→24k) so large PRs stop losing thousands of tokens of context to trimming.
+- User-visible PR comments no longer embed internal telemetry (review plan/reducer/candidate-publication/M072 bridge/lifecycle/validation-truth lines, redaction flag dumps); those stay in structured logs. The token-usage footer now includes prompt-cache read/write counts so cost is interpretable.
+
+### Fixed
+
+- Review reducer no longer silently drops findings whose confidence field is missing (`Number(undefined) >= min` was always false), and the default confidence floor (50) no longer discards every minor style/documentation finding that the strict profile promises (now 40, the minimum reachable score).
+- `missing-replacement` candidates are no longer double-counted as "fix-eligibility-blocked" while simultaneously being moved to details.
+
 ## v0.50 (2026-07-29)
 
 An exhaustive correctness sweep across review publication, dependency-bump review, knowledge/embedding clustering, wiki sync, review-graph indexing, expertise scoring, and the durable webhook queue, plus a deploy-safety fix so a deploy can no longer kill jobs that are still in flight.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,7 +8,7 @@ For environment variables and application-level config (API keys, database URLs,
 
 ```yaml
 # .kodiai.yml — common configuration
-model: claude-sonnet-4-5-20250929
+model: claude-sonnet-5
 maxTurns: 25
 timeoutSeconds: 600
 
@@ -80,7 +80,7 @@ These fields sit at the root of `.kodiai.yml`, outside any section.
 | | |
 |---|---|
 | **Type** | `string` |
-| **Default** | `"claude-sonnet-4-5-20250929"` |
+| **Default** | `"claude-sonnet-5"` |
 
 The primary LLM model used for tasks. This is the baseline model unless overridden by `models`, `defaultModel`, or task-specific routing.
 
@@ -124,7 +124,7 @@ Per-task-type model overrides. Keys are task type identifiers (e.g., `"review.fu
 
 ```yaml
 models:
-  review.full: claude-sonnet-4-5-20250929
+  review.full: claude-sonnet-5
   mention.reply: gpt-4o-mini
 ```
 

--- a/src/contributor/experience-contract.ts
+++ b/src/contributor/experience-contract.ts
@@ -268,8 +268,8 @@ export function buildContributorExperiencePromptSection(params: {
         "- Use terse finding descriptions (issue + consequence only)",
         "- Omit links to basic documentation",
         "- For MINOR findings, a one-liner is sufficient",
-        "- Focus on architecture and design, not syntax or style",
         "- Use peer-to-peer tone: direct, brief, no hedging",
+        "- Experience context adapts tone and verbosity ONLY. It never lowers the bar for what to report: flag every issue you would flag for any other author, including uncertain ones.",
       ];
 
       if (areaExpertise && areaExpertise.length > 0) {
@@ -277,7 +277,7 @@ export function buildContributorExperiencePromptSection(params: {
         if (strongAreas.length > 0) {
           const topics = strongAreas.map((entry) => entry.topic).join(", ");
           lines.push(
-            `- The author has deep expertise in ${topics}. Only flag issues you're highly confident about.`,
+            `- The author has deep expertise in ${topics}. Keep explanations in those areas minimal, but report findings there at the same threshold as everywhere else.`,
           );
         }
       }

--- a/src/execution/config.test.ts
+++ b/src/execution/config.test.ts
@@ -128,8 +128,8 @@ test("returns defaults when no .kodiai.yml exists", async () => {
   const dir = await mkdtemp(join(tmpdir(), "kodiai-test-"));
   try {
     const { config, warnings } = await loadRepoConfig(dir);
-    expect(config.model).toBe("claude-sonnet-4-5-20250929");
-    expect(config.maxTurns).toBe(25);
+    expect(config.model).toBe("claude-sonnet-5");
+    expect(config.maxTurns).toBe(40);
     expect(config.write.enabled).toBe(false);
     expect(config.write.allowPaths).toEqual([]);
     expect(config.write.denyPaths).toEqual([
@@ -529,7 +529,7 @@ test("falls back to defaults for invalid values with warning", async () => {
   try {
     await writeFile(join(dir, ".kodiai.yml"), "maxTurns: 999\n");
     const { config, warnings } = await loadRepoConfig(dir);
-    expect(config.maxTurns).toBe(25);
+    expect(config.maxTurns).toBe(40);
     expect(warnings.length).toBe(1);
     expect(warnings[0]!.section).toBe("maxTurns");
   } finally {
@@ -762,7 +762,7 @@ test("falls back to defaults for individual top-level scalars", async () => {
       "maxTurns: 999\nmodel: claude-opus-4-20250514\n",
     );
     const { config, warnings } = await loadRepoConfig(dir);
-    expect(config.maxTurns).toBe(25); // default (999 exceeds max 100)
+    expect(config.maxTurns).toBe(40); // default (999 exceeds max 100)
     expect(config.model).toBe("claude-opus-4-20250514"); // preserved
     expect(warnings.length).toBe(1);
     expect(warnings[0]!.section).toBe("maxTurns");
@@ -792,8 +792,8 @@ test("completely invalid config (not an object) falls back to all defaults", asy
   try {
     await writeFile(join(dir, ".kodiai.yml"), "justAString");
     const { config, warnings } = await loadRepoConfig(dir);
-    expect(config.model).toBe("claude-sonnet-4-5-20250929");
-    expect(config.maxTurns).toBe(25);
+    expect(config.model).toBe("claude-sonnet-5");
+    expect(config.maxTurns).toBe(40);
     expect(config.write.enabled).toBe(false);
     expect(config.review.enabled).toBe(true);
     expect(config.mention.enabled).toBe(true);

--- a/src/execution/config.ts
+++ b/src/execution/config.ts
@@ -629,8 +629,8 @@ const modelsSchema = z
   .default({});
 
 const repoConfigSchema = z.object({
-  model: z.string().default("claude-sonnet-4-5-20250929"),
-  maxTurns: z.number().min(1).max(100).default(25),
+  model: z.string().default("claude-sonnet-5"),
+  maxTurns: z.number().min(1).max(100).default(40),
   timeoutSeconds: z.number().min(30).max(1800).default(600),
   systemPromptAppend: z.string().optional(),
   /** Per-task-type model overrides (e.g., "review.full": "gpt-4o-mini"). */
@@ -805,13 +805,13 @@ export async function loadRepoConfig(
   }
 
   // model
-  const modelSchema = z.string().default("claude-sonnet-4-5-20250929");
+  const modelSchema = z.string().default("claude-sonnet-5");
   const modelResult = modelSchema.safeParse(obj.model);
   let model: string;
   if (modelResult.success) {
     model = modelResult.data;
   } else {
-    model = "claude-sonnet-4-5-20250929";
+    model = "claude-sonnet-5";
     warnings.push({
       section: "model",
       issues: modelResult.error.issues.map(
@@ -821,13 +821,13 @@ export async function loadRepoConfig(
   }
 
   // maxTurns
-  const maxTurnsSchema = z.number().min(1).max(100).default(25);
+  const maxTurnsSchema = z.number().min(1).max(100).default(40);
   const maxTurnsResult = maxTurnsSchema.safeParse(obj.maxTurns);
   let maxTurns: number;
   if (maxTurnsResult.success) {
     maxTurns = maxTurnsResult.data;
   } else {
-    maxTurns = 25;
+    maxTurns = 40;
     warnings.push({
       section: "maxTurns",
       issues: maxTurnsResult.error.issues.map(

--- a/src/execution/executor.test.ts
+++ b/src/execution/executor.test.ts
@@ -489,23 +489,14 @@ function createTestableExecutor(deps: {
         const hasGitTools = await $`git -C ${context.workspace.dir} rev-parse --is-inside-work-tree`.quiet().nothrow()
           .then((result) => result.exitCode === 0 && result.stdout.toString().trim() === "true");
         const { TASK_TYPES } = await import("../llm/task-types.ts");
-        const { SMALL_DIFF_REVIEW_BASE_TOOLS } = await import("../lib/review-routing.ts");
-        const isSmallDiffReview = taskType === TASK_TYPES.REVIEW_SMALL_DIFF;
         const isReadOnlyPrMention =
           isMentionEvent &&
           !isWriteMode &&
           context.prNumber !== undefined &&
           taskType === TASK_TYPES.MENTION_RESPONSE;
-        const baseTools = isSmallDiffReview
-          ? [
-              "Read",
-              "Grep",
-              "Glob",
-              ...(hasGitTools ? SMALL_DIFF_REVIEW_BASE_TOOLS.filter((tool) => tool.startsWith("Bash(")) : []),
-            ]
-          : isReadOnlyPrMention
-            ? ["Read", "Grep", ...(hasGitTools ? ["Bash(git diff:*)", "Bash(git status:*)"] : [])]
-            : ["Read", "Grep", "Glob", ...(hasGitTools ? ["Bash(git diff:*)", "Bash(git log:*)", "Bash(git show:*)", "Bash(git status:*)"] : [])];
+        const baseTools = isReadOnlyPrMention
+          ? ["Read", "Grep", ...(hasGitTools ? ["Bash(git diff:*)", "Bash(git status:*)"] : [])]
+          : ["Read", "Grep", "Glob", ...(hasGitTools ? ["Bash(git diff:*)", "Bash(git log:*)", "Bash(git show:*)", "Bash(git status:*)"] : [])];
         const writeTools = isWriteMode ? ["Edit", "Write", "MultiEdit"] : [];
         const mcpTools = buildAllowedMcpTools(Object.keys(mcpFactories));
         const allowedTools = context.allowedToolsOverride ?? [...baseTools, ...writeTools, ...mcpTools];
@@ -1286,7 +1277,7 @@ test("ACA dispatch: explicit review mention stages a review bundle transport wit
   };
 
   expect(agentConfig.taskType).toBe("review.full");
-  expect(agentConfig.maxTurns).toBe(25);
+  expect(agentConfig.maxTurns).toBe(40);
   expect(agentConfig.allowedTools).toContain("Glob");
   expect(agentConfig.allowedTools).toContain("Bash(git log:*)");
   expect(agentConfig.allowedTools).toContain("Bash(git show:*)");
@@ -1302,7 +1293,7 @@ test("ACA dispatch: explicit review mention stages a review bundle transport wit
   });
 });
 
-test("ACA dispatch: explicit small-diff review mention uses constrained review toolset", async () => {
+test("ACA dispatch: explicit small-diff review mention uses full review toolset", async () => {
   tmpDir = await mkdtemp(join(tmpdir(), "kodiai-executor-test-"));
   const sourceRepoDir = join(tmpDir, "source");
   await mkdir(join(sourceRepoDir, "src"), { recursive: true });
@@ -1358,8 +1349,8 @@ test("ACA dispatch: explicit small-diff review mention uses constrained review t
   expect(agentConfig.allowedTools).toContain("Glob");
   expect(agentConfig.allowedTools).toContain("Bash(git diff:*)");
   expect(agentConfig.allowedTools).toContain("Bash(git show:*)");
-  expect(agentConfig.allowedTools).not.toContain("Bash(git log:*)");
-  expect(agentConfig.allowedTools).not.toContain("Bash(git status:*)");
+  expect(agentConfig.allowedTools).toContain("Bash(git log:*)");
+  expect(agentConfig.allowedTools).toContain("Bash(git status:*)");
   expect(agentConfig.allowedTools).toContain("mcp__github_inline_comment__create_inline_comment");
 });
 

--- a/src/execution/executor.ts
+++ b/src/execution/executor.ts
@@ -39,7 +39,6 @@ import {
 } from "../jobs/workspace.ts";
 import type { PromptSectionRecord } from "../telemetry/types.ts";
 import { TASK_TYPES } from "../llm/task-types.ts";
-import { SMALL_DIFF_REVIEW_BASE_TOOLS } from "../lib/review-routing.ts";
 import {
   type ReviewCandidateFinding,
   type ReviewCandidateFindingExecutionResult,
@@ -672,22 +671,15 @@ export function createExecutor(deps: {
         // handler for trigger semantics, but they still need the broader review tool
         // budget. Only conversational PR mentions keep the reduced tool surface.
         const hasGitTools = await hasGitWorkspace(context.workspace.dir);
-        const isSmallDiffReview = taskType === TASK_TYPES.REVIEW_SMALL_DIFF;
         const isReadOnlyPrMention =
           isMentionEvent &&
           !isWriteMode &&
           context.prNumber !== undefined &&
           taskType === TASK_TYPES.MENTION_RESPONSE;
-        const baseTools = isSmallDiffReview
-          ? [
-              "Read",
-              "Grep",
-              "Glob",
-              ...(hasGitTools
-                ? SMALL_DIFF_REVIEW_BASE_TOOLS.filter((tool) => tool.startsWith("Bash("))
-                : []),
-            ]
-          : isReadOnlyPrMention
+        // Small-diff reviews get the same tool surface as full reviews: a tiny
+        // diff can still have a repo-wide blast radius, so the reviewer needs
+        // the freedom to trace callers and read any source file.
+        const baseTools = isReadOnlyPrMention
             ? [
                 "Read",
                 "Grep",

--- a/src/execution/mention-prompt.test.ts
+++ b/src/execution/mention-prompt.test.ts
@@ -606,25 +606,25 @@ describe("buildMentionPrompt", () => {
 // Phase 116: Cross-surface epistemic guardrails (PROMPT-04)
 // ---------------------------------------------------------------------------
 describe("epistemic guardrails on mention surfaces (PROMPT-04)", () => {
-  test("PR mention prompt includes Epistemic Boundaries section", () => {
+  test("PR mention prompt includes Evidence and Verification section", () => {
     const prompt = buildMentionPrompt({
       mention: baseMention(),
       mentionContext: "",
       userQuestion: "Review this please.",
     });
-    expect(prompt).toContain("## Epistemic Boundaries");
-    expect(prompt).toContain("Diff-visible");
-    expect(prompt).toContain("External knowledge");
+    expect(prompt).toContain("## Evidence and Verification");
+    expect(prompt).toContain("full read access to the repository");
+    expect(prompt).toContain("Library and API behavior claims are allowed");
   });
 
-  test("issue mention prompt includes Epistemic Boundaries section", () => {
+  test("issue mention prompt includes Evidence and Verification section", () => {
     const prompt = buildMentionPrompt({
       mention: issueMention(),
       mentionContext: "",
       userQuestion: "What version was this fixed in?",
     });
-    expect(prompt).toContain("## Epistemic Boundaries");
-    expect(prompt).toContain("Diff-visible");
+    expect(prompt).toContain("## Evidence and Verification");
+    expect(prompt).toContain("full read access to the repository");
   });
 
   test("issue mention prompt includes context-visible tier for issue surface", () => {

--- a/src/execution/mention-prompt.ts
+++ b/src/execution/mention-prompt.ts
@@ -331,7 +331,7 @@ export function buildMentionPromptDetails(params: {
     lines.push("### Context-Visible Tier (Issue Mentions)");
     lines.push("");
     lines.push(
-      "For issue mentions, your \"visible context\" includes: the issue body, comment thread, any linked code snippets, and repository information provided in this prompt. Apply the same epistemic rules — assert what you can see, cite accordingly, silently omit what you cannot verify.",
+      "For issue mentions, your \"visible context\" includes: the issue body, comment thread, any linked code snippets, and repository information provided in this prompt. Apply the same evidence rules — assert what you can see, cite accordingly, and state uncertainty explicitly for claims you cannot fully verify.",
     );
   }
 

--- a/src/execution/review-prompt.test.ts
+++ b/src/execution/review-prompt.test.ts
@@ -36,19 +36,21 @@ import { projectContributorExperienceContract } from "../contributor/experience-
 import type { StructuralImpactPayload } from "../structural-impact/types.ts";
 
 describe("small-diff review prompt scope", () => {
-  test("adds a tiny-diff scope contract when requested", () => {
+  test("adds small-diff review guidance when requested", () => {
     const result = buildReviewPromptDetails(baseContext({ smallDiffReview: true }));
 
-    expect(buildSmallDiffScopeSection()).toContain("Inspect the provided diff context first.");
-    expect(result.text).toContain("## Tiny-diff scope contract");
-    expect(result.text).toContain("Do not do generalized architecture exploration.");
+    expect(buildSmallDiffScopeSection()).toContain("Trace the impact of each behavioral change");
+    expect(result.text).toContain("## Small-diff review guidance");
+    expect(result.text).toContain("A small diff is not the same as a small blast radius");
+    expect(result.text).not.toContain("Tiny-diff scope contract");
+    expect(result.text).not.toContain("one focused inspection pass");
     expect(result.sections.some((section) => section.sectionName === "review-small-diff-scope")).toBe(true);
   });
 
-  test("omits the tiny-diff scope contract for normal reviews", () => {
+  test("omits the small-diff review guidance for normal reviews", () => {
     const result = buildReviewPromptDetails(baseContext());
 
-    expect(result.text).not.toContain("## Tiny-diff scope contract");
+    expect(result.text).not.toContain("## Small-diff review guidance");
     expect(result.sections.some((section) => section.sectionName === "review-small-diff-scope")).toBe(false);
   });
   test("omits git command instructions when the remote workspace has no git metadata", () => {
@@ -745,7 +747,7 @@ test("buildReviewPromptDetails reports deterministic budget outcomes without raw
 
   const result = buildReviewPromptDetails(baseContext({
     changedFiles: oversizedChangedFiles,
-    diffContent: `${"+diff line with enough context\n".repeat(700)}${diffOverflowSentinel}`,
+    diffContent: `${"+diff line with enough context\n".repeat(1400)}${diffOverflowSentinel}`,
     customInstructions: `${"Investigate this custom instruction carefully. ".repeat(500)}${instructionOverflowSentinel}`,
     linkedIssues: {
       referencedIssues: Array.from({ length: 18 }, (_, index) => ({
@@ -2020,7 +2022,8 @@ describe("Phase 35: Findings organization and tone", () => {
   test("tone guidelines include epistemic principle", () => {
     const prompt = buildReviewPrompt(baseContext());
     expect(prompt).toContain("Evidence principle");
-    expect(prompt).toContain("Silently omit what you cannot verify");
+    expect(prompt).toContain("state the claim with explicit uncertainty instead of omitting it");
+    expect(prompt).not.toContain("Silently omit what you cannot verify");
   });
 
   // 12. buildPrIntentScopingSection helper includes branch and scoping rules
@@ -2598,58 +2601,40 @@ describe("formatClusterPatterns", () => {
 // Phase 115: Epistemic Boundary Section (PROMPT-01, PROMPT-02, PROMPT-03)
 // ---------------------------------------------------------------------------
 describe("buildEpistemicBoundarySection", () => {
-  test("returns string containing Epistemic Boundaries heading", () => {
+  test("returns string containing Evidence and Verification heading", () => {
     const section = buildEpistemicBoundarySection();
-    expect(section).toContain("## Epistemic Boundaries");
+    expect(section).toContain("## Evidence and Verification");
+    expect(section).not.toContain("## Epistemic Boundaries");
   });
 
-  test("contains allowlist categories (diff-visible, system-provided enrichment)", () => {
+  test("grants full repo read access and instructs verification by reading code", () => {
     const section = buildEpistemicBoundarySection();
-    expect(section).toContain("Diff-visible");
-    expect(section).toContain("System-provided enrichment");
+    expect(section).toContain("full read access to the repository");
+    expect(section).toContain("verify claims by reading the actual code");
   });
 
-  test("contains compact denylist for version/API/library claims not in evidence", () => {
+  test("allows library and API behavior claims with version assumptions stated", () => {
     const section = buildEpistemicBoundarySection();
-    expect(section).toMatch(/version.*API.*release.*library/i);
+    expect(section).toContain("Library and API behavior claims are allowed");
+    expect(section).toContain("state the version assumption explicitly");
   });
 
-  test("states external knowledge claims must be silently omitted", () => {
+  test("instructs reporting unverified-but-plausible risks with stated uncertainty", () => {
     const section = buildEpistemicBoundarySection();
-    expect(section).toMatch(/silently omit/i);
+    expect(section).toContain("report it anyway with your uncertainty stated plainly");
+    expect(section).not.toMatch(/silently omit/i);
   });
 
-  test("allows general programming knowledge (null deref, SQL injection)", () => {
-    const section = buildEpistemicBoundarySection();
-    expect(section).toMatch(/general programming/i);
-  });
-
-  test("defines universal citation rule — diff-visible cites file:line, enrichment cites footnote URL", () => {
+  test("defines citation rule — code claims cite file:line, enrichment cites footnote URL", () => {
     const section = buildEpistemicBoundarySection();
     expect(section).toContain("file:line");
     expect(section).toMatch(/footnote URL/i);
-  });
-
-  test("states no URL = no assertion rule", () => {
-    const section = buildEpistemicBoundarySection();
-    expect(section).toMatch(/no URL.*no assertion|cannot.*assert.*without.*URL/i);
   });
 
   // Phase 116: Surface-neutral language (PROMPT-04)
   test("uses surface-neutral language — does NOT contain 'this review'", () => {
     const section = buildEpistemicBoundarySection();
     expect(section).not.toContain("this review");
-  });
-
-  test("uses 'your response' instead of review-specific language", () => {
-    const section = buildEpistemicBoundarySection();
-    expect(section).toContain("your response");
-  });
-
-  test("stays compact enough for every prompt surface", () => {
-    const section = buildEpistemicBoundarySection();
-    expect(section.split("\n").length).toBeLessThanOrEqual(9);
-    expect(section.length).toBeLessThan(900);
   });
 });
 
@@ -2692,7 +2677,7 @@ describe("truthfulness drift guidance in buildReviewPrompt", () => {
 describe("epistemic section placement in buildReviewPrompt", () => {
   test("epistemic section appears BEFORE conventional commit context", () => {
     const prompt = buildReviewPrompt(baseContext({ conventionalType: { type: "feat", isBreaking: false } }));
-    const epistemicIdx = prompt.indexOf("## Epistemic Boundaries");
+    const epistemicIdx = prompt.indexOf("## Evidence and Verification");
     const conventionalIdx = prompt.indexOf("## Conventional Commit Context");
     expect(epistemicIdx).toBeGreaterThan(-1);
     expect(conventionalIdx).toBeGreaterThan(-1);
@@ -2702,7 +2687,7 @@ describe("epistemic section placement in buildReviewPrompt", () => {
   test("epistemic section appears after focus hints", () => {
     const prompt = buildReviewPrompt(baseContext({ focusHints: ["auth"] }));
     const focusIdx = prompt.indexOf("## Focus Hints");
-    const epistemicIdx = prompt.indexOf("## Epistemic Boundaries");
+    const epistemicIdx = prompt.indexOf("## Evidence and Verification");
     expect(focusIdx).toBeGreaterThan(-1);
     expect(epistemicIdx).toBeGreaterThan(-1);
     expect(epistemicIdx).toBeGreaterThan(focusIdx);

--- a/src/execution/review-prompt.ts
+++ b/src/execution/review-prompt.ts
@@ -160,7 +160,7 @@ function buildSeverityClassificationGuidelines(): string {
     "",
     "**Path context adjustments:**",
     "- Test files: downgrade findings by one severity level (e.g. MAJOR becomes MEDIUM).",
-    "- Config files: only report CRITICAL findings.",
+    "- Config files: report anything that changes runtime/deploy behavior incorrectly at its true severity; skip pure formatting.",
     "- Documentation files: only report factual errors, including mismatched commands, verifier names, config keys, or contradictory section labels in the changed text.",
   ].join("\n");
 }
@@ -412,12 +412,11 @@ export function buildPrIntentScopingSection(
 // ---------------------------------------------------------------------------
 export function buildEpistemicBoundarySection(): string {
   return [
-    "## Epistemic Boundaries",
-    "- Ground every assertion in your response in Diff-visible code/config/tests or System-provided enrichment.",
-    "- Cite Diff-visible claims with `file:line`; cite enrichment with a footnote URL.",
-    "- No URL means no assertion for enrichment; no evidence means silently omit the claim.",
-    "- External knowledge: do not assert version/API release/library behavior facts unless visible in the diff or enrichment.",
-    "- General programming knowledge is allowed when it does not depend on package versions, APIs, or dates.",
+    "## Evidence and Verification",
+    "- You have full read access to the repository (Read/Grep/Glob). Use it: verify claims by reading the actual code — the changed files, their callers, and any dependency source vendored in the repo.",
+    "- Ground assertions in code you have read (cite `file:line`), in System-provided enrichment (cite the footnote URL), or in well-established programming/library knowledge.",
+    "- Library and API behavior claims are allowed. When the claim depends on a specific version, verify it against vendored sources in the repository when present; otherwise state the version assumption explicitly.",
+    "- When you cannot fully verify a claim but the risk is real, report it anyway with your uncertainty stated plainly (e.g. \"if X holds, this breaks Y — worth verifying\"). A clearly-labeled uncertain finding is more useful than a silently dropped one.",
   ].join("\n");
 }
 
@@ -441,7 +440,7 @@ export function buildSecurityPolicySection(): string {
 export function buildToneGuidelinesSection(): string {
   return [
     "## Finding Language Guidelines",
-    "- Evidence principle: Assert what is verifiable from visible context or enrichment. Silently omit what you cannot verify.",
+    "- Evidence principle: Assert what is verifiable from code you read or enrichment. For unverified-but-plausible risks, state the claim with explicit uncertainty instead of omitting it.",
     "- What happens, when, why it matters: each finding must state the concrete failure condition and impact.",
     "- Cite code claims with file:line and enrichment claims with footnote URLs.",
     "- Prefix Preference findings with \"Optional:\" to signal they are non-blocking.",
@@ -1719,15 +1718,14 @@ function buildDepBumpSection(ctx: DepBumpContext): string {
 
 export function buildSmallDiffScopeSection(): string {
   return [
-    "## Tiny-diff scope contract",
+    "## Small-diff review guidance",
     "",
-    "This is a small diff (≤2 files, ≤20 lines). Follow these constraints:",
-    "- Inspect the provided diff context first.",
-    "- Read only the changed file and directly adjacent context.",
-    "- Broaden scope only if the diff itself proves an ambiguity that cannot be resolved without wider context.",
-    "- Do not do generalized architecture exploration.",
-    "- If no actionable issue exists, end without additional exploratory turns.",
-    "- Produce a merge decision after one focused inspection pass.",
+    "This is a small diff (≤2 files, ≤20 lines). A small diff is not the same as a small blast radius:",
+    "a few changed lines in a shared code path can alter behavior for every caller.",
+    "- Start from the provided diff context, then read the full changed function and its surrounding file.",
+    "- Trace the impact of each behavioral change: find the callers of changed functions and any code paths whose behavior the change alters. Use Grep/Glob/Read freely across the repository.",
+    "- If the change replaces or removes an existing branch, condition, or fallback, verify what previously depended on it before concluding the removal is safe.",
+    "- Before approving, confirm you can explain what the code did before, what it does now, and who is affected by the difference.",
   ].join("\n");
 }
 
@@ -2117,15 +2115,18 @@ export function buildReviewPromptDetails(context: {
   const sectionBlocks: Array<{ sectionName: string; text: string; budgetChars: number; budgetOutcome?: PromptBudgetOutcome }> = [];
   const scaleNotes: string[] = [];
   const mode = context.mode ?? "standard";
+  // Budgets sized for claude-sonnet-5 (input tokens are cheap and heavily
+  // prompt-cached; trimming review context costs far more in missed findings
+  // than the extra input tokens cost in dollars).
   const REVIEW_SECTION_BUDGETS = {
     prContext: 2_800,
-    smallDiffScope: 1_200,
-    changeContext: 4_000,
+    smallDiffScope: 1_600,
+    changeContext: 6_000,
     sizeContext: 3_200,
-    graphContext: 4_000,
-    knowledgeContext: 3_600,
-    diffContext: 12_000,
-    instructions: 16_000,
+    graphContext: 6_000,
+    knowledgeContext: 8_000,
+    diffContext: 32_000,
+    instructions: 24_000,
   } as const;
 
   const pushSection = (sectionName: string, lines: string[], budgetChars?: number, budgetOutcome?: PromptBudgetOutcome) => {
@@ -2397,13 +2398,14 @@ export function buildReviewPromptDetails(context: {
   pushInstructionSection("core-rules", [
     "## Rules",
     "",
-    "- ONLY report actionable issues that need to be fixed",
+    "- Report every issue you find, including ones you are uncertain about or consider low-severity. Do not filter for importance or confidence at this stage — a downstream filter ranks and gates findings. Your goal is coverage: it is better to surface a finding that later gets filtered out than to silently drop a real bug.",
+    "- For each finding, include severity and category metadata, and state your uncertainty in the body when a claim is not fully verified.",
     '- NO positive feedback, NO "looks good"',
     "- In standard mode, use the five-section template (What Changed, Strengths, Observations, Suggestions, Verdict) for the summary comment",
     "- ONLY post a summary comment when you have actionable inline issues to report",
     "- Use inline comments for ALL code-specific issues",
     "- When listing items, use (1), (2), (3) format -- NEVER #1, #2, #3 (GitHub treats those as issue links)",
-    "- Focus on correctness and safety, not style preferences",
+    "- Prioritize correctness and safety; guideline violations on changed lines are still findings",
     "",
     buildSeverityClassificationGuidelines(),
     "",

--- a/src/handlers/mention-explicit-review-publication.ts
+++ b/src/handlers/mention-explicit-review-publication.ts
@@ -121,8 +121,20 @@ export async function publishExplicitMentionReviewResult(params: {
       "Attempting explicit mention review approval publish",
     );
 
-    const explicitReviewLifecycleEvidenceLine = buildExplicitReviewLifecycleEvidenceLine(
-      params.explicitReviewFindingLifecycleResult,
+    // Lifecycle telemetry stays in structured logs — the user-facing evidence
+    // list keeps only lines a human reviewer can interpret.
+    params.logger.info(
+      {
+        surface: params.surface,
+        owner: params.owner,
+        repo: params.repo,
+        prNumber: params.prNumber,
+        gate: "explicit-review-publish",
+        lifecycleEvidence: buildExplicitReviewLifecycleEvidenceLine(
+          params.explicitReviewFindingLifecycleResult,
+        ),
+      },
+      "Explicit review lifecycle evidence",
     );
     const approvalEvidence = [
       typeof params.explicitReviewPromptFileCount === "number"
@@ -131,7 +143,6 @@ export async function publishExplicitMentionReviewResult(params: {
       params.usedRepoInspectionTools
         ? "Repo inspection tools were used to verify the changed code."
         : null,
-      explicitReviewLifecycleEvidenceLine,
     ].filter((line): line is string => Boolean(line));
 
     if (!params.canPublishExplicitReviewOutput("explicit mention review publish", params.canonicalReviewSurfaceKey)) {

--- a/src/handlers/mention.test.ts
+++ b/src/handlers/mention.test.ts
@@ -11080,7 +11080,7 @@ describe("createMentionHandler review command", () => {
     expect(capturedPrompt).toContain("You are reviewing pull request #102 in acme/repo.");
     expect(capturedPrompt).toContain("Candidate-Preferred Finding Capture");
     expect(capturedPrompt).toContain("record_candidate_finding");
-    expect(capturedPrompt).toContain("## Tiny-diff scope contract");
+    expect(capturedPrompt).toContain("## Small-diff review guidance");
     expect(capturedPrompt).not.toContain("You MUST post a reply when you are mentioned.");
     expect(capturedMaxTurnsOverride).toBeUndefined();
     expect(capturedEnableInlineTools).toBe(true);
@@ -13579,12 +13579,19 @@ describe("createMentionHandler formatter suggestion intent context", () => {
     });
     expect(JSON.stringify(validationTruthLog?.bindings)).not.toContain(rawCanary);
     expect(body).toContain("Decision: APPROVE");
-    expect(body).toContain("Review finding lifecycle: status=normalized");
-    expect(body).toContain("counts=input:1,recorded:1,rejected:0,unsafeInputFields:0");
-    expect(body).toContain("redaction=privateOnly:y,rawPrompts:n,rawModelOutput:n,candidateBodies:n,toolPayloads:n,secretLike:n,diffs:n,unboundedArrays:n,unsafeFields:0");
+    // Lifecycle evidence moved from the user-visible approval evidence into
+    // structured logs.
+    expect(body).not.toContain("Review finding lifecycle:");
+    expect(body).not.toContain("counts=input:1,recorded:1,rejected:0,unsafeInputFields:0");
     expect(body).toContain("<!-- kodiai:review-output-key:");
     expect(body).not.toContain("Review validation truth:");
     expect(body).not.toContain(rawCanary);
+
+    const lifecycleEvidenceLog = result.infoCalls.find(
+      (entry) => entry.message === "Explicit review lifecycle evidence",
+    );
+    expect(String(lifecycleEvidenceLog?.bindings.lifecycleEvidence)).toContain("Review finding lifecycle: status=normalized");
+    expect(JSON.stringify(lifecycleEvidenceLog?.bindings)).not.toContain(rawCanary);
 
     const publishLog = result.infoCalls.find(
       (entry) => entry.message === "Submitted approval review for explicit mention request"

--- a/src/handlers/review-candidate-verification-integration.test.ts
+++ b/src/handlers/review-candidate-verification-integration.test.ts
@@ -345,11 +345,15 @@ function expectCorrelationEverywhere(scenario: IntegrationScenarioResult) {
     hasCorrelationKey: true,
   });
 
+  // Verification-evidence telemetry moved from the user-visible Review
+  // Details comment into structured logs; visible bodies must not carry it.
   const detailsBody = visibleBodies(scenario).find((body) => body.includes("M070 candidate verification publication"));
-  expect(detailsBody).toContain("metadata=deliveryId:y,reviewOutputKey:y,correlationKey:y");
-  expect(detailsBody).not.toContain("deliveryIdValue:delivery-shadow-metrics");
-  expect(detailsBody).not.toContain(`reviewOutputKeyValue:${scenario.executorInput.reviewOutputKey}`);
-  expect(detailsBody).not.toContain(`correlationKeyValue:${context?.correlationKey}`);
+  expect(detailsBody).toBeUndefined();
+  for (const body of visibleBodies(scenario)) {
+    expect(body).not.toContain("deliveryIdValue:delivery-shadow-metrics");
+    expect(body).not.toContain(`reviewOutputKeyValue:${scenario.executorInput.reviewOutputKey}`);
+    expect(body).not.toContain(`correlationKeyValue:${context?.correlationKey}`);
+  }
 }
 
 function expectAggregateOnlySurfaces(scenario: IntegrationScenarioResult, forbiddenValues: string[]) {
@@ -404,7 +408,7 @@ describe("production-like normal review M070 candidate verification integration"
     expect(scenario.evidence.counts).toMatchObject({ attempted: 1, allowed: 1, denied: 0, published: 1 });
     expect(scenario.evidence.redactionFlags.publicationEvidenceIncluded).toBe(false);
     expectCorrelationEverywhere(scenario);
-    expect(visibleBodies(scenario).filter((body) => body.includes("M070 candidate verification publication"))).toHaveLength(1);
+    expect(visibleBodies(scenario).filter((body) => body.includes("M070 candidate verification publication"))).toHaveLength(0);
   });
 
   test.each([

--- a/src/handlers/review-candidate-verification-publication.test.ts
+++ b/src/handlers/review-candidate-verification-publication.test.ts
@@ -346,8 +346,14 @@ describe("review handler M070 candidate verification publication wiring", () => 
     expect(bridgeIndex).toBeGreaterThanOrEqual(0);
     expect(degradedPublicationIndex).toBeGreaterThan(bridgeIndex);
 
+    // Bridge telemetry moved from the user-visible Review Details comment
+    // into structured logs; the visible fallback body must not carry it.
     const fallbackBody = scenario.issueCreatePayloads.map((payload) => String(payload.body ?? "")).find((body) => body.includes("<summary>Review Details</summary>"));
-    expect(fallbackBody).toContain("M072 candidate publication bridge: status=allowed");
+    expect(fallbackBody).toBeDefined();
+    expect(fallbackBody).not.toContain("M072 candidate publication bridge:");
+
+    const bridgeLog = scenario.entries.find((entry) => entry.data?.gate === "m072-review-handler-publication-bridge");
+    expect(bridgeLog?.data?.candidatePublicationBridgeStatus).toBe("allowed");
   });
 
   test("unsafe candidate bridge diagnostics remain bounded and redact raw canaries from handler publications and logs", async () => {

--- a/src/handlers/review-details-body-base.ts
+++ b/src/handlers/review-details-body-base.ts
@@ -105,6 +105,8 @@ export function resolveReviewDetailsBodyBase(params: {
   tokenUsageSource: {
     inputTokens?: number;
     outputTokens?: number;
+    cacheReadTokens?: number;
+    cacheCreationTokens?: number;
     costUsd?: number;
   };
   structuralImpact: ReviewDetailsBodyBaseParams["structuralImpact"];
@@ -138,6 +140,8 @@ export function resolveReviewDetailsBodyBase(params: {
     tokenUsage: {
       inputTokens: params.tokenUsageSource.inputTokens,
       outputTokens: params.tokenUsageSource.outputTokens,
+      cacheReadTokens: params.tokenUsageSource.cacheReadTokens,
+      cacheCreationTokens: params.tokenUsageSource.cacheCreationTokens,
       costUsd: params.tokenUsageSource.costUsd,
     },
     structuralImpact: params.structuralImpact,

--- a/src/handlers/review.test.ts
+++ b/src/handlers/review.test.ts
@@ -905,7 +905,7 @@ describe("createReviewHandler repository doctrine wiring", () => {
     });
 
     const detailsBlock = extractReviewDetailsBlock(detailsCommentBody);
-    expect(detailsBlock).toContain("doctrine=applied/2/2/0");
+    expect(detailsBlock).not.toContain("doctrine=applied/2/2/0");
     expect(detailsBlock).not.toContain("PROMPT_SECRET_DO_NOT_LEAK");
     expect(detailsBlock).not.toContain("RAW_DOCTRINE_BODY_CANARY");
     expect(detailsBlock).not.toContain("RAW_MIGRATION_CANARY");
@@ -6215,10 +6215,7 @@ describe("createReviewHandler finding extraction", () => {
     expect(detailsCommentBody).toMatch(/Findings: \d+ critical, \d+ major, \d+ medium, \d+ minor/);
     expect(detailsCommentBody).toMatch(/Review completed: \d{4}-\d{2}-\d{2}T/);
     expect(detailsCommentBody).toContain(`<!-- kodiai:review-details:${reviewOutputKey} -->`);
-    expect((detailsCommentBody?.match(/Review finding lifecycle:/g) ?? [])).toHaveLength(1);
-    expect(detailsCommentBody).toContain("Review finding lifecycle: status=normalized");
-    expect(detailsCommentBody).toContain("correlation=repo:y,pull:y,reviewOutputKey:y,deliveryId:y,commit:y");
-    expect(detailsCommentBody).toContain("redaction=privateOnly:y,rawPrompts:n,rawModelOutput:n,candidateBodies:n,toolPayloads:n,secretLike:n,diffs:n,unboundedArrays:n");
+    expect(detailsCommentBody).not.toContain("Review finding lifecycle:");
     expect(detailsCommentBody).not.toContain("RAW_PROMPT_CANARY");
     expect(detailsCommentBody).not.toContain("RAW_MODEL_OUTPUT_CANARY");
     expect(detailsCommentBody).not.toContain("CANDIDATE_BODY_CANARY");
@@ -6371,8 +6368,8 @@ describe("createReviewHandler finding extraction", () => {
     expect(recordedFindings).toHaveLength(1);
     expect(recordedFindings[0]?.title).toBe("Finding that would be filtered");
     expect(deletedCommentIds).toEqual([]);
-    expect(detailsCommentBody).toContain("Review reducer: degraded");
-    expect(detailsCommentBody).toContain("reason=reducer-exception");
+    expect(detailsCommentBody).not.toContain("Review reducer:");
+    expect(detailsCommentBody).not.toContain("reason=reducer-exception");
   });
 
   test("review-comment idempotency accept still publishes Review Details when no canonical issue comment exists yet", async () => {
@@ -16907,15 +16904,29 @@ describe("createReviewHandler ReviewPlan wiring", () => {
     severity: string;
     category: string;
     title: string;
+    body?: string;
     fixReplacementText: string;
   }): string {
     return [
       `**Fix suggestion:** ${params.title}`,
       `Severity: ${params.severity} · Category: ${params.category}`,
+      ...(params.body ? ["", params.body] : []),
       "",
       "```suggestion",
       params.fixReplacementText,
       "```",
+    ].join("\n");
+  }
+
+  function formattedCandidateProseBody(params: {
+    severity: string;
+    category: string;
+    title: string;
+    body?: string;
+  }): string {
+    return [
+      `**${params.severity.toUpperCase()}** (${params.category}): ${params.title}`,
+      ...(params.body ? ["", params.body] : []),
     ].join("\n");
   }
 
@@ -16950,7 +16961,7 @@ describe("createReviewHandler ReviewPlan wiring", () => {
       endLine?: number;
       severity?: string;
       category?: string;
-      fixReplacementText?: string;
+      fixReplacementText?: string | null;
     } = {},
   ) {
     return async (input: ShadowSpecialistSubflowInput): Promise<ShadowSpecialistSubflowResult> => {
@@ -16962,7 +16973,9 @@ describe("createReviewHandler ReviewPlan wiring", () => {
       const endLine = candidate.endLine ?? line;
       const severity = candidate.severity ?? "major";
       const category = candidate.category ?? "correctness";
-      const fixReplacementText = candidate.fixReplacementText ?? candidateFixReplacementText;
+      const fixReplacementText = candidate.fixReplacementText === null
+        ? null
+        : candidate.fixReplacementText ?? candidateFixReplacementText;
       const fingerprint = reviewCandidateFingerprint({
         repo: "acme/repo",
         pullNumber: 101,
@@ -16980,12 +16993,15 @@ describe("createReviewHandler ReviewPlan wiring", () => {
         ...(line === endLine ? { line } : { startLine: line, line: endLine }),
         reviewOutputKey: candidateReviewOutputKey(baseReviewOutputKey, fingerprint),
         deliveryId: String(input.deliveryId ?? ""),
-        body: formattedCandidateFixSuggestionBody({
-          severity,
-          category,
-          title,
-          fixReplacementText,
-        }),
+        body: fixReplacementText === null
+          ? formattedCandidateProseBody({ severity, category, title, body })
+          : formattedCandidateFixSuggestionBody({
+              severity,
+              category,
+              title,
+              body,
+              fixReplacementText,
+            }),
       });
       return {
         trigger: {
@@ -17330,7 +17346,7 @@ describe("createReviewHandler ReviewPlan wiring", () => {
     const { updatedSummaryBody, recordReviewEntries, logEntries } = await runReviewPlanScenario();
 
     const detailsBlock = extractReviewDetailsBlock(updatedSummaryBody ?? "");
-    expect(detailsBlock).toContain("graph=skipped");
+    expect(detailsBlock).not.toContain("graph=skipped");
 
     const readyLog = logEntries.find((entry) => entry.data?.gate === "review-plan");
     expect(readyLog?.data?.graphValidationStatus).toBe("skipped");
@@ -17346,7 +17362,7 @@ describe("createReviewHandler ReviewPlan wiring", () => {
 
     expect(executeCalls).toHaveLength(1);
     const detailsBlock = extractReviewDetailsBlock(updatedSummaryBody ?? "");
-    expect(detailsBlock).toContain("graph=unavailable");
+    expect(detailsBlock).not.toContain("graph=unavailable");
 
     const readyLog = logEntries.find((entry) => entry.data?.gate === "review-plan");
     expect(readyLog?.data?.graphValidationStatus).toBe("unavailable");
@@ -17363,7 +17379,7 @@ describe("createReviewHandler ReviewPlan wiring", () => {
     });
 
     const detailsBlock = extractReviewDetailsBlock(updatedSummaryBody ?? "");
-    expect(detailsBlock).toContain("graph=enabled");
+    expect(detailsBlock).not.toContain("graph=enabled");
 
     const readyLog = logEntries.find((entry) => entry.data?.gate === "review-plan");
     expect(readyLog?.data?.graphValidationStatus).toBe("enabled");
@@ -17381,7 +17397,7 @@ describe("createReviewHandler ReviewPlan wiring", () => {
     expect(promptBuildContexts[0]?.candidateFindingMode).toBe("preferred");
 
     const detailsBlock = extractReviewDetailsBlock(updatedSummaryBody ?? "");
-    expect(detailsBlock).toContain("candidates=preferred");
+    expect(detailsBlock).not.toContain("candidates=preferred");
   });
 
   test("passes a bounded diff snippet to shadow specialist instead of duplicating the full diff", async () => {
@@ -17434,14 +17450,8 @@ describe("createReviewHandler ReviewPlan wiring", () => {
     });
 
     const detailsBlock = extractReviewDetailsBlock(updatedSummaryBody ?? "");
-    expect(detailsBlock.match(/Review candidates:/g) ?? []).toHaveLength(1);
-    expect(detailsBlock.match(/Review validation truth:/g) ?? []).toHaveLength(1);
-    expect(detailsBlock).toContain("Review validation truth: status=empty");
-    expect(detailsBlock).toMatch(/counts=detected:\d+,suggested:\d+,validated:\d+,revalidated:\d+,resolved:\d+,blocked:\d+,degraded:\d+,open:\d+,uncertain:\d+,inputFindings:\d+,unsafeInputFields:\d+/);
-    expect(detailsBlock).toContain("evidence=fresh:");
-    expect(detailsBlock).toContain("correlation=reviewOutputKey:y,deliveryId:y");
-    expect(detailsBlock).toContain("redaction=privateOnly:y,rawPrompts:n,rawModelOutput:n,candidateBodies:n,replacementText:n,toolPayloads:n,secretLike:n,diffs:n,unboundedArrays:n");
-    expect(detailsBlock).toContain("Review candidates: shadow recorded=2 rejected=1 errors=0 artifact=present");
+    expect(detailsBlock).not.toContain("Review candidates:");
+    expect(detailsBlock).not.toContain("Review validation truth:");
     expect(detailsBlock).not.toContain("RAW TITLE MUST NOT LEAK");
     expect(detailsBlock).not.toContain("RAW BODY MUST NOT LEAK");
     expect(detailsBlock).not.toContain("/tmp/workspace");
@@ -17603,7 +17613,7 @@ describe("createReviewHandler ReviewPlan wiring", () => {
     expect(String(createdReviewComments[0]?.body)).toContain(candidateTitle);
     expect(String(createdReviewComments[0]?.body)).toContain("```suggestion");
     expect(String(createdReviewComments[0]?.body)).toContain(candidateFixReplacementText);
-    expect(String(createdReviewComments[0]?.body)).not.toContain(candidateBody);
+    expect(String(createdReviewComments[0]?.body)).toContain(candidateBody);
 
     expect(recordReviewEntries[0]?.findingsTotal).toBe(1);
     expect(recordFindingEntries).toHaveLength(1);
@@ -17717,7 +17727,10 @@ describe("createReviewHandler ReviewPlan wiring", () => {
     const reviewOutputKey = String(executeCalls[0]?.reviewOutputKey ?? "");
     const deliveryId = "delivery-123";
     const detailsBlock = extractReviewDetailsBlock(updatedSummaryBody ?? "");
-    const validationTruthLineCount = detailsBlock.split("\n").filter((line) => line.includes("Review validation truth:")).length;
+    // Validation-truth projection moved from the user-visible Review Details
+    // comment into structured logs; evidence now counts the log projection.
+    const validationTruthLogEntries = logEntries.filter((entry) => entry.data?.gate === "review-validation-truth");
+    const validationTruthLineCount = validationTruthLogEntries.length;
     const lifecycleLog = logEntries.find((entry) => entry.data?.gate === "review-finding-lifecycle");
     const fixEligibilityLog = logEntries.find((entry) => entry.data?.gate === "review-fix-eligibility");
     const validationTruthLog = logEntries.find((entry) => entry.data?.gate === "review-validation-truth");
@@ -17729,9 +17742,8 @@ describe("createReviewHandler ReviewPlan wiring", () => {
     expect(createdSuggestion?.line).toBe(2);
     expect(String(createdSuggestion?.body)).toContain("```suggestion");
     expect(String(createdSuggestion?.body)).toContain(candidateFixReplacementText);
-    expect(String(createdSuggestion?.body)).not.toContain(candidateBody);
-    expect(detailsBlock).toContain("Review validation truth:");
-    expect(detailsBlock).toContain("correlation=reviewOutputKey:y,deliveryId:y");
+    expect(String(createdSuggestion?.body)).toContain(candidateBody);
+    expect(detailsBlock).not.toContain("Review validation truth:");
 
     const evidence: M074S06EvidenceSnapshot = {
       schema: "m074-s06-production-like-proof.v1",
@@ -17802,11 +17814,11 @@ describe("createReviewHandler ReviewPlan wiring", () => {
         statusCode: "m074_s05_ok",
         checkIds: ["review-details-validation-truth", "visible-volume-bounds", "diagnostic-correlation", "redaction-flags-and-canaries"],
         sourceAvailable: true,
-        correlationPresent: detailsBlock.includes("correlation=reviewOutputKey:y,deliveryId:y"),
+        correlationPresent: validationTruthLog?.data?.reviewOutputKey === reviewOutputKey && validationTruthLog?.data?.deliveryId === deliveryId,
         counts: { validationTruthLineCount },
         validationTruthLineCount,
-        reviewOutputKeyPresent: detailsBlock.includes("reviewOutputKey:y"),
-        deliveryIdPresent: detailsBlock.includes("deliveryId:y"),
+        reviewOutputKeyPresent: validationTruthLog?.data?.reviewOutputKey === reviewOutputKey,
+        deliveryIdPresent: validationTruthLog?.data?.deliveryId === deliveryId,
         addedLines: validationTruthLineCount,
         maxAddedLines: 1,
         visibleCharDelta: detailsBlock.length,
@@ -17992,10 +18004,15 @@ describe("createReviewHandler ReviewPlan wiring", () => {
     }));
   });
 
-  test("missing-replacement candidates surface concrete findings before bounded Review Details", async () => {
-    const { updatedSummaryBody, recordReviewEntries, recordFindingEntries, logEntries } = await runReviewPlanScenario({
+  test("missing-replacement candidates publish inline as prose comments", async () => {
+    const { updatedSummaryBody, createdReviewComments, recordReviewEntries, recordFindingEntries, logEntries } = await runReviewPlanScenario({
       executorPublished: false,
       exposeSummaryComment: true,
+      shadowSpecialistSubflow: buildCandidateVerificationShadowSubflow("verified", {
+        title: "Candidate without replacement",
+        body: "This candidate has no generated replacement, but the concrete risk needs author attention.",
+        fixReplacementText: null,
+      }),
       candidateFindingResult: {
         status: "shadow",
         repo: "acme/repo",
@@ -18045,38 +18062,35 @@ describe("createReviewHandler ReviewPlan wiring", () => {
       }),
     });
 
-    expect(recordReviewEntries[0]?.findingsTotal).toBe(0);
-    expect(recordFindingEntries).toHaveLength(0);
+    expect(recordReviewEntries[0]?.findingsTotal).toBe(1);
+    expect(recordFindingEntries).toHaveLength(1);
+
+    expect(createdReviewComments).toHaveLength(1);
+    expect(createdReviewComments[0]?.path).toBe("README.md");
+    expect(createdReviewComments[0]?.line).toBe(2);
+    const inlineBody = String(createdReviewComments[0]?.body);
+    expect(inlineBody).toContain("**MAJOR** (correctness): Candidate without replacement");
+    expect(inlineBody).toContain("This candidate has no generated replacement, but the concrete risk needs author attention.");
+    expect(inlineBody).not.toContain("```suggestion");
 
     const detailsBlock = extractReviewDetailsBlock(updatedSummaryBody ?? "");
-    expect(updatedSummaryBody).toContain("Decision: NOT APPROVED");
-    expect(updatedSummaryBody).not.toContain("Decision: APPROVE");
-    expect(updatedSummaryBody).toContain("- **MAJOR** `README.md:2` — Candidate without replacement");
-    expect(updatedSummaryBody).toContain("This candidate has no generated replacement, but the concrete risk needs author attention.");
     expect(updatedSummaryBody).not.toContain("Kodiai found 1 unpublished finding that requires human review.");
     expect(updatedSummaryBody).not.toContain("Raw finding text was kept private");
-    expect(detailsBlock).toContain("Review candidate publication: mode=moved-to-details");
-    expect(detailsBlock).toContain("approved=1");
-    expect(detailsBlock).toContain("publishable=0");
-    expect(detailsBlock).toContain("nonPublishable=1");
-    expect(detailsBlock).toContain("fixBlocked=1");
-    expect(detailsBlock).toContain("reasons=candidate-moved-to-details,fix-eligibility-blocked");
-    expect(detailsBlock).toContain("movedToDetails=1");
-    expect(detailsBlock).toContain("Moved review candidates preserved in details:");
-    expect(detailsBlock).toContain("reason=missing-replacement");
+    expect(detailsBlock).not.toContain("Review candidate publication:");
+    expect(detailsBlock).not.toContain("Moved review candidates preserved in details:");
+    expect(detailsBlock).not.toContain("reason=missing-replacement");
 
     const publicationLog = logEntries.find((entry) => entry.data?.gate === "review-candidate-publication");
     expect(publicationLog?.level).toBe("info");
-    expect(publicationLog?.message).toBe("Review candidate publication completed");
+    expect(publicationLog?.data?.gateResult).toBe("candidate-approved");
     expect(publicationLog?.data?.counts).toEqual(expect.objectContaining({
       approvedReferences: 1,
-      candidatePublishable: 0,
-      candidatePublished: 0,
-      candidateMovedToDetails: 1,
-      fixEligibilityBlocked: 1,
-      nonPublishableReferences: 1,
+      candidatePublishable: 1,
+      candidatePublished: 1,
+      candidateMovedToDetails: 0,
+      fixEligibilityBlocked: 0,
+      nonPublishableReferences: 0,
     }));
-    expect(publicationLog?.data?.reasons).toEqual(["candidate-moved-to-details", "fix-eligibility-blocked"]);
   });
 
   test("candidate draft prioritization respects maxComments before inline publication", async () => {
@@ -18249,10 +18263,7 @@ describe("createReviewHandler ReviewPlan wiring", () => {
     const { updatedSummaryBody, recordReviewEntries, logEntries } = await runReviewPlanScenario();
 
     const detailsBlock = extractReviewDetailsBlock(updatedSummaryBody ?? "");
-    expect(detailsBlock).toContain("Review candidate publication: mode=direct-fallback");
-    expect(detailsBlock).toContain("published=0");
-    expect(detailsBlock).toContain("directFallback=1");
-    expect(detailsBlock).toContain("buckets=blocked:1:approval-blocked+no-candidate-publication-path,direct-fallback:1:direct-fallback-attempted+direct-fallback-published+direct-fallback-audited");
+    expect(detailsBlock).not.toContain("Review candidate publication:");
 
     const publicationLog = logEntries.find((entry) => entry.data?.gate === "review-candidate-publication");
     expect(publicationLog?.data?.gateResult).toBe("direct-fallback");
@@ -18353,15 +18364,11 @@ describe("createReviewHandler ReviewPlan wiring", () => {
 
     const movedDetailsBody = createdIssueComments
       .map((comment) => String(comment.body ?? ""))
-      .find((body) => body.includes("Review candidate publication: mode=moved-to-details"));
+      .find((body) => body.includes("Moved review candidates preserved in details:"));
     expect(movedDetailsBody).toBeDefined();
     const detailsBlock = extractReviewDetailsBlock(movedDetailsBody ?? "");
-    expect(detailsBlock).toContain("Review candidate publication: mode=moved-to-details");
-    expect(detailsBlock).toContain("published=0");
-    expect(detailsBlock).toContain("directFallback=0");
-    expect(detailsBlock).toContain("movedToDetails=1");
+    expect(detailsBlock).not.toContain("Review candidate publication:");
     expect(detailsBlock).toContain("Moved review candidates preserved in details:");
-    expect(detailsBlock).toContain("buckets=moved-to-details:1:candidate-moved-to-details+line-not-commentable");
     expect(detailsBlock).toContain("[major/correctness] Unpublishable candidate line (README.md:999, reason=line-not-commentable)");
     expect(detailsBlock).not.toContain("PROMPT_SECRET");
     expect(detailsBlock).not.toContain("TOKEN=abc123");
@@ -18515,8 +18522,7 @@ describe("createReviewHandler ReviewPlan wiring", () => {
     const { updatedSummaryBody, recordReviewEntries, logEntries } = await runReviewPlanScenario();
 
     const detailsBlock = extractReviewDetailsBlock(updatedSummaryBody ?? "");
-    expect(detailsBlock.match(/Review candidates:/g) ?? []).toHaveLength(1);
-    expect(detailsBlock).toContain("Review candidates: unavailable");
+    expect(detailsBlock).not.toContain("Review candidates:");
 
     const candidateLog = logEntries.find((entry) => entry.data?.gate === "review-candidate-finding");
     expect(candidateLog?.data?.gateResult).toBe("unavailable");
@@ -18548,9 +18554,7 @@ describe("createReviewHandler ReviewPlan wiring", () => {
     });
 
     const detailsBlock = extractReviewDetailsBlock(updatedSummaryBody ?? "");
-    expect(detailsBlock.match(/Review candidates:/g) ?? []).toHaveLength(1);
-    expect(detailsBlock).toContain("Review candidates: degraded");
-    expect(detailsBlock).toContain("errors=2");
+    expect(detailsBlock).not.toContain("Review candidates:");
     expect(detailsBlock).not.toContain("PROMPT_SECRET");
     expect(detailsBlock).not.toContain("TOKEN=abc123");
 
@@ -18568,7 +18572,7 @@ describe("createReviewHandler ReviewPlan wiring", () => {
     });
   });
 
-  test("successful review publishes a compact ready Review plan line and preserves executor dispatch inputs", async () => {
+  test("successful review logs a compact ready Review plan and preserves executor dispatch inputs", async () => {
     const { updatedSummaryBody, executeCalls, logEntries } = await runReviewPlanScenario();
 
     expect(executeCalls).toHaveLength(1);
@@ -18587,10 +18591,7 @@ describe("createReviewHandler ReviewPlan wiring", () => {
     }));
 
     const detailsBlock = extractReviewDetailsBlock(updatedSummaryBody ?? "");
-    expect(detailsBlock.match(/Review plan:/g) ?? []).toHaveLength(1);
-    expect(detailsBlock).toContain("Review plan: ready");
-    expect(detailsBlock).toContain("task=review.small-diff");
-    expect(detailsBlock).toContain("route=tiny-diff");
+    expect(detailsBlock).not.toContain("Review plan:");
     expect(detailsBlock).not.toContain("safe test prompt");
     expect(detailsBlock).not.toContain("base\\nfeature");
 
@@ -18624,7 +18625,7 @@ describe("createReviewHandler ReviewPlan wiring", () => {
     expect(serialized).not.toContain("diffContent");
   });
 
-  test("injected ready review reducer publishes compact details, logs counts, and stores safe snapshot", async () => {
+  test("injected ready review reducer keeps details compact, logs counts, and stores safe snapshot", async () => {
     const { updatedSummaryBody, recordReviewEntries, logEntries } = await runReviewPlanScenario({
       reviewReducer: async (input) => {
         const counts = {
@@ -18659,8 +18660,7 @@ describe("createReviewHandler ReviewPlan wiring", () => {
     });
 
     const detailsBlock = extractReviewDetailsBlock(updatedSummaryBody ?? "");
-    expect(detailsBlock.match(/Review reducer:/g) ?? []).toHaveLength(1);
-    expect(detailsBlock).toContain("Review reducer: ready");
+    expect(detailsBlock).not.toContain("Review reducer:");
     expect(detailsBlock).not.toContain("safe test prompt");
     expect(detailsBlock).not.toContain("diff --git");
 
@@ -18688,9 +18688,7 @@ describe("createReviewHandler ReviewPlan wiring", () => {
 
     expect(executeCalls).toHaveLength(1);
     const detailsBlock = extractReviewDetailsBlock(updatedSummaryBody ?? "");
-    expect(detailsBlock.match(/Review reducer:/g) ?? []).toHaveLength(1);
-    expect(detailsBlock).toContain("Review reducer: degraded");
-    expect(detailsBlock).toContain("reason=reducer-exception");
+    expect(detailsBlock).not.toContain("Review reducer:");
     expect(detailsBlock).not.toContain("PROMPT_SECRET");
     expect(detailsBlock).not.toContain("TOKEN=abc123");
     expect(detailsBlock).not.toContain("diff --git");
@@ -18708,7 +18706,7 @@ describe("createReviewHandler ReviewPlan wiring", () => {
     expect(JSON.stringify(configSnapshot)).not.toContain("diff --git");
   });
 
-  test("builder failure still dispatches executor and renders a degraded Review plan line", async () => {
+  test("builder failure still dispatches executor and logs a degraded Review plan", async () => {
     const { updatedSummaryBody, executeCalls, recordReviewEntries, logEntries } = await runReviewPlanScenario({
       reviewPlanBuilder: () => {
         throw new Error("boom raw prompt token diff should not leak");
@@ -18720,9 +18718,7 @@ describe("createReviewHandler ReviewPlan wiring", () => {
     expect(executeCalls[0]?.prompt).toBe("safe test prompt");
 
     const detailsBlock = extractReviewDetailsBlock(updatedSummaryBody ?? "");
-    expect(detailsBlock.match(/Review plan:/g) ?? []).toHaveLength(1);
-    expect(detailsBlock).toContain("Review plan: degraded");
-    expect(detailsBlock).toContain("reason=builder-error");
+    expect(detailsBlock).not.toContain("Review plan:");
     expect(detailsBlock).not.toContain("raw prompt");
     expect(detailsBlock).not.toContain("boom raw prompt token diff should not leak");
     expect(detailsBlock).not.toContain("diffContent");

--- a/src/lib/review-details-candidate-publication-formatting.ts
+++ b/src/lib/review-details-candidate-publication-formatting.ts
@@ -148,6 +148,18 @@ function isSafeReviewCandidatePublicationBucketReason(value: string): boolean {
   return !/(redacted|prompt|diff|token|secret|unsafe|raw|canary|hidden)/.test(value);
 }
 
+export function formatReviewCandidateMovedToDetailsOnlyLines(
+  reviewCandidatePublication?: ReviewCandidatePublicationRuntimeDetailsSummary | null,
+): string[] {
+  try {
+    if (!reviewCandidatePublication) return [];
+    if (reviewCandidatePublication.label !== "Review candidate publication runtime") return [];
+    return formatReviewCandidateMovedToDetailsLines(reviewCandidatePublication);
+  } catch {
+    return [];
+  }
+}
+
 function formatReviewCandidateMovedToDetailsLines(
   reviewCandidatePublication: ReviewCandidatePublicationRuntimeDetailsSummary,
 ): string[] {

--- a/src/lib/review-details-formatting.ts
+++ b/src/lib/review-details-formatting.ts
@@ -16,26 +16,15 @@ import type { ReviewBoundednessContract } from "./review-boundedness.ts";
 import type { ReviewFirstPassPayload } from "./review-first-pass.ts";
 import type { ReviewPlanDetailsSummary } from "../review-orchestration/review-plan.ts";
 import type { ReviewReducerDetailsSummary } from "../review-orchestration/review-reducer.ts";
-import {
-  formatReviewPlanDetailsLine,
-  formatReviewReducerDetailsLine,
-} from "./review-details-plan-formatting.ts";
 import type { ReviewCandidateFindingDetailsSummary } from "../review-orchestration/review-candidate-finding.ts";
 import type { ReviewCandidatePublicationRuntimeDetailsSummary } from "../review-orchestration/review-candidate-publication-runtime.ts";
 import {
-  formatReviewCandidateFindingDetailsLine,
-  formatReviewCandidatePublicationDetailsLine,
-  formatCandidatePublicationBridgeLine,
   type CandidatePublicationBridgeReviewDetails,
-  formatCandidateVerificationPublicationEvidenceLine,
   type CandidateVerificationPublicationEvidenceReviewDetails,
 } from "./review-details-candidate-formatting.ts";
+import { formatReviewCandidateMovedToDetailsOnlyLines } from "./review-details-candidate-publication-formatting.ts";
 import type { ReviewFindingLifecyclePublicProjection } from "../review-lifecycle/finding-lifecycle.ts";
 import type { ValidationTruthProjection } from "../review-lifecycle/validation-truth.ts";
-import {
-  formatReviewFindingLifecycleDetailsLine,
-  formatReviewValidationTruthDetailsLine,
-} from "./review-details-validation-formatting.ts";
 import {
   describeReviewFirstPass,
   type TimeoutBudgetDetails,
@@ -100,6 +89,8 @@ type UsageLimitDetails = {
 type TokenUsageDetails = {
   inputTokens: number | undefined;
   outputTokens: number | undefined;
+  cacheReadTokens?: number | undefined;
+  cacheCreationTokens?: number | undefined;
   costUsd: number | undefined;
 };
 
@@ -184,18 +175,6 @@ export function classifyRetryFailure(err: unknown): ReviewRetryFailureClassifica
 
 export function buildReviewDetailsMarker(reviewOutputKey: string): string {
   return `<!-- kodiai:review-details:${reviewOutputKey} -->`;
-}
-
-function optionalReviewDetailsLine<T>(
-  value: T,
-  formatter: (value: T) => string | null,
-): string[] {
-  try {
-    const line = formatter(value);
-    return line ? [line] : [];
-  } catch {
-    return [];
-  }
 }
 
 function formatProfileLine(label: string, profile: ResolvedReviewProfile): string {
@@ -302,16 +281,10 @@ function formatCoreReviewDetailsSection(params: ReviewDetailsSummaryParams & {
 }
 
 function formatPublicationDiagnosticsSection(params: ReviewDetailsSummaryParams): string[] {
-  return [
-    ...formatReviewPlanDetailsLine(params.reviewPlan),
-    ...formatReviewReducerDetailsLine(params.reviewReducer),
-    ...formatReviewCandidateFindingDetailsLine(params.reviewCandidateFinding),
-    ...formatReviewCandidatePublicationDetailsLine(params.reviewCandidatePublication),
-    ...optionalReviewDetailsLine(params.candidatePublicationBridge, formatCandidatePublicationBridgeLine),
-    ...optionalReviewDetailsLine(params.candidateVerificationPublicationEvidence, formatCandidateVerificationPublicationEvidenceLine),
-    ...optionalReviewDetailsLine(params.reviewFindingLifecycle, formatReviewFindingLifecycleDetailsLine),
-    ...optionalReviewDetailsLine(params.reviewValidationTruth, formatReviewValidationTruthDetailsLine),
-  ];
+  // Machine diagnostics (plan/reducer/bridge/lifecycle/validation summaries)
+  // are emitted to structured logs already; the PR comment keeps only content
+  // a human reviewer can act on — findings that were preserved in details.
+  return formatReviewCandidateMovedToDetailsOnlyLines(params.reviewCandidatePublication);
 }
 
 function formatPhaseTimingSection(
@@ -341,8 +314,13 @@ function formatTokenUsageSection(tokenUsage?: TokenUsageDetails): string[] {
   if (tokenUsage?.inputTokens === undefined && tokenUsage?.outputTokens === undefined) return [];
   const inp = tokenUsage.inputTokens ?? 0;
   const out = tokenUsage.outputTokens ?? 0;
-  const costStr = tokenUsage.costUsd !== undefined ? ` | ${tokenUsage.costUsd.toFixed(4)}` : "";
-  return [`- Tokens: ${inp.toLocaleString()} in / ${out.toLocaleString()} out${costStr}`];
+  const cacheRead = tokenUsage.cacheReadTokens ?? 0;
+  const cacheWrite = tokenUsage.cacheCreationTokens ?? 0;
+  const cacheStr = cacheRead > 0 || cacheWrite > 0
+    ? ` (+${cacheRead.toLocaleString()} cache read / +${cacheWrite.toLocaleString()} cache write)`
+    : "";
+  const costStr = tokenUsage.costUsd !== undefined ? ` | $${tokenUsage.costUsd.toFixed(4)}` : "";
+  return [`- Tokens: ${inp.toLocaleString()} in / ${out.toLocaleString()} out${cacheStr}${costStr}`];
 }
 
 function formatLargePrTriageSection(largePRTriage?: LargePrTriageDetails): string[] {

--- a/src/lib/review-routing.test.ts
+++ b/src/lib/review-routing.test.ts
@@ -60,12 +60,12 @@ describe("review-routing", () => {
     });
   });
 
-  test("does not apply risk scaling to small-diff reviews without an explicit routing override", () => {
+  test("applies risk scaling to small-diff reviews the same as full reviews", () => {
     expect(resolveReviewMaxTurnsOverride({
       taskType: TASK_TYPES.REVIEW_SMALL_DIFF,
       timeoutRiskLevel: "high",
       baseMaxTurns: 25,
-    })).toBeUndefined();
+    })).toBe(HIGH_RISK_REVIEW_MAX_TURNS);
   });
 
   test("raises standard full-review turn budget for medium and high timeout risk", () => {

--- a/src/lib/review-routing.ts
+++ b/src/lib/review-routing.ts
@@ -8,14 +8,6 @@ export const SEMANTIC_FANOUT_REVIEW_MAX_TURNS = MEDIUM_RISK_REVIEW_MAX_TURNS;
 
 export type ReviewTimeoutRiskLevel = "low" | "medium" | "high";
 
-export const SMALL_DIFF_REVIEW_BASE_TOOLS = [
-  "Read",
-  "Grep",
-  "Glob",
-  "Bash(git diff:*)",
-  "Bash(git show:*)",
-] as const;
-
 export type ReviewTaskRouting = {
   taskType: string;
   routingReason: "tiny-diff" | "standard";
@@ -109,7 +101,9 @@ export function resolveReviewMaxTurnsOverride(params: {
     return params.routingMaxTurnsOverride;
   }
 
-  if (params.taskType !== TASK_TYPES.REVIEW_FULL) {
+  // Both review task types scale with risk: small diffs can still touch
+  // headers or shared code paths whose blast radius needs extra turns.
+  if (params.taskType !== TASK_TYPES.REVIEW_FULL && params.taskType !== TASK_TYPES.REVIEW_SMALL_DIFF) {
     return undefined;
   }
 

--- a/src/lib/review-utils.test.ts
+++ b/src/lib/review-utils.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect } from "bun:test";
 import { formatReviewDetailsSummary } from "./review-details-formatting.ts";
+import { formatReviewPlanDetailsLine, formatReviewReducerDetailsLine } from "./review-details-plan-formatting.ts";
+import {
+  formatReviewCandidateFindingDetailsLine,
+  formatReviewCandidatePublicationDetailsLine,
+} from "./review-details-candidate-formatting.ts";
+import {
+  formatReviewFindingLifecycleDetailsLine,
+  formatReviewValidationTruthDetailsLine,
+} from "./review-details-validation-formatting.ts";
 import type { ReviewFirstPassPayload } from "./review-first-pass.ts";
 import { projectContributorExperienceContract } from "../contributor/experience-contract.ts";
 import type { ReviewPlanDetailsSummary } from "../review-orchestration/review-plan.ts";
@@ -100,15 +109,12 @@ function candidatePublicationSummary(input: {
 
 describe("formatReviewDetailsSummary", () => {
   it("renders bounded doctrine counts in structured review plan details without raw canaries", () => {
-    const result = formatReviewDetailsSummary({
-      ...BASE_PARAMS,
-      reviewPlan: {
-        label: "Review plan",
-        status: "ready",
-        hash: "abcdef1234567890",
-        text: "Review plan: ready hash=abcdef123456 route=standard task=review.full files=2 lines=20(local-diff) budget=na/900s gates=1/2 publish=inline+summary graph=enabled candidates=shadow doctrine=applied/3/2/1 reasons=redaction-applied +1 omitted",
-      },
-    });
+    const result = formatReviewPlanDetailsLine({
+      label: "Review plan",
+      status: "ready",
+      hash: "abcdef1234567890",
+      text: "Review plan: ready hash=abcdef123456 route=standard task=review.full files=2 lines=20(local-diff) budget=na/900s gates=1/2 publish=inline+summary graph=enabled candidates=shadow doctrine=applied/3/2/1 reasons=redaction-applied +1 omitted",
+    }).join("\n");
 
     expect(result).toContain("doctrine=applied/3/2/1 reasons=redaction-applied");
     expect(result).toContain("+1 omitted");
@@ -118,15 +124,13 @@ describe("formatReviewDetailsSummary", () => {
   });
 
   it("renders exactly one compact ready review plan line without dumping structured plan data", () => {
-    const result = formatReviewDetailsSummary({
-      ...BASE_PARAMS,
-      reviewPlan: {
-        label: "Review plan",
-        status: "ready",
-        hash: "abcdef1234567890",
-        text: "Review plan: ready hash=abcdef123456 route=standard task=review.full files=4 lines=212(local-diff) budget=na/900s gates=1/2 publish=inline+summary graph=enabled candidates=shadow",
-      } satisfies ReviewPlanDetailsSummary,
-    });
+    const reviewPlan = {
+      label: "Review plan",
+      status: "ready",
+      hash: "abcdef1234567890",
+      text: "Review plan: ready hash=abcdef123456 route=standard task=review.full files=4 lines=212(local-diff) budget=na/900s gates=1/2 publish=inline+summary graph=enabled candidates=shadow",
+    } satisfies ReviewPlanDetailsSummary;
+    const result = formatReviewPlanDetailsLine(reviewPlan).join("\n");
 
     expect(reviewPlanLineCount(result)).toBe(1);
     expect(result).toContain("- Review plan: ready hash=abcdef123456 route=standard task=review.full files=4 lines=212(local-diff) budget=na/900s gates=1/2 publish=inline+summary graph=enabled candidates=shadow");
@@ -134,18 +138,18 @@ describe("formatReviewDetailsSummary", () => {
     expect(result).not.toContain("routing:");
     expect(result).not.toContain("diff --git");
     expect(result).not.toContain("prompt text");
+
+    const summary = formatReviewDetailsSummary({ ...BASE_PARAMS, reviewPlan });
+    expect(reviewPlanLineCount(summary)).toBe(0);
   });
 
   it("renders exactly one compact degraded review plan line without throwing on missing hash or unknown projection fields", () => {
-    const result = formatReviewDetailsSummary({
-      ...BASE_PARAMS,
-      reviewPlan: {
-        label: "Review plan",
-        status: "degraded",
-        text: "Review plan: degraded route=unknown reason=builder-error graph=skipped candidates=unavailable",
-        routing: { prompt: "prompt text", diff: "diff --git a/secret b/secret" },
-      } as never,
-    });
+    const result = formatReviewPlanDetailsLine({
+      label: "Review plan",
+      status: "degraded",
+      text: "Review plan: degraded route=unknown reason=builder-error graph=skipped candidates=unavailable",
+      routing: { prompt: "prompt text", diff: "diff --git a/secret b/secret" },
+    } as never).join("\n");
 
     expect(reviewPlanLineCount(result)).toBe(1);
     expect(result).toContain("- Review plan: degraded route=unknown reason=builder-error graph=skipped candidates=unavailable");
@@ -166,20 +170,21 @@ describe("formatReviewDetailsSummary", () => {
   });
 
   it("renders exactly one compact review reducer line next to the review plan line", () => {
-    const result = formatReviewDetailsSummary({
-      ...BASE_PARAMS,
-      reviewPlan: {
-        label: "Review plan",
-        status: "ready",
-        hash: "abcdef1234567890",
-        text: "Review plan: ready hash=abcdef123456 route=standard task=review.full files=4 lines=212(local-diff) budget=na/900s gates=1/2 publish=inline+summary graph=enabled candidates=shadow",
-      } satisfies ReviewPlanDetailsSummary,
-      reviewReducer: {
-        label: "Review reducer",
-        status: "ready",
-        text: "Review reducer: ready input=2 kept=1 suppressed=1 rewritten=0 deprioritized=0 lowConfidence=0 auditEvents=1 severityDemoted=0 graphValidated=1 graphUncertain=0",
-      } satisfies ReviewReducerDetailsSummary,
-    });
+    const reviewPlan = {
+      label: "Review plan",
+      status: "ready",
+      hash: "abcdef1234567890",
+      text: "Review plan: ready hash=abcdef123456 route=standard task=review.full files=4 lines=212(local-diff) budget=na/900s gates=1/2 publish=inline+summary graph=enabled candidates=shadow",
+    } satisfies ReviewPlanDetailsSummary;
+    const reviewReducer = {
+      label: "Review reducer",
+      status: "ready",
+      text: "Review reducer: ready input=2 kept=1 suppressed=1 rewritten=0 deprioritized=0 lowConfidence=0 auditEvents=1 severityDemoted=0 graphValidated=1 graphUncertain=0",
+    } satisfies ReviewReducerDetailsSummary;
+    const result = [
+      ...formatReviewPlanDetailsLine(reviewPlan),
+      ...formatReviewReducerDetailsLine(reviewReducer),
+    ].join("\n");
 
     expect(reviewPlanLineCount(result)).toBe(1);
     expect(reviewReducerLineCount(result)).toBe(1);
@@ -187,33 +192,25 @@ describe("formatReviewDetailsSummary", () => {
     expect(result).toContain("- Review reducer: ready input=2 kept=1 suppressed=1 rewritten=0 deprioritized=0 lowConfidence=0 auditEvents=1 severityDemoted=0 graphValidated=1 graphUncertain=0");
     expect(result).not.toContain("diff --git");
     expect(result).not.toContain("prompt text");
+
+    const summary = formatReviewDetailsSummary({ ...BASE_PARAMS, reviewPlan, reviewReducer });
+    expect(reviewPlanLineCount(summary)).toBe(0);
+    expect(reviewReducerLineCount(summary)).toBe(0);
   });
 
   it("renders exactly one compact review candidate line after plan and reducer lines", () => {
-    const result = formatReviewDetailsSummary({
-      ...BASE_PARAMS,
-      reviewPlan: {
-        label: "Review plan",
-        status: "ready",
-        hash: "abcdef1234567890",
-        text: "Review plan: ready hash=abcdef123456 route=standard task=review.full files=4 lines=212(local-diff) budget=na/900s gates=1/2 publish=inline+summary graph=enabled candidates=shadow",
-      } satisfies ReviewPlanDetailsSummary,
-      reviewReducer: {
-        label: "Review reducer",
-        status: "ready",
-        text: "Review reducer: ready input=2 kept=1 suppressed=1 rewritten=0 deprioritized=0 lowConfidence=0 auditEvents=1 severityDemoted=0 graphValidated=1 graphUncertain=0",
-      } satisfies ReviewReducerDetailsSummary,
-      reviewCandidateFinding: {
-        label: "Review candidates",
-        status: "shadow",
-        text: "Review candidates: shadow recorded=1 rejected=0 errors=0 artifact=present repo=owner-repo pr=42 key=review-output-abc123 delivery=delivery-001",
-      } satisfies ReviewCandidateFindingDetailsSummary,
-    });
+    const reviewCandidateFinding = {
+      label: "Review candidates",
+      status: "shadow",
+      text: "Review candidates: shadow recorded=1 rejected=0 errors=0 artifact=present repo=owner-repo pr=42 key=review-output-abc123 delivery=delivery-001",
+    } satisfies ReviewCandidateFindingDetailsSummary;
+    const result = formatReviewCandidateFindingDetailsLine(reviewCandidateFinding).join("\n");
 
     expect(reviewCandidateLineCount(result)).toBe(1);
-    expect(result.indexOf("Review plan:")).toBeLessThan(result.indexOf("Review reducer:"));
-    expect(result.indexOf("Review reducer:")).toBeLessThan(result.indexOf("Review candidates:"));
     expect(result).toContain("- Review candidates: shadow recorded=1 rejected=0 errors=0 artifact=present repo=owner-repo pr=42 key=review-output-abc123 delivery=delivery-001");
+
+    const summary = formatReviewDetailsSummary({ ...BASE_PARAMS, reviewCandidateFinding });
+    expect(reviewCandidateLineCount(summary)).toBe(0);
   });
 
   it("omits candidate metadata when omitted or malformed without breaking Review Details", () => {
@@ -251,9 +248,7 @@ describe("formatReviewDetailsSummary", () => {
   });
 
   it("renders a safe bounded lifecycle projection exactly once without raw canaries", () => {
-    const result = formatReviewDetailsSummary({
-      ...BASE_PARAMS,
-      reviewFindingLifecycle: {
+    const result = formatReviewFindingLifecycleDetailsLine({
         schema: "review-finding-lifecycle.v1",
         status: "normalized",
         counts: {
@@ -290,8 +285,7 @@ describe("formatReviewDetailsSummary", () => {
           unboundedArraysIncluded: false,
           unsafeInputFieldCount: 3,
         },
-      },
-    });
+    }) ?? "";
 
     expect(reviewFindingLifecycleLineCount(result)).toBe(1);
     expect(result).toContain("- Review finding lifecycle: status=normalized");
@@ -346,9 +340,7 @@ describe("formatReviewDetailsSummary", () => {
   });
 
   it("renders a safe bounded validation truth projection exactly once without raw canaries", () => {
-    const result = formatReviewDetailsSummary({
-      ...BASE_PARAMS,
-      reviewValidationTruth: {
+    const result = formatReviewValidationTruthDetailsLine({
         schema: "review-validation-truth.v1",
         gate: "review-validation-truth",
         reviewOutputKey: "review-output-abc123",
@@ -405,8 +397,7 @@ describe("formatReviewDetailsSummary", () => {
         toolPayload: "TOOL_PAYLOAD_CANARY",
         secret: "sk-secret-value",
         diffText: "diff --git a/secret b/secret",
-      } as never,
-    });
+    } as never) ?? "";
 
     expect(reviewValidationTruthLineCount(result)).toBe(1);
     expect(result).toContain("- Review validation truth: status=normalized");
@@ -426,9 +417,7 @@ describe("formatReviewDetailsSummary", () => {
   });
 
   it("caps validation truth reason and reference details with omitted counts", () => {
-    const result = formatReviewDetailsSummary({
-      ...BASE_PARAMS,
-      reviewValidationTruth: {
+    const result = formatReviewValidationTruthDetailsLine({
         schema: "review-validation-truth.v1",
         gate: "review-validation-truth",
         status: "degraded",
@@ -468,8 +457,7 @@ describe("formatReviewDetailsSummary", () => {
           unboundedArraysIncluded: false,
           unsafeInputFieldCount: 0,
         },
-      },
-    });
+    }) ?? "";
 
     expect(reviewValidationTruthLineCount(result)).toBe(1);
     expect(result).toContain("reasons=suggested-but-open:1,validation-missing:1,validation-passed:2,validation-failed:1,validation-stale:1,revalidation-missing:1,revalidation-passed:1,revalidation-failed:1 +6 omitted");
@@ -479,18 +467,15 @@ describe("formatReviewDetailsSummary", () => {
   });
 
   it("does not leak raw candidate title body diff prompt token or secret-like strings in public details", () => {
-    const result = formatReviewDetailsSummary({
-      ...BASE_PARAMS,
-      reviewCandidateFinding: {
-        label: "Review candidates",
-        status: "degraded",
-        text: "Review candidates: degraded recorded=0 rejected=1 errors=1 artifact=absent reason=scanner-redacted repo=owner-repo pr=42 key=review-output-abc123",
-        rawTitle: "Raw candidate title",
-        rawBody: "Raw body with diff --git and prompt text",
-        token: "ghp_secret_token_value",
-        secret: "sk-secret-value",
-      } as never,
-    });
+    const result = formatReviewCandidateFindingDetailsLine({
+      label: "Review candidates",
+      status: "degraded",
+      text: "Review candidates: degraded recorded=0 rejected=1 errors=1 artifact=absent reason=scanner-redacted repo=owner-repo pr=42 key=review-output-abc123",
+      rawTitle: "Raw candidate title",
+      rawBody: "Raw body with diff --git and prompt text",
+      token: "ghp_secret_token_value",
+      secret: "sk-secret-value",
+    } as never).join("\n");
 
     expect(reviewCandidateLineCount(result)).toBe(1);
     expect(result).toContain("- Review candidates: degraded recorded=0 rejected=1 errors=1 artifact=absent reason=scanner-redacted repo=owner-repo pr=42 key=review-output-abc123");
@@ -503,37 +488,30 @@ describe("formatReviewDetailsSummary", () => {
   });
 
   it("renders exactly one bounded candidate-approved publication line after candidate details", () => {
-    const result = formatReviewDetailsSummary({
-      ...BASE_PARAMS,
-      reviewCandidateFinding: {
-        label: "Review candidates",
-        status: "shadow",
-        text: "Review candidates: shadow recorded=2 rejected=0 errors=0 artifact=present repo=owner-repo pr=42 key=review-output-abc123 delivery=delivery-001",
-      } satisfies ReviewCandidateFindingDetailsSummary,
-      reviewCandidatePublication: candidatePublicationSummary({
-        text: "Review candidate publication runtime: candidate-approved approvedRefs=2 rewrittenRefs=1 publishable=3 candidatePublished=3 skipped=0 blocked=0 failed=0 directPublished=0 fallbackEvidence=0 malformed=0 reasons=candidate-publisher-published",
-        mode: "candidate-approved",
-        counts: {
-          approvedReferences: 2,
-          rewrittenReferences: 1,
-          candidatePublishable: 3,
-          candidatePublished: 3,
-          convertedProcessedFindings: 3,
-        },
-        reasons: ["candidate-publisher-published"],
-      }),
+    const reviewCandidatePublication = candidatePublicationSummary({
+      text: "Review candidate publication runtime: candidate-approved approvedRefs=2 rewrittenRefs=1 publishable=3 candidatePublished=3 skipped=0 blocked=0 failed=0 directPublished=0 fallbackEvidence=0 malformed=0 reasons=candidate-publisher-published",
+      mode: "candidate-approved",
+      counts: {
+        approvedReferences: 2,
+        rewrittenReferences: 1,
+        candidatePublishable: 3,
+        candidatePublished: 3,
+        convertedProcessedFindings: 3,
+      },
+      reasons: ["candidate-publisher-published"],
     });
+    const result = formatReviewCandidatePublicationDetailsLine(reviewCandidatePublication).join("\n");
 
     expect(reviewCandidatePublicationLineCount(result)).toBe(1);
-    expect(result.indexOf("Review candidates:")).toBeLessThan(result.indexOf("Review candidate publication:"));
     expect(result).toContain("- Review candidate publication: mode=candidate-approved approved=2 rewritten=1 publishable=3 nonPublishable=0 fixBlocked=0 published=3 directFallback=0 reasons=candidate-publisher-published");
     expect(result).not.toContain("Review candidate publication runtime:");
+
+    const summary = formatReviewDetailsSummary({ ...BASE_PARAMS, reviewCandidatePublication });
+    expect(reviewCandidatePublicationLineCount(summary)).toBe(0);
   });
 
   it("renders candidate publication details from typed metadata instead of reparsing stale visible text", () => {
-    const result = formatReviewDetailsSummary({
-      ...BASE_PARAMS,
-      reviewCandidatePublication: {
+    const result = formatReviewCandidatePublicationDetailsLine({
         label: "Review candidate publication runtime",
         text: "Review candidate publication runtime: degraded approvedRefs=999 rewrittenRefs=999 publishable=999 candidatePublished=999 directPublished=999 fallbackEvidence=999 reasons=stale-visible-text",
         mode: "candidate-approved",
@@ -559,8 +537,7 @@ describe("formatReviewDetailsSummary", () => {
           malformed: 0,
         },
         reasons: ["candidate-publisher-published"],
-      } satisfies ReviewCandidatePublicationRuntimeDetailsSummary,
-    });
+    } satisfies ReviewCandidatePublicationRuntimeDetailsSummary).join("\n");
 
     expect(result).toContain("- Review candidate publication: mode=candidate-approved approved=2 rewritten=1 publishable=3 nonPublishable=0 fixBlocked=0 published=3 directFallback=0 reasons=candidate-publisher-published");
     expect(result).not.toContain("approved=999");
@@ -568,9 +545,7 @@ describe("formatReviewDetailsSummary", () => {
   });
 
   it("renders compact publication outcome buckets without raw canaries", () => {
-    const result = formatReviewDetailsSummary({
-      ...BASE_PARAMS,
-      reviewCandidatePublication: {
+    const result = formatReviewCandidatePublicationDetailsLine({
         ...candidatePublicationSummary({
           text: "Review candidate publication runtime: candidate-approved-partial approvedRefs=7 rewrittenRefs=0 publishable=5 candidatePublished=1 skipped=1 blocked=1 failed=1 movedToDetails=2 detailsOnly=2 detailsOmitted=1 directPublished=0 fallbackEvidence=0 malformed=1 reasons=candidate-publisher-published,candidate-publisher-skipped,candidate-publisher-blocked,candidate-publisher-failed,candidate-moved-to-details,direct-fallback-disallowed,candidate-publisher-malformed",
           mode: "candidate-approved-partial",
@@ -598,8 +573,7 @@ describe("formatReviewDetailsSummary", () => {
           fallbackDisallowed: { mode: "fallback-disallowed", count: 1, reasons: ["direct-fallback-disallowed"] },
           degraded: { mode: "degraded", count: 1, reasons: ["candidate-publisher-malformed"] },
         },
-      },
-    });
+    }).join("\n");
 
     expect(reviewCandidatePublicationLineCount(result)).toBe(1);
     expect(result).toContain("buckets=published:1:candidate-publisher-published");
@@ -616,9 +590,7 @@ describe("formatReviewDetailsSummary", () => {
   });
 
   it("caps compact publication outcome bucket text and redacts unsafe bucket reasons", () => {
-    const result = formatReviewDetailsSummary({
-      ...BASE_PARAMS,
-      reviewCandidatePublication: {
+    const result = formatReviewCandidatePublicationDetailsLine({
         ...candidatePublicationSummary({
           text: "Review candidate publication runtime: degraded approvedRefs=240 rewrittenRefs=0 publishable=240 candidatePublished=60 skipped=60 blocked=60 failed=60 directPublished=0 fallbackEvidence=0 malformed=1 reasons=candidate-publisher-partial",
           mode: "degraded",
@@ -640,8 +612,7 @@ describe("formatReviewDetailsSummary", () => {
           failed: { mode: "failed", count: 60, reasons: ["candidate-publisher-failed"] },
           degraded: { mode: "degraded", count: 1, reasons: ["malformed-publisher-result", "BEGIN PROMPT hidden instructions"] },
         },
-      },
-    });
+    }).join("\n");
 
     const line = result.split("\n").find((entry) => entry.includes("Review candidate publication:")) ?? "";
     expect(line).toContain("buckets=published:60:candidate-publisher-published");
@@ -656,9 +627,7 @@ describe("formatReviewDetailsSummary", () => {
 
 
   it("renders moved-to-details publication status plus bounded details-only findings", () => {
-    const result = formatReviewDetailsSummary({
-      ...BASE_PARAMS,
-      reviewCandidatePublication: {
+    const reviewCandidatePublication = {
         ...candidatePublicationSummary({
           text: "Review candidate publication runtime: moved-to-details approvedRefs=1 rewrittenRefs=0 publishable=0 candidatePublished=0 skipped=0 blocked=0 failed=0 movedToDetails=1 detailsOnly=1 detailsOmitted=0 directPublished=0 fallbackEvidence=0 malformed=0 reasons=candidate-moved-to-details,line-not-commentable-in-pr-diff",
           mode: "moved-to-details",
@@ -693,14 +662,19 @@ describe("formatReviewDetailsSummary", () => {
           reason: "line-not-commentable-in-pr-diff",
           excerpt: "The enqueue path dereferences payload before validating it.",
         }],
-      } satisfies ReviewCandidatePublicationRuntimeDetailsSummary,
-    });
+    } satisfies ReviewCandidatePublicationRuntimeDetailsSummary;
+    const result = formatReviewCandidatePublicationDetailsLine(reviewCandidatePublication).join("\n");
+    const summary = formatReviewDetailsSummary({ ...BASE_PARAMS, reviewCandidatePublication });
 
     expect(reviewCandidatePublicationLineCount(result)).toBe(1);
     expect(result).toContain("- Review candidate publication: mode=moved-to-details approved=1 rewritten=0 publishable=0 nonPublishable=0 fixBlocked=0 published=0 directFallback=0 reasons=candidate-moved-to-details,line-not-commentable-in-pr-diff movedToDetails=1 detailsOmitted=0");
     expect(result).toContain("- Moved review candidates preserved in details:");
     expect(result).toContain("  - [major/correctness] Guard null payload before enqueue (src/worker.ts:42, reason=line-not-commentable-in-pr-diff) — The enqueue path dereferences payload before validating it.");
     expect(result).not.toContain("direct-fallback-published");
+
+    expect(reviewCandidatePublicationLineCount(summary)).toBe(0);
+    expect(summary).toContain("- Moved review candidates preserved in details:");
+    expect(summary).toContain("  - [major/correctness] Guard null payload before enqueue (src/worker.ts:42, reason=line-not-commentable-in-pr-diff) — The enqueue path dereferences payload before validating it.");
   });
 
   it("bounds and sanitizes moved-to-details finding lines while reporting omitted count", () => {
@@ -715,9 +689,7 @@ describe("formatReviewDetailsSummary", () => {
       excerpt: `short excerpt ${index} TOKEN=abc123 secret=value \`\`\`suggestion\nreplacement text\n\`\`\` diff --git prompt text`,
     }));
 
-    const result = formatReviewDetailsSummary({
-      ...BASE_PARAMS,
-      reviewCandidatePublication: {
+    const reviewCandidatePublication = {
         ...candidatePublicationSummary({
           text: "Review candidate publication runtime: moved-to-details approvedRefs=12 rewrittenRefs=0 publishable=0 candidatePublished=0 skipped=0 blocked=0 failed=0 movedToDetails=12 detailsOnly=12 detailsOmitted=7 directPublished=0 fallbackEvidence=0 malformed=0 reasons=candidate-moved-to-details,oversized reason one,oversized reason two,oversized reason three,oversized reason four,oversized reason five,oversized reason six,oversized reason seven",
           mode: "moved-to-details",
@@ -744,8 +716,9 @@ describe("formatReviewDetailsSummary", () => {
           },
         },
         detailsOnlyFindings: findings,
-      } satisfies ReviewCandidatePublicationRuntimeDetailsSummary,
-    });
+    } satisfies ReviewCandidatePublicationRuntimeDetailsSummary;
+    const result = formatReviewCandidatePublicationDetailsLine(reviewCandidatePublication).join("\n");
+    const summary = formatReviewDetailsSummary({ ...BASE_PARAMS, reviewCandidatePublication });
 
     expect(result).toContain("movedToDetails=12 detailsOmitted=7");
     expect(result).toContain("+2 more");
@@ -753,15 +726,17 @@ describe("formatReviewDetailsSummary", () => {
     expect(result).toContain("Safe title 0 redacted redacted prompt-redacted");
     expect(result).toContain("[fix-redacted]");
     expect(result).not.toContain("Safe title 5");
+    expect(summary).toContain("- Moved review candidates preserved in details:");
+    expect(summary).toContain("  - ...and 7 more omitted (bounded-details-only)");
+    expect(summary).not.toContain("Safe title 5");
     for (const unsafe of ["sk-secret-value", "ghp_secret_token_value", "BEGIN PROMPT", "TOKEN=abc123", "secret=value", "replacement text", "diff --git"] as const) {
       expect(result).not.toContain(unsafe);
+      expect(summary).not.toContain(unsafe);
     }
   });
 
   it("degrades moved-to-details metadata and omits findings when projection is malformed or unsafe", () => {
-    const result = formatReviewDetailsSummary({
-      ...BASE_PARAMS,
-      reviewCandidatePublication: {
+    const reviewCandidatePublication = {
         ...candidatePublicationSummary({
           text: "Review candidate publication runtime: not-a-real-mode approvedRefs=1 rewrittenRefs=0 publishable=0 candidatePublished=0 skipped=0 blocked=0 failed=0 movedToDetails=1 detailsOnly=1 detailsOmitted=0 directPublished=0 fallbackEvidence=0 malformed=0 reasons=BEGIN PROMPT,diff --git,unknown reason",
           mode: "degraded",
@@ -796,8 +771,9 @@ describe("formatReviewDetailsSummary", () => {
           reason: "line-not-commentable",
           excerpt: "PROMPT_SECRET diff --git",
         }],
-      } as never,
-    });
+    } as never;
+    const result = formatReviewCandidatePublicationDetailsLine(reviewCandidatePublication).join("\n");
+    const summary = formatReviewDetailsSummary({ ...BASE_PARAMS, reviewCandidatePublication });
 
     expect(reviewCandidatePublicationLineCount(result)).toBe(1);
     expect(result).toContain("mode=degraded");
@@ -806,12 +782,14 @@ describe("formatReviewDetailsSummary", () => {
     expect(result).not.toContain("MUST_NOT_RENDER");
     expect(result).not.toContain("sk-secret-value");
     expect(result).not.toContain("diff --git");
+    expect(summary).not.toContain("Moved review candidates preserved in details");
+    expect(summary).not.toContain("MUST_NOT_RENDER");
+    expect(summary).not.toContain("sk-secret-value");
+    expect(summary).not.toContain("diff --git");
   });
 
   it("renders direct fallback publication state as audited fallback evidence", () => {
-    const result = formatReviewDetailsSummary({
-      ...BASE_PARAMS,
-      reviewCandidatePublication: candidatePublicationSummary({
+    const result = formatReviewCandidatePublicationDetailsLine(candidatePublicationSummary({
         text: "Review candidate publication runtime: direct-fallback approvedRefs=0 rewrittenRefs=0 publishable=0 candidatePublished=0 skipped=0 blocked=0 failed=0 directPublished=2 fallbackEvidence=2 malformed=0 reasons=direct-fallback-attempted,direct-fallback-published",
         mode: "direct-fallback",
         counts: {
@@ -820,35 +798,35 @@ describe("formatReviewDetailsSummary", () => {
           fallbackEvidence: 2,
         },
         reasons: ["direct-fallback-attempted", "direct-fallback-published"],
-      }),
-    });
+    })).join("\n");
 
     expect(reviewCandidatePublicationLineCount(result)).toBe(1);
     expect(result).toContain("- Review candidate publication: mode=direct-fallback approved=0 rewritten=0 publishable=0 nonPublishable=0 fixBlocked=0 published=0 directFallback=2 reasons=direct-fallback-attempted,direct-fallback-published");
   });
 
   it("omits missing candidate publication metadata and degrades malformed metadata without breaking Review Details", () => {
+    const malformedMetadata = {
+      label: "Review candidate publication runtime",
+      text: 17,
+    } as never;
     const omitted = formatReviewDetailsSummary({ ...BASE_PARAMS });
-    const malformed = formatReviewDetailsSummary({
+    const malformedSummary = formatReviewDetailsSummary({
       ...BASE_PARAMS,
-      reviewCandidatePublication: {
-        label: "Review candidate publication runtime",
-        text: 17,
-      } as never,
+      reviewCandidatePublication: malformedMetadata,
     });
+    const malformed = formatReviewCandidatePublicationDetailsLine(malformedMetadata).join("\n");
 
     expect(reviewCandidatePublicationLineCount(omitted)).toBe(0);
+    expect(reviewCandidatePublicationLineCount(malformedSummary)).toBe(0);
     expect(reviewCandidatePublicationLineCount(malformed)).toBe(1);
     expect(malformed).toContain("- Review candidate publication: mode=degraded approved=0 rewritten=0 publishable=0 nonPublishable=0 fixBlocked=0 published=0 directFallback=0 reasons=malformed-runtime-summary");
     expect(malformed).toContain("buckets=degraded:1:malformed-runtime-summary");
-    expect(malformed).toContain("<summary>Review Details</summary>");
-    expect(malformed).toContain("<!-- kodiai:review-details:test-key-001 -->");
+    expect(malformedSummary).toContain("<summary>Review Details</summary>");
+    expect(malformedSummary).toContain("<!-- kodiai:review-details:test-key-001 -->");
   });
 
   it("caps oversized candidate publication reasons and redacts secret prompt and diff markers", () => {
-    const result = formatReviewDetailsSummary({
-      ...BASE_PARAMS,
-      reviewCandidatePublication: candidatePublicationSummary({
+    const result = formatReviewCandidatePublicationDetailsLine(candidatePublicationSummary({
         text: "Review candidate publication runtime: degraded approvedRefs=1 rewrittenRefs=0 publishable=1 candidatePublished=0 skipped=0 blocked=0 failed=1 directPublished=0 fallbackEvidence=0 malformed=1 reasons=candidate-publisher-failed,sk-secret-value,ghp_secret_token_value,BEGIN PROMPT,diff --git,hidden instructions,oversized reason one,oversized reason two,oversized reason three,oversized reason four,oversized reason five,oversized reason six",
         mode: "degraded",
         counts: {
@@ -858,8 +836,7 @@ describe("formatReviewDetailsSummary", () => {
           malformed: 1,
         },
         reasons: ["candidate-publisher-failed", "sk-secret-value", "ghp_secret_token_value", "BEGIN PROMPT", "diff --git", "hidden instructions", "oversized reason one", "oversized reason two", "oversized reason three", "oversized reason four", "oversized reason five", "oversized reason six"],
-      }),
-    });
+    })).join("\n");
 
     expect(reviewCandidatePublicationLineCount(result)).toBe(1);
     expect(result).toContain("- Review candidate publication: mode=degraded approved=1 rewritten=0 publishable=1 nonPublishable=0 fixBlocked=0 published=0 directFallback=0 reasons=candidate-publisher-failed,redacted,redacted,prompt-redacted,diff-redacted,prompt-redacted");

--- a/src/llm/pricing.json
+++ b/src/llm/pricing.json
@@ -3,6 +3,7 @@
   "models": {
     "claude-sonnet-4-20250514": { "inputPerMillion": 3.00, "outputPerMillion": 15.00 },
     "claude-sonnet-4-5-20250929": { "inputPerMillion": 3.00, "outputPerMillion": 15.00 },
+    "claude-sonnet-5": { "inputPerMillion": 3.00, "outputPerMillion": 15.00 },
     "claude-haiku-4-5-20251001": { "inputPerMillion": 0.80, "outputPerMillion": 4.00 },
     "gpt-4o-mini": { "inputPerMillion": 0.15, "outputPerMillion": 0.60 },
     "o3-mini": { "inputPerMillion": 1.10, "outputPerMillion": 4.40 },

--- a/src/llm/structured-generate.test.ts
+++ b/src/llm/structured-generate.test.ts
@@ -217,11 +217,11 @@ describe("generateStructuredWithFallback", () => {
     await expect(result).resolves.toMatchObject({
       usedFallback: true,
       fallbackReason: "domain-grounding-rejection",
-      model: "claude-sonnet-4-5-20250929",
+      model: "claude-sonnet-5",
     });
     expect(capturedModels).toEqual([
       "claude-haiku-4-5-20251001",
-      "claude-sonnet-4-5-20250929",
+      "claude-sonnet-5",
     ]);
     expect(loadCount).toBe(2);
     expect(trackAgentSdkCall).toHaveBeenCalledTimes(2);
@@ -258,7 +258,7 @@ describe("generateStructuredWithFallback", () => {
     });
     expect(capturedModels).toEqual([
       "claude-haiku-4-5-20251001",
-      "claude-sonnet-4-5-20250929",
+      "claude-sonnet-5",
     ]);
   });
 
@@ -302,7 +302,7 @@ describe("generateStructuredWithFallback", () => {
     expect(result).toMatchObject({
       usedFallback: true,
       fallbackReason: "execution-error",
-      model: "claude-sonnet-4-5-20250929",
+      model: "claude-sonnet-5",
     });
     expect(trackAgentSdkCall).toHaveBeenCalledTimes(2);
     expect(trackAgentSdkCall).toHaveBeenNthCalledWith(1, expect.objectContaining({
@@ -316,7 +316,7 @@ describe("generateStructuredWithFallback", () => {
     expect(trackAgentSdkCall).toHaveBeenNthCalledWith(2, expect.objectContaining({
       repo: "xbmc/repo-plugins",
       taskType: TASK_TYPES.GUARDRAIL_CLASSIFICATION,
-      model: "claude-sonnet-4-5-20250929",
+      model: "claude-sonnet-5",
       deliveryId: "delivery-fallback",
       usedFallback: true,
       fallbackReason: "execution-error",

--- a/src/llm/task-router.test.ts
+++ b/src/llm/task-router.test.ts
@@ -6,7 +6,7 @@ describe("createTaskRouter", () => {
   test("uses supported Haiku as the distinct fallback for agentic Sonnet tasks", () => {
     const resolved = createTaskRouter({ models: {} }).resolve(TASK_TYPES.REVIEW_FULL);
 
-    expect(resolved.modelId).toBe("claude-sonnet-4-5-20250929");
+    expect(resolved.modelId).toBe("claude-sonnet-5");
     expect(resolved.fallbackModelId).toBe("claude-haiku-4-5-20251001");
   });
 
@@ -16,6 +16,6 @@ describe("createTaskRouter", () => {
     );
 
     expect(resolved.modelId).toBe("claude-haiku-4-5-20251001");
-    expect(resolved.fallbackModelId).toBe("claude-sonnet-4-5-20250929");
+    expect(resolved.fallbackModelId).toBe("claude-sonnet-5");
   });
 });

--- a/src/llm/task-router.ts
+++ b/src/llm/task-router.ts
@@ -14,7 +14,7 @@ import { extractProvider } from "./providers.ts";
 
 /** Result of resolving a task type to a concrete model. */
 export interface ResolvedModel {
-  /** The model ID to use (e.g., "claude-sonnet-4-5-20250929"). */
+  /** The model ID to use (e.g., "claude-sonnet-5"). */
   modelId: string;
   /** The provider name (e.g., "anthropic", "openai", "google"). */
   provider: string;
@@ -30,7 +30,7 @@ export interface ResolvedModel {
 export interface TaskRouterConfig {
   /** Task type to model ID mappings. Supports wildcards like "review.*". */
   models: Record<string, string>;
-  /** Global default model. Defaults to claude-sonnet-4-5-20250929. */
+  /** Global default model. Defaults to claude-sonnet-5. */
   defaultModel?: string;
   /** Default fallback model. Defaults to a distinct Sonnet/Haiku counterpart. */
   defaultFallbackModel?: string;
@@ -42,7 +42,7 @@ export interface TaskRouter {
   resolve(taskType: string): ResolvedModel;
 }
 
-const DEFAULT_MODEL = "claude-sonnet-4-5-20250929";
+const DEFAULT_MODEL = "claude-sonnet-5";
 const DEFAULT_HAIKU_MODEL = "claude-haiku-4-5-20251001";
 
 /**

--- a/src/review-lifecycle/same-pr-fix-eligibility.test.ts
+++ b/src/review-lifecycle/same-pr-fix-eligibility.test.ts
@@ -91,9 +91,39 @@ describe("reduceSamePrFixEligibility", () => {
     expect(result.drafts[0]?.body).toContain("```suggestion\nconst multiA = 'new';\nconst multiB = 'new';\n```");
   });
 
+  test("emits a prose draft when replacement text is missing", () => {
+    const result = reduceSamePrFixEligibility({
+      reviewOutputKey: "rok-1",
+      deliveryId: "delivery-1",
+      prDiffText: PR_DIFF,
+      maxSuggestions: 5,
+      candidates: [candidate({
+        findingIdentity: "missing",
+        replacementText: "  \n",
+        rawCandidateBody: "Prefer the computed value here.",
+      })],
+    });
+
+    expect(result.summary.counts).toMatchObject({ input: 1, eligible: 1, blocked: 0, omitted: 0, capped: 0 });
+    expect(result.summary.reasonCounts).toMatchObject({ eligible: 1 });
+    expect(result.drafts).toHaveLength(1);
+    expect(result.drafts[0]).toMatchObject({
+      path: "src/app.ts",
+      line: 12,
+      side: "RIGHT",
+      kind: "prose",
+      reason: "eligible",
+    });
+    expect(result.drafts[0]?.body).toBe([
+      "**MEDIUM** (correctness): Use computed value",
+      "",
+      "Prefer the computed value here.",
+    ].join("\n"));
+    expect(result.drafts[0]?.body).not.toContain("```suggestion");
+  });
+
   test("blocks every required reason with stable reason codes", () => {
     const inputs: Array<[SamePrFixEligibilityReasonCode, SamePrFixCandidateInput]> = [
-      ["missing-replacement", candidate({ findingIdentity: "missing", replacementText: "  \n" })],
       ["unmappable-location", candidate({ findingIdentity: "unmapped", filePath: "../secret.ts" })],
       ["secret-detected", candidate({ findingIdentity: "secret", replacementText: "const token = 'ghp_123456789012345678901234567890123456';" })],
       ["reducer-denied", candidate({ findingIdentity: "reducer", reducerApproved: false })],
@@ -188,7 +218,8 @@ describe("reduceSamePrFixEligibility", () => {
     expect(body).toContain("const safe = true;");
     expect(body).not.toContain("BEGIN PROMPT");
     expect(body).not.toContain("raw model output");
-    expect(body).not.toContain("candidate body");
+    // The normalized candidate body is now published between the header and the fence.
+    expect(body).toContain("candidate body should stay private\n\n```suggestion");
     expect(body).not.toContain("tool payload");
     expect(body).not.toContain("diff --git");
     expect(result.summary.redaction).toMatchObject({

--- a/src/review-lifecycle/same-pr-fix-eligibility.ts
+++ b/src/review-lifecycle/same-pr-fix-eligibility.ts
@@ -53,6 +53,8 @@ export type SamePrFixDraft = {
   severity: FindingSeverity | string;
   category: FindingCategory | string;
   reason: "eligible";
+  /** "suggestion" when the body carries a ```suggestion``` patch; "prose" otherwise. */
+  kind: "suggestion" | "prose";
 };
 
 export type SamePrFixEligibilityOutcome = {
@@ -148,7 +150,8 @@ export function reduceSamePrFixEligibility(input: SamePrFixEligibilityInput): Sa
       ...(normalized.line ? { line: normalized.line } : {}),
     };
 
-    const secretScan = normalized.replacementText ? scanOutgoingForSecrets(normalized.replacementText) : { blocked: false };
+    const outgoingText = [normalized.replacementText, normalized.bodyText].filter(Boolean).join("\n");
+    const secretScan = outgoingText ? scanOutgoingForSecrets(outgoingText) : { blocked: false };
     if (secretScan.blocked) secretDetected = true;
 
     const reason = classifyCandidate({
@@ -221,7 +224,8 @@ function classifyCandidate(input: {
   maxReached: boolean;
   secretDetected: boolean;
 }): SamePrFixEligibilityReasonCode {
-  if (!input.normalized.replacementText) return "missing-replacement";
+  // A missing replacement no longer blocks publication: findings without a
+  // generated patch publish as prose inline comments instead of vanishing.
   if (!input.normalized.path || !input.normalized.startLine || !input.normalized.line) return "unmappable-location";
   if (input.secretDetected) return "secret-detected";
   if (input.candidate.reducerApproved === false) return "reducer-denied";
@@ -246,6 +250,7 @@ type NormalizedSamePrFixCandidate = {
   severity: FindingSeverity | string;
   category: FindingCategory | string;
   replacementText: string;
+  bodyText: string;
 };
 
 function normalizeCandidate(
@@ -259,6 +264,7 @@ function normalizeCandidate(
   const orderedStart = startLine && endLine ? Math.min(startLine, endLine) : (startLine ?? 0);
   const orderedEnd = startLine && endLine ? Math.max(startLine, endLine) : (endLine ?? 0);
   const replacementText = normalizeReplacement(candidate.replacementText);
+  const bodyText = normalizeBody(candidate.rawCandidateBody);
   const title = normalizeTitle(candidate.title);
   const severity = normalizeContextToken(candidate.severity, "medium");
   const category = normalizeContextToken(candidate.category, "correctness");
@@ -287,21 +293,24 @@ function normalizeCandidate(
     severity,
     category,
     replacementText,
+    bodyText,
   };
 }
 
 function toDraft(candidate: NormalizedSamePrFixCandidate): SamePrFixDraft {
+  const kind = candidate.replacementText ? "suggestion" : "prose";
   return {
     identity: candidate.identity,
     path: candidate.path,
     ...(candidate.startLine === candidate.line ? {} : { startLine: candidate.startLine }),
     line: candidate.line,
     side: "RIGHT",
-    body: formatSuggestionBody(candidate),
+    body: kind === "suggestion" ? formatSuggestionBody(candidate) : formatProseBody(candidate),
     title: candidate.title,
     severity: candidate.severity,
     category: candidate.category,
     reason: "eligible",
+    kind,
   };
 }
 
@@ -309,10 +318,18 @@ function formatSuggestionBody(candidate: NormalizedSamePrFixCandidate): string {
   return [
     `**Fix suggestion:** ${candidate.title}`,
     `Severity: ${candidate.severity} · Category: ${candidate.category}`,
+    ...(candidate.bodyText ? ["", candidate.bodyText] : []),
     "",
     "```suggestion",
     candidate.replacementText,
     "```",
+  ].join("\n");
+}
+
+function formatProseBody(candidate: NormalizedSamePrFixCandidate): string {
+  return [
+    `**${String(candidate.severity).toUpperCase()}** (${candidate.category}): ${candidate.title}`,
+    ...(candidate.bodyText ? ["", candidate.bodyText] : []),
   ].join("\n");
 }
 
@@ -335,6 +352,18 @@ function normalizeReplacement(value: unknown): string {
   const stripped = value.replace(/\r\n/g, "\n").replace(/\r/g, "\n").replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F-\u009F]/g, "");
   const bounded = stripped.length > MAX_REPLACEMENT_CHARS ? stripped.slice(0, MAX_REPLACEMENT_CHARS) : stripped;
   return bounded.trim().length > 0 ? bounded.replace(/\n+$/g, "") : "";
+}
+
+const MAX_BODY_CHARS = 4_000;
+
+function normalizeBody(value: unknown): string {
+  if (typeof value !== "string") return "";
+  const stripped = value
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n")
+    .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F-\u009F]/g, "");
+  const bounded = stripped.length > MAX_BODY_CHARS ? `${stripped.slice(0, MAX_BODY_CHARS - 1)}…` : stripped;
+  return bounded.trim();
 }
 
 function normalizeTitle(value: unknown): string {

--- a/src/review-orchestration/review-candidate-publication-adapter.test.ts
+++ b/src/review-orchestration/review-candidate-publication-adapter.test.ts
@@ -142,7 +142,9 @@ describe("review candidate publication adapter", () => {
     expect(adapted.payloads[0]!.publication.body).toContain("```suggestion\nApproved candidate replacement\n```");
     expect(adapted.payloads[1]!.publication.body).toContain("```suggestion\nRewritten reducer replacement\n```");
     expect(adapted.payloads[1]!.publication.body).toContain("**Fix suggestion:** Rewritten reducer title");
-    expect(adapted.payloads[1]!.publication.body).not.toContain("Stale rewrite title body is safe and grounded.");
+    // The normalized candidate body is now published between the header and the fence.
+    expect(adapted.payloads[1]!.publication.body).toContain("Stale rewrite title body is safe and grounded.");
+    expect(adapted.payloads[1]!.publication.body).not.toContain("Rewritten reducer body should stay private");
   });
 
   test("skips malformed approval references and missing rewritten reducer joins with bounded reasons", () => {
@@ -257,17 +259,15 @@ describe("review candidate publication adapter", () => {
 
     expect(adapted.payloads).toHaveLength(1);
     expect(adapted.summary.fixEligibility.reasonCounts).toMatchObject({
-      "missing-replacement": 1,
       eligible: 1,
-      "duplicate-fix": 1,
       "formatter-owned": 1,
       "secret-detected": 1,
-      "max-fixes-exceeded": 2,
+      "max-fixes-exceeded": 4,
     });
-    expect(adapted.summary.fixEligibility.counts).toMatchObject({ input: 7, eligible: 1, blocked: 4, omitted: 2, capped: 2 });
+    expect(adapted.summary.fixEligibility.counts).toMatchObject({ input: 7, eligible: 1, blocked: 2, omitted: 4, capped: 4 });
     expect(summary.text).toContain("fixEligible=1");
-    expect(summary.text).toContain("fixBlocked=4");
-    expect(summary.text).toContain("fixCapped=2");
+    expect(summary.text).toContain("fixBlocked=2");
+    expect(summary.text).toContain("fixCapped=4");
     for (const privateText of ["same replacement", "formatter owned replacement", "over cap replacement", "AKIA1234567890ABCDEF", "body is safe and grounded"]) {
       expect(summary.text).not.toContain(privateText);
     }
@@ -327,11 +327,11 @@ describe("review candidate publication adapter", () => {
     expect(JSON.stringify(adapted.summary.detailsOnlyFindings)).not.toContain("safe replacement that must not appear");
   });
 
-  test("projects approved findings without replacement text into bounded details-only findings", () => {
+  test("publishes approved findings without replacement text as inline prose payloads", () => {
     const candidates = candidateResult([
-      candidateInput("src/without-fix.ts", "Finding without generated fix", {
-        startLine: 12,
-        endLine: 12,
+      candidateInput("src/approved.ts", "Finding without generated fix", {
+        startLine: 20,
+        endLine: 20,
         severity: "major",
         category: "correctness",
         body: "The implementation can return stale data after the cache key changes.",
@@ -351,28 +351,22 @@ describe("review candidate publication adapter", () => {
       prDiffText: PR_DIFF,
     });
 
-    expect(adapted.payloads).toEqual([]);
+    expect(adapted.payloads).toHaveLength(1);
     expect(adapted.summary.counts).toMatchObject({
-      publishable: 0,
-      detailsOnlyFindings: 1,
-      movedToDetails: 1,
+      publishable: 1,
+      detailsOnlyFindings: 0,
+      movedToDetails: 0,
       detailsOnlyOmitted: 0,
     });
-    expect(adapted.summary.movedToDetails).toMatchObject({
-      counts: { total: 1, fromFixEligibility: 1, fromPublisherResult: 0, omitted: 0 },
-      reasonCounts: { "missing-replacement": 1 },
-    });
-    expect(adapted.summary.detailsOnlyFindings).toEqual([
-      expect.objectContaining({
-        fingerprint: candidate.fingerprint,
-        severity: "major",
-        category: "correctness",
-        title: "Finding without generated fix",
-        location: { path: "src/without-fix.ts", line: 12 },
-        reason: "missing-replacement",
-        excerpt: "The implementation can return stale data after the cache key changes.",
-      }),
-    ]);
+    expect(adapted.summary.fixEligibility.reasonCounts).toMatchObject({ eligible: 1 });
+    expect(adapted.payloads[0]!.candidateFingerprint).toBe(candidate.fingerprint);
+    expect(adapted.payloads[0]!.publication.location).toEqual({ path: "src/approved.ts", line: 20, side: "RIGHT" });
+    expect(adapted.payloads[0]!.publication.body).toBe([
+      "**MAJOR** (correctness): Finding without generated fix",
+      "",
+      "The implementation can return stale data after the cache key changes.",
+    ].join("\n"));
+    expect(adapted.payloads[0]!.publication.body).not.toContain("```suggestion");
   });
 
   test("does not promote malformed, missing-line, or unsafe-path candidates to details-only findings", () => {
@@ -405,10 +399,12 @@ describe("review candidate publication adapter", () => {
 
   test("caps details-only projection and redacts secrets, prompt canaries, diffs, and replacements", () => {
     const rawSecret = "AKIA1234567890ABCDEF";
-    const inputs = Array.from({ length: 25 }, (_, index) => candidateInput(`src/non-commentable-${index}.ts`, `Non commentable ${index} TOKEN=super-secret`, {
+    // The raw AWS key lives in the title (not the body): bodies with scanner-matching
+    // secrets are now blocked outright as secret-detected instead of moving to details.
+    const inputs = Array.from({ length: 25 }, (_, index) => candidateInput(`src/non-commentable-${index}.ts`, `Non commentable ${index} TOKEN=super-secret ${rawSecret}`, {
       startLine: 50 + index,
       endLine: 50 + index,
-      body: `BEGIN PROMPT hidden ${index}\ndiff --git a/private b/private\n${rawSecret}\nVisible tail`,
+      body: `BEGIN PROMPT hidden ${index}\ndiff --git a/private b/private\nVisible tail`,
       fixReplacementText: `replacement-canary-${index}`,
     }));
     const candidates = createReviewCandidateFindingExecutionResult({

--- a/src/review-orchestration/review-candidate-publication-runtime.test.ts
+++ b/src/review-orchestration/review-candidate-publication-runtime.test.ts
@@ -247,7 +247,9 @@ describe("review candidate publication runtime classifier", () => {
           ...emptyFixEligibilitySummary(),
           status: "blocked",
           counts: { input: 3, eligible: 0, blocked: 3, omitted: 0, capped: 0 },
-          reasonCounts: { "missing-replacement": 3 },
+          // missing-replacement is now exempt from blocking counts (it publishes as
+          // prose), so use a reason that still blocks fix eligibility.
+          reasonCounts: { "secret-detected": 3 },
         },
       },
       publisher: publisher([]),
@@ -264,7 +266,7 @@ describe("review candidate publication runtime classifier", () => {
     expect(result.outcomeBuckets.blocked).toMatchObject({
       mode: "blocked",
       count: 3,
-      reasons: expect.arrayContaining(["fix-eligibility-blocked", "missing-replacement"]),
+      reasons: expect.arrayContaining(["fix-eligibility-blocked", "secret-detected"]),
     });
     expect(result.detailsSummary.text).toContain("publishable=0");
     expect(result.detailsSummary.text).toContain("nonPublishable=3");

--- a/src/review-orchestration/review-candidate-publication-runtime.ts
+++ b/src/review-orchestration/review-candidate-publication-runtime.ts
@@ -509,7 +509,7 @@ function normalizeAdapterCounts(
   if (fixEligibilityBlocked > 0 && isRecord(adapter?.fixEligibility?.reasonCounts)) {
     for (const [reason, count] of Object.entries(adapter.fixEligibility.reasonCounts)) {
       const normalizedReason = sanitizeSummaryToken(reason);
-      if (normalizedReason === "eligible" || normalizedReason === "line-not-commentable") continue;
+      if (normalizedReason === "eligible" || normalizedReason === "line-not-commentable" || normalizedReason === "missing-replacement") continue;
       if (normalizeCount(count) > 0) addBucketReason(bucketReasons.blocked, reason, "fix-eligibility-blocked");
     }
   }
@@ -530,7 +530,9 @@ function countBlockingFixEligibilityReasons(reasonCounts: unknown): number {
   let total = 0;
   for (const [reason, count] of Object.entries(reasonCounts)) {
     const normalizedReason = sanitizeSummaryToken(reason);
-    if (normalizedReason === "eligible" || normalizedReason === "line-not-commentable") continue;
+    // moved-to-details reasons (missing-replacement, line-not-commentable)
+    // are preserved findings, not blocked ones — do not count them as blocked.
+    if (normalizedReason === "eligible" || normalizedReason === "line-not-commentable" || normalizedReason === "missing-replacement") continue;
     total += normalizeCount(count);
   }
   return total;

--- a/src/review-orchestration/review-reducer.ts
+++ b/src/review-orchestration/review-reducer.ts
@@ -194,7 +194,11 @@ type DegradedReviewReducerInput = {
   reason: string;
 };
 
-const DEFAULT_MIN_CONFIDENCE = 50;
+// 40 keeps every severity/category combination from computeConfidence visible
+// (the lowest, minor+documentation, scores exactly 40). The old default of 50
+// silently dropped all minor style/documentation findings even under the
+// strict profile, which promises minor-level findings.
+const DEFAULT_MIN_CONFIDENCE = 40;
 const DEFAULT_FAIL_OPEN_CONFIDENCE = 100;
 const MAX_SUMMARY_LENGTH = 240;
 const MAX_REASON_LENGTH = 64;
@@ -678,8 +682,14 @@ if (finding.suppressed || (typeof finding.confidence === "number" && Number.isFi
     }
 
     const fileRiskByPath = new Map(input.riskScores.map((risk) => [risk.filePath, risk.score]));
+    // Findings without a numeric confidence pass the filter: Number(undefined)
+    // is NaN and NaN >= min is always false, which used to silently drop them.
+    const passesConfidence = (finding: ProcessedReviewFinding): boolean =>
+      typeof finding.confidence !== "number"
+      || !Number.isFinite(finding.confidence)
+      || finding.confidence >= input.minConfidence;
     let visibleFindings = processedFindings.filter((finding) =>
-      !finding.suppressed && Number(finding.confidence) >= input.minConfidence
+      !finding.suppressed && passesConfidence(finding)
     );
 
     let prioritizationStats: ReviewReducerPrioritizationStats | undefined;
@@ -717,7 +727,7 @@ if (finding.suppressed || (typeof finding.confidence === "number" && Number.isFi
       );
 
       processedFindings = processedFindings.map((finding) => {
-        if (finding.suppressed || Number(finding.confidence) < input.minConfidence) {
+        if (finding.suppressed || !passesConfidence(finding)) {
           return finding;
         }
         if (selectedCommentIds.has(finding.commentId)) {
@@ -728,15 +738,15 @@ if (finding.suppressed || (typeof finding.confidence === "number" && Number.isFi
 
       audit.push({ action: "deprioritized", source: "finding-prioritizer", count: prioritizationStats.omittedFindings ?? 0 });
       visibleFindings = processedFindings.filter((finding) =>
-        !finding.suppressed && !finding.deprioritized && Number(finding.confidence) >= input.minConfidence
+        !finding.suppressed && !finding.deprioritized && passesConfidence(finding)
       );
     }
 
     const lowConfidenceFindings = processedFindings.filter((finding) =>
-      !finding.suppressed && Number(finding.confidence) < input.minConfidence
+      !finding.suppressed && !passesConfidence(finding)
     );
     const filteredInlineFindings = processedFindings.filter((finding) =>
-      finding.suppressed || Number(finding.confidence) < input.minConfidence || Boolean(finding.deprioritized)
+      finding.suppressed || !passesConfidence(finding) || Boolean(finding.deprioritized)
     );
 
     const counts = buildReviewReducerCounts(processedFindings, audit, { minConfidence: input.minConfidence });

--- a/src/slack/assistant-handler.test.ts
+++ b/src/slack/assistant-handler.test.ts
@@ -773,10 +773,10 @@ describe("createSlackAssistantHandler", () => {
 
     expect(executionInputs).toHaveLength(1);
     const prompt = executionInputs[0]!.prompt;
-    // PROMPT-04: Epistemic boundaries section is present
-    expect(prompt).toContain("## Epistemic Boundaries");
-    expect(prompt).toContain("Diff-visible");
-    expect(prompt).toContain("External knowledge");
+    // PROMPT-04: Evidence and Verification section is present
+    expect(prompt).toContain("## Evidence and Verification");
+    expect(prompt).toContain("full read access to the repository");
+    expect(prompt).toContain("Library and API behavior claims are allowed");
     expect(prompt).toContain("System-provided enrichment");
   });
 


### PR DESCRIPTION
## Why

Kodiai reviews degraded into rubber stamps. Canonical failure: xbmc/xbmc#28838 — approved in **2 agent turns** with zero findings, while a manual Opus review of the same diff found a codec-limited fix, an MKV VFR regression risk, and guideline violations visible in the diff itself. Root causes traced in prod logs + code:

1. **Tiny-diff fast path forbade exploration** — "Read only the changed file", "end without additional exploratory turns", "merge decision after one focused inspection pass". 14/76 reviews last week took this path; every one approved with zero findings.
2. **Suppression-stacked prompt** — "silently omit what you cannot verify", external library/API knowledge banned, senior authors got "only flag issues you're highly confident about".
3. **Inline publication structurally required a generated fix patch** — findings without a safe autofix (`missing-replacement`) could never become inline comments; a MAJOR undefined-behavior finding on xbmc/xbmc#28831 was reduced to a 240-char stub. ~40% of last week's reviews hit this blocked-findings path.
4. **Reducer silently dropped findings** — missing confidence field (NaN comparison) and every minor style/doc finding (floor 50 vs. computed 40–45).
5. **User-visible comments were telemetry dumps** — M072 bridge lines, redaction flags, lifecycle counts.

## What changed

- **Small-diff reviews**: full review tool set (Read/Grep/Glob + git diff/log/show/status), risk-scaled turn budgets, prompt requires tracing each change's blast radius (callers, removed fallbacks) before approving.
- **Coverage-first prompt**: report every issue found — uncertain and low-severity included, with severity + stated uncertainty — downstream reducer ranks and gates. "Evidence and Verification" section grants full repository read access and allows library/API behavior claims (version assumptions stated, verified against vendored sources when present). Author experience adapts tone/verbosity only, never the reporting bar.
- **Prose inline comments**: findings without a fix patch now publish as normal inline review comments (`**SEVERITY** (category): title` + finding body). Suggestion comments now include the finding explanation above the ```suggestion``` fence. Secret scanning covers the body text.
- **Model + budgets**: default model `claude-sonnet-5` (same list price as Sonnet 4.5, adaptive thinking on by default), default maxTurns 25→40, prompt section budgets raised (diff 12k→32k chars, knowledge 3.6k→8k, instructions 16k→24k) — a 983-line PR was losing 11.6k tokens of context to trimming.
- **Readable comments**: internal telemetry lines removed from PR comment bodies (still in structured logs). Token footer now shows cache read/write so cost is interpretable.
- **Bug fixes**: NaN-confidence drop, confidence floor 50→40, `missing-replacement` no longer double-counted as fix-eligibility-blocked.

## Cost

Last 7 days: 56 reviews, ~$0.40 avg. These changes raise turns/context on small diffs; Sonnet 5 intro pricing ($2/$10 through Aug 31) offsets most of it. Expected steady-state well under $1/review.

## Verification

- `bun test src`: 5564 pass / 0 fail
- `bunx tsc --noEmit`: clean
- `bunx eslint src --max-warnings=0`: clean

Follow-up candidates (not in this PR): `scripts/verify-m074-s06.ts` wording still references the details-block validation-truth line (evidence now derives from log projection); large-PR "minimal" auto-profile band could be revisited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)