### PR TITLE
Milestone verifiers source telemetry evidence from log projections

### DIFF
--- a/scripts/verify-m067-s01.test.ts
+++ b/scripts/verify-m067-s01.test.ts
@@ -36,6 +36,7 @@ describe("evaluateM067S01ReviewPlanContract", () => {
     });
 
     expect(report.review_details.ready.marker_count).toBe(1);
+    expect(report.review_details.ready.visible_review_plan_line_count).toBe(0);
     expect(report.review_details.ready.review_plan_line_count).toBe(1);
     expect(report.review_details.ready.review_plan_line).toStartWith("- Review plan: ready hash=");
     expect(report.review_details.ready.review_plan_line.length).toBeLessThanOrEqual(242);
@@ -55,6 +56,7 @@ describe("evaluateM067S01ReviewPlanContract", () => {
 
     expect(report.degraded_plan.status).toBe("degraded");
     expect(report.degraded_plan.hash).toMatch(/^degraded-[a-f0-9]{16}$/);
+    expect(report.review_details.degraded.visible_review_plan_line_count).toBe(0);
     expect(report.review_details.degraded.review_plan_line_count).toBe(1);
     expect(report.review_details.degraded.review_plan_line).toContain("Review plan: degraded");
     expect(report.review_details.degraded.review_plan_line).toContain("graph=skipped");
@@ -107,8 +109,8 @@ describe("main", () => {
         ready_plan: { status: "ready", hash: "" },
         degraded_plan: { status: "degraded", hash: "degraded-0000000000000000" },
         review_details: {
-          ready: { marker_count: 0, review_plan_line_count: 0, review_plan_line: "" },
-          degraded: { marker_count: 0, review_plan_line_count: 0, review_plan_line: "" },
+          ready: { marker_count: 0, visible_review_plan_line_count: 0, review_plan_line_count: 0, review_plan_line: "" },
+          degraded: { marker_count: 0, visible_review_plan_line_count: 0, review_plan_line_count: 0, review_plan_line: "" },
         },
       }),
     });

--- a/scripts/verify-m067-s01.ts
+++ b/scripts/verify-m067-s01.ts
@@ -7,6 +7,7 @@ import {
   type ReviewPlanInput,
 } from "../src/review-orchestration/review-plan.ts";
 import { formatReviewDetailsSummary } from "../src/lib/review-utils.ts";
+import { formatReviewPlanDetailsLine } from "../src/lib/review-details-plan-formatting.ts";
 import { projectContributorExperienceContract } from "../src/contributor/experience-contract.ts";
 
 export const M067_S01_CHECK_IDS = [
@@ -39,6 +40,9 @@ export type M067S01Check = {
 
 export type M067S01ReviewDetailsEvidence = {
   marker_count: number;
+  /** Review plan lines visible in the user-facing Review Details block (must be 0). */
+  visible_review_plan_line_count: number;
+  /** Review plan lines produced by the structured-log line formatter (must be 1). */
   review_plan_line_count: number;
   review_plan_line: string;
 };
@@ -170,16 +174,24 @@ function countOccurrences(value: string, needle: string): number {
   return value.split(needle).length - 1;
 }
 
-function inspectReviewDetails(body: string, reviewOutputKey: string): M067S01ReviewDetailsEvidence {
-  const reviewPlanLines = body
+function inspectReviewDetails(params: {
+  body: string;
+  reviewOutputKey: string;
+  formatterLines: string[];
+}): M067S01ReviewDetailsEvidence {
+  const visibleReviewPlanLines = params.body
     .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.includes("Review plan:"));
+  const formatterReviewPlanLines = params.formatterLines
     .map((line) => line.trim())
     .filter((line) => line.includes("Review plan:"));
 
   return {
-    marker_count: countOccurrences(body, `<!-- kodiai:review-details:${reviewOutputKey} -->`),
-    review_plan_line_count: reviewPlanLines.length,
-    review_plan_line: reviewPlanLines[0] ?? "",
+    marker_count: countOccurrences(params.body, `<!-- kodiai:review-details:${params.reviewOutputKey} -->`),
+    visible_review_plan_line_count: visibleReviewPlanLines.length,
+    review_plan_line_count: formatterReviewPlanLines.length,
+    review_plan_line: formatterReviewPlanLines[0] ?? "",
   };
 }
 
@@ -200,15 +212,17 @@ function buildReadyPlanHashCheck(plan: ReviewPlan): M067S01Check {
 }
 
 function buildReadyReviewDetailsCheck(evidence: M067S01ReviewDetailsEvidence): M067S01Check {
+  const visibleBlockClean = evidence.visible_review_plan_line_count === 0;
   const hasExactlyOneLine = evidence.review_plan_line_count === 1;
   const hasMarker = evidence.marker_count === 1;
   const startsCompact = evidence.review_plan_line.startsWith("- Review plan: ready hash=");
   const withinBound = evidence.review_plan_line.length <= 242;
   const rawLeak = hasRawLeak(evidence.review_plan_line);
-  const passed = hasExactlyOneLine && hasMarker && startsCompact && withinBound && !rawLeak;
+  const passed = visibleBlockClean && hasExactlyOneLine && hasMarker && startsCompact && withinBound && !rawLeak;
 
   const failures = [
-    ...(!hasExactlyOneLine ? [`expected exactly one compact Review plan line, found ${evidence.review_plan_line_count}`] : []),
+    ...(!visibleBlockClean ? [`expected exactly one compact Review plan line, found ${evidence.visible_review_plan_line_count} in the visible Review Details block (must be absent from the user-visible comment)`] : []),
+    ...(!hasExactlyOneLine ? [`expected exactly one compact Review plan line from the log-line formatter, found ${evidence.review_plan_line_count}`] : []),
     ...(!hasMarker ? [`expected exactly one Review Details marker, found ${evidence.marker_count}`] : []),
     ...(!startsCompact ? ["Review plan line does not use the compact ready prefix"] : []),
     ...(!withinBound ? [`Review plan line is too long (${evidence.review_plan_line.length} chars)`] : []),
@@ -220,7 +234,7 @@ function buildReadyReviewDetailsCheck(evidence: M067S01ReviewDetailsEvidence): M
     passed,
     status_code: passed ? "ready_review_details_compact" : "ready_review_details_not_compact",
     detail: passed
-      ? "ready Review Details contains exactly one compact Review plan line and marker with no raw data leaks"
+      ? "ready Review Details omits the Review plan line; log-line formatter emits exactly one compact line with no raw data leaks"
       : failures.join("; "),
   };
 }
@@ -230,6 +244,7 @@ function buildDegradedPlanRenderingCheck(params: {
   evidence: M067S01ReviewDetailsEvidence;
 }): M067S01Check {
   const hasDegradedHash = /^degraded-[a-f0-9]{16}$/.test(params.plan.hash);
+  const visibleBlockClean = params.evidence.visible_review_plan_line_count === 0;
   const hasExactlyOneLine = params.evidence.review_plan_line_count === 1;
   const hasMarker = params.evidence.marker_count === 1;
   const line = params.evidence.review_plan_line;
@@ -237,11 +252,12 @@ function buildDegradedPlanRenderingCheck(params: {
     && line.includes("graph=skipped")
     && line.includes("candidates=unavailable");
   const rawLeak = hasRawLeak(line);
-  const passed = hasDegradedHash && hasExactlyOneLine && hasMarker && hasDegradedSignals && !rawLeak;
+  const passed = hasDegradedHash && visibleBlockClean && hasExactlyOneLine && hasMarker && hasDegradedSignals && !rawLeak;
 
   const failures = [
     ...(!hasDegradedHash ? ["degraded plan hash missing or malformed"] : []),
-    ...(!hasExactlyOneLine ? [`expected one degraded Review plan line, found ${params.evidence.review_plan_line_count}`] : []),
+    ...(!visibleBlockClean ? [`expected zero degraded Review plan lines in the visible Review Details block, found ${params.evidence.visible_review_plan_line_count}`] : []),
+    ...(!hasExactlyOneLine ? [`expected one degraded Review plan line from the log-line formatter, found ${params.evidence.review_plan_line_count}`] : []),
     ...(!hasMarker ? [`expected one degraded Review Details marker, found ${params.evidence.marker_count}`] : []),
     ...(!hasDegradedSignals ? ["degraded Review plan line missing degraded/graph/candidate signals"] : []),
     ...(rawLeak ? ["degraded Review plan line leaked raw data"] : []),
@@ -252,7 +268,7 @@ function buildDegradedPlanRenderingCheck(params: {
     passed,
     status_code: passed ? "degraded_plan_rendered" : "degraded_plan_not_rendered",
     detail: passed
-      ? "degraded plan renders as fail-open Review Details metadata"
+      ? "degraded plan renders as fail-open structured-log metadata and stays out of the visible Review Details block"
       : failures.join("; "),
   };
 }
@@ -289,8 +305,8 @@ function buildInvalidArgReport(params: { generatedAt?: string; issue: string }):
     ready_plan: { status: "ready", hash: "" },
     degraded_plan: { status: "degraded", hash: "degraded-0000000000000000" },
     review_details: {
-      ready: { marker_count: 0, review_plan_line_count: 0, review_plan_line: "" },
-      degraded: { marker_count: 0, review_plan_line_count: 0, review_plan_line: "" },
+      ready: { marker_count: 0, visible_review_plan_line_count: 0, review_plan_line_count: 0, review_plan_line: "" },
+      degraded: { marker_count: 0, visible_review_plan_line_count: 0, review_plan_line_count: 0, review_plan_line: "" },
     },
   };
 }
@@ -317,8 +333,16 @@ export function evaluateM067S01ReviewPlanContract(params?: EvaluateM067S01Params
     formatter,
   });
 
-  const readyEvidence = inspectReviewDetails(readyReviewDetails, READY_REVIEW_OUTPUT_KEY);
-  const degradedEvidence = inspectReviewDetails(degradedReviewDetails, DEGRADED_REVIEW_OUTPUT_KEY);
+  const readyEvidence = inspectReviewDetails({
+    body: readyReviewDetails,
+    reviewOutputKey: READY_REVIEW_OUTPUT_KEY,
+    formatterLines: formatReviewPlanDetailsLine(toReviewPlanDetailsSummary(readyPlan)),
+  });
+  const degradedEvidence = inspectReviewDetails({
+    body: degradedReviewDetails,
+    reviewOutputKey: DEGRADED_REVIEW_OUTPUT_KEY,
+    formatterLines: formatReviewPlanDetailsLine(toReviewPlanDetailsSummary(degradedPlan)),
+  });
   const checks = [
     buildReadyPlanHashCheck(readyPlan),
     buildReadyReviewDetailsCheck(readyEvidence),

--- a/scripts/verify-m067-s03.test.ts
+++ b/scripts/verify-m067-s03.test.ts
@@ -68,6 +68,7 @@ describe("evaluateM067S03ReviewReducerContract", () => {
     expect(report.reducer.low_confidence_comment_ids).toEqual([4]);
     expect(report.reducer.details_line).toStartWith("Review reducer: ready");
     expect(report.reducer.details_line.length).toBeLessThanOrEqual(240);
+    expect(report.reducer.visible_review_reducer_line_count).toBe(0);
     expect(report.reducer.review_details_line_count).toBe(1);
     expect(report.degraded.status).toBe("degraded");
     expect(report.degraded.filtered_inline_count).toBe(0);
@@ -166,6 +167,7 @@ describe("evaluateM067S03ReviewReducerContract", () => {
           low_confidence_comment_ids: [],
           audit_sources: [],
           details_line: "",
+          visible_review_reducer_line_count: 0,
           review_details_line_count: 0,
         },
         degraded: {

--- a/scripts/verify-m067-s03.ts
+++ b/scripts/verify-m067-s03.ts
@@ -1,4 +1,5 @@
 import { formatReviewDetailsSummary } from "../src/lib/review-utils.ts";
+import { formatReviewReducerDetailsLine } from "../src/lib/review-details-plan-formatting.ts";
 import { projectContributorExperienceContract } from "../src/contributor/experience-contract.ts";
 import {
   createDegradedReviewReducerResult,
@@ -55,6 +56,9 @@ export type M067S03ReducerEvidence = {
   low_confidence_comment_ids: number[];
   audit_sources: string[];
   details_line: string;
+  /** Review reducer lines visible in the user-facing Review Details block (must be 0). */
+  visible_review_reducer_line_count: number;
+  /** Review reducer lines produced by the structured-log line formatter (must be 1). */
   review_details_line_count: number;
 };
 
@@ -336,7 +340,10 @@ function toReducerEvidence(result: ReviewReducerResult, reviewDetails: string): 
     low_confidence_comment_ids: result.lowConfidenceFindings.map((finding) => finding.commentId).sort((a, b) => a - b),
     audit_sources: result.audit.map((event) => event.source).sort(),
     details_line: sanitizeEvidenceText(result.detailsSummary.text),
-    review_details_line_count: countReviewReducerLines(reviewDetails),
+    visible_review_reducer_line_count: countReviewReducerLines(reviewDetails),
+    review_details_line_count: countReviewReducerLines(
+      formatReviewReducerDetailsLine(result.detailsSummary).join("\n"),
+    ),
   };
 }
 
@@ -397,7 +404,8 @@ function buildBehaviorParityCheck(evidence: M067S03ReducerEvidence): M067S03Chec
 function buildDetailsCompactCheck(evidence: M067S03ReducerEvidence): M067S03Check {
   const line = evidence.details_line;
   const failures = [
-    ...(evidence.review_details_line_count !== 1 ? [`Review Details emitted ${evidence.review_details_line_count} reducer lines`] : []),
+    ...(evidence.visible_review_reducer_line_count !== 0 ? [`visible Review Details emitted ${evidence.visible_review_reducer_line_count} reducer lines (must stay out of the user-visible comment)`] : []),
+    ...(evidence.review_details_line_count !== 1 ? [`log-line formatter emitted ${evidence.review_details_line_count} reducer lines`] : []),
     ...(!line.startsWith("Review reducer: ready") ? ["reducer details line did not use ready prefix"] : []),
     ...(line.length > 240 ? [`reducer details line too long (${line.length} chars)`] : []),
     ...(!line.includes("kept=2") ? ["details line omitted kept=2"] : []),
@@ -412,7 +420,7 @@ function buildDetailsCompactCheck(evidence: M067S03ReducerEvidence): M067S03Chec
     passed: failures.length === 0,
     status_code: failures.length === 0 ? "reducer_details_compact" : "reducer_details_not_compact",
     detail: failures.length === 0
-      ? "Review Details contains exactly one bounded Review reducer line with no raw fixture leakage"
+      ? "visible Review Details omits the reducer line; log-line formatter emits exactly one bounded Review reducer line with no raw fixture leakage"
       : failures.join("; "),
   };
 }
@@ -502,6 +510,7 @@ function emptyReducerEvidence(): M067S03ReducerEvidence {
     low_confidence_comment_ids: [],
     audit_sources: [],
     details_line: "",
+    visible_review_reducer_line_count: 0,
     review_details_line_count: 0,
   };
 }

--- a/scripts/verify-m067-s04.test.ts
+++ b/scripts/verify-m067-s04.test.ts
@@ -65,6 +65,8 @@ describe("evaluateM067S04CandidateSeamContract", () => {
     });
     expect(report.mcp.allowed_tools).toContain("mcp__review_candidate_finding__record_candidate_finding");
     expect(report.mcp.allowed_tools).toContain("mcp__github_inline_comment__create_inline_comment");
+    expect(report.review_details.visible_candidate_line_count).toBe(0);
+    expect(report.review_details.candidate_line_count).toBe(1);
     expect(report.review_details.candidate_line).toStartWith("- Review candidates: shadow");
     expect(report.review_plan.candidate_mode).toBe("shadow");
     expect(report.prompt.has_shadow_section).toBe(true);
@@ -184,6 +186,7 @@ describe("main", () => {
         },
         review_details: {
           marker_count: 0,
+          visible_candidate_line_count: 0,
           candidate_line_count: 0,
           candidate_line: "",
         },

--- a/scripts/verify-m067-s04.ts
+++ b/scripts/verify-m067-s04.ts
@@ -4,6 +4,7 @@ import { buildAllowedMcpTools, buildMcpServerFactories } from "../src/execution/
 import { createCandidateFindingServer } from "../src/execution/mcp/candidate-finding-server.ts";
 import { buildReviewPrompt } from "../src/execution/review-prompt.ts";
 import { formatReviewDetailsSummary } from "../src/lib/review-utils.ts";
+import { formatReviewCandidateFindingDetailsLine } from "../src/lib/review-details-candidate-finding-formatting.ts";
 import {
   buildReviewPlan,
   toReviewPlanDetailsSummary,
@@ -81,6 +82,9 @@ export type M067S04Report = {
   };
   review_details: {
     marker_count: number;
+    /** Review candidates lines visible in the user-facing Review Details block (must be 0). */
+    visible_candidate_line_count: number;
+    /** Review candidates lines produced by the structured-log line formatter (must be 1). */
     candidate_line_count: number;
     candidate_line: string;
   };
@@ -248,16 +252,29 @@ function buildReviewDetails(params: {
   });
 }
 
-function inspectReviewDetails(body: string): { marker_count: number; candidate_line_count: number; candidate_line_raw: string; candidate_line: string } {
-  const candidateLines = body
+function inspectReviewDetails(params: {
+  body: string;
+  formatterLines: string[];
+}): {
+  marker_count: number;
+  visible_candidate_line_count: number;
+  candidate_line_count: number;
+  candidate_line_raw: string;
+  candidate_line: string;
+} {
+  const visibleCandidateLines = params.body
     .split("\n")
     .map((line) => line.trim())
     .filter((line) => line.includes("Review candidates:"));
+  const formatterCandidateLines = params.formatterLines
+    .map((line) => line.trim())
+    .filter((line) => line.includes("Review candidates:"));
 
-  const candidateLineRaw = candidateLines[0] ?? "";
+  const candidateLineRaw = formatterCandidateLines[0] ?? "";
   return {
-    marker_count: countOccurrences(body, `<!-- kodiai:review-details:${REVIEW_OUTPUT_KEY} -->`),
-    candidate_line_count: candidateLines.length,
+    marker_count: countOccurrences(params.body, `<!-- kodiai:review-details:${REVIEW_OUTPUT_KEY} -->`),
+    visible_candidate_line_count: visibleCandidateLines.length,
+    candidate_line_count: formatterCandidateLines.length,
     candidate_line_raw: candidateLineRaw,
     candidate_line: sanitizeEvidenceText(candidateLineRaw),
   };
@@ -357,11 +374,17 @@ function buildFailOpenCheck(params: {
   };
 }
 
-function buildDetailsCompactCheck(params: { markerCount: number; candidateLineCount: number; candidateLineRaw: string }): M067S04Check {
+function buildDetailsCompactCheck(params: {
+  markerCount: number;
+  visibleCandidateLineCount: number;
+  candidateLineCount: number;
+  candidateLineRaw: string;
+}): M067S04Check {
   const line = params.candidateLineRaw;
   const failures = [
     ...(params.markerCount !== 1 ? [`Review Details marker count was ${params.markerCount}`] : []),
-    ...(params.candidateLineCount !== 1 ? [`Review candidates line count was ${params.candidateLineCount}`] : []),
+    ...(params.visibleCandidateLineCount !== 0 ? [`visible Review Details emitted ${params.visibleCandidateLineCount} Review candidates lines (must stay out of the user-visible comment)`] : []),
+    ...(params.candidateLineCount !== 1 ? [`log-line formatter Review candidates line count was ${params.candidateLineCount}`] : []),
     ...(!line.startsWith("- Review candidates: shadow") ? ["candidate details line did not use shadow prefix"] : []),
     ...(line.length > 262 ? [`candidate details line too long (${line.length} chars)`] : []),
     ...(!line.includes("recorded=1") ? ["candidate details line omitted recorded=1"] : []),
@@ -379,7 +402,7 @@ function buildDetailsCompactCheck(params: { markerCount: number; candidateLineCo
     passed: failures.length === 0,
     status_code: failures.length === 0 ? "candidate_details_compact" : "candidate_details_not_compact",
     detail: failures.length === 0
-      ? "Review Details contains exactly one compact Review candidates line with count-only/correlation-only evidence"
+      ? "visible Review Details omits the candidates line; log-line formatter emits exactly one compact Review candidates line with count-only/correlation-only evidence"
       : sanitizeEvidenceText(failures.join("; ")),
   };
 }
@@ -488,6 +511,7 @@ function emptyReport(params: { generatedAt?: string; issue: string }): M067S04Re
     },
     review_details: {
       marker_count: 0,
+      visible_candidate_line_count: 0,
       candidate_line_count: 0,
       candidate_line: "",
     },
@@ -538,7 +562,10 @@ export async function evaluateM067S04CandidateSeamContract(params?: EvaluateM067
   }).plan;
   const reviewPlanSummary = toReviewPlanDetailsSummary(reviewPlan);
   const reviewDetails = buildReviewDetails({ candidateSummary, reviewPlanSummary });
-  const reviewDetailsEvidence = inspectReviewDetails(reviewDetails);
+  const reviewDetailsEvidence = inspectReviewDetails({
+    body: reviewDetails,
+    formatterLines: formatReviewCandidateFindingDetailsLine(candidateSummary),
+  });
 
   const recordedCalls: unknown[] = [];
   const warnings: unknown[] = [];
@@ -629,6 +656,7 @@ export async function evaluateM067S04CandidateSeamContract(params?: EvaluateM067
     }),
     buildDetailsCompactCheck({
       markerCount: reviewDetailsEvidence.marker_count,
+      visibleCandidateLineCount: reviewDetailsEvidence.visible_candidate_line_count,
       candidateLineCount: reviewDetailsEvidence.candidate_line_count,
       candidateLineRaw: reviewDetailsEvidence.candidate_line_raw,
     }),
@@ -666,6 +694,7 @@ export async function evaluateM067S04CandidateSeamContract(params?: EvaluateM067
     },
     review_details: {
       marker_count: reviewDetailsEvidence.marker_count,
+      visible_candidate_line_count: reviewDetailsEvidence.visible_candidate_line_count,
       candidate_line_count: reviewDetailsEvidence.candidate_line_count,
       candidate_line: reviewDetailsEvidence.candidate_line,
     },

--- a/scripts/verify-m067-s05.test.ts
+++ b/scripts/verify-m067-s05.test.ts
@@ -119,7 +119,7 @@ function makeS04Report(success = true): M067S04Report {
     issues: [],
     candidate: { status: "shadow" as const, counts: { input: 1, recorded: 1, rejected: 0, errors: 0 }, artifact_present: true, artifact_basename: "review-candidate-findings.json", details_line: "" },
     mcp: { server_names: [], allowed_tools: [], recorded_response: {}, failing_recorder_response: {}, warning_count: 0 },
-    review_details: { marker_count: 1, candidate_line_count: 1, candidate_line: "" },
+    review_details: { marker_count: 1, visible_candidate_line_count: 0, candidate_line_count: 1, candidate_line: "" },
     review_plan: { status: "ready" as const, candidate_mode: "shadow" as const, details_line: "" },
     prompt: { has_shadow_section: true, shadow_section: "", publish_tool_count: 2, includes_candidate_in_publish_contract: false },
     sidecar: { artifact_present: true, artifact_basename: "review-candidate-findings.json" },

--- a/scripts/verify-m070-s03.test.ts
+++ b/scripts/verify-m070-s03.test.ts
@@ -77,6 +77,7 @@ describe("verify-m070-s03", () => {
         correlationKeyAvailable: true,
       },
       surfaces: {
+        reviewDetailsLineOmittedFromComment: true,
         reviewDetailsLineAvailable: true,
         reviewDetailsAggregateCountsAvailable: true,
         reviewDetailsReasonsAvailable: true,
@@ -164,7 +165,7 @@ describe("verify-m070-s03", () => {
     expect(report.success).toBe(false);
     expect(report.failing_check_id).toBe("M070-S03-REVIEW-DETAILS-SURFACE");
     expect(report.redaction.reviewDetailsLeakPresent).toBe(true);
-    expect(report.issues.join("\n")).toContain("Expected reviewDetailsAggregateCountsAvailable to be true.");
+    expect(report.issues.join("\n")).toContain("Expected reviewDetailsLineOmittedFromComment to be true.");
   });
 
   test("fails if runtime log fields contain a forbidden canary", async () => {

--- a/scripts/verify-m070-s03.ts
+++ b/scripts/verify-m070-s03.ts
@@ -1,4 +1,5 @@
 import { formatReviewDetailsSummary } from "../src/lib/review-utils.ts";
+import { formatCandidateVerificationPublicationEvidenceLine } from "../src/lib/review-details-candidate-verification-formatting.ts";
 import { projectContributorExperienceContract } from "../src/contributor/experience-contract.ts";
 import {
   initialCandidateVerificationPublicationEvidenceSummary,
@@ -106,6 +107,7 @@ export type M070S03Report = {
     readonly correlationKeyValue: string | null;
   };
   readonly surfaces: {
+    readonly reviewDetailsLineOmittedFromComment: boolean;
     readonly reviewDetailsLineAvailable: boolean;
     readonly reviewDetailsAggregateCountsAvailable: boolean;
     readonly reviewDetailsReasonsAvailable: boolean;
@@ -345,11 +347,15 @@ export async function evaluateM070S03Contract(options: EvaluateM070S03Options = 
   const fixtureSummaries = FIXTURES.map((fixture) => summarizeFixture(fixture));
   const aggregateEvidence = summarizeAggregate(fixtureSummaries);
   const reviewDetails = buildReviewDetails(formatDetails, aggregateEvidence);
-  const reviewDetailsLine = reviewDetails.split("\n").find((line) => line.includes("M070 candidate verification publication")) ?? "";
+  // The M070 aggregate line is a machine diagnostic: it must stay OUT of the
+  // user-visible Review Details comment and is asserted against the exported
+  // structured-log line formatter instead.
+  const reviewDetailsLine = formatCandidateVerificationPublicationEvidenceLine(aggregateEvidence) ?? "";
+  const reviewDetailsLineOmittedFromComment = !reviewDetails.includes("M070 candidate verification publication");
   const runtimeLogFields = buildLogFields(aggregateEvidence);
-  const surfaces = summarizeSurfaces(reviewDetailsLine, runtimeLogFields);
+  const surfaces = summarizeSurfaces(reviewDetailsLine, reviewDetailsLineOmittedFromComment, runtimeLogFields);
   const packageJsonText = await readPackageJsonText();
-  const redaction = summarizeRedaction(aggregateEvidence, reviewDetails, runtimeLogFields);
+  const redaction = summarizeRedaction(aggregateEvidence, `${reviewDetails}\n${reviewDetailsLine}`, runtimeLogFields);
   const malformedFailClosed = summarizeMalformed(fixtureSummaries);
 
   const reportWithoutChecks = {
@@ -517,9 +523,14 @@ function buildCandidateVerificationPublicationEvidenceLogFields(evidence: Candid
   };
 }
 
-function summarizeSurfaces(reviewDetailsLine: string, logFields: Record<string, unknown>): M070S03Report["surfaces"] {
+function summarizeSurfaces(
+  reviewDetailsLine: string,
+  reviewDetailsLineOmittedFromComment: boolean,
+  logFields: Record<string, unknown>,
+): M070S03Report["surfaces"] {
   const logText = JSON.stringify(logFields);
   return {
+    reviewDetailsLineOmittedFromComment,
     reviewDetailsLineAvailable: reviewDetailsLine.includes("M070 candidate verification publication"),
     reviewDetailsAggregateCountsAvailable: reviewDetailsLine.includes("counts=attempted:") && reviewDetailsLine.includes("verification=verified:"),
     reviewDetailsReasonsAvailable: reviewDetailsLine.includes("denialCounts=") && reviewDetailsLine.includes("reasons="),
@@ -622,6 +633,7 @@ function buildAggregateProjectionCheck(evidence: CandidateVerificationPublicatio
 
 function buildReviewDetailsSurfaceCheck(surfaces: M070S03Report["surfaces"]): M070S03Check {
   const failures = booleanFailures(surfaces, [
+    "reviewDetailsLineOmittedFromComment",
     "reviewDetailsLineAvailable",
     "reviewDetailsAggregateCountsAvailable",
     "reviewDetailsReasonsAvailable",
@@ -632,7 +644,7 @@ function buildReviewDetailsSurfaceCheck(surfaces: M070S03Report["surfaces"]): M0
     id: "M070-S03-REVIEW-DETAILS-SURFACE",
     okCode: "review_details_surface_ok",
     failCode: "review_details_surface_failed",
-    okDetail: "Review Details exposes the M070 aggregate line with counts, bounded reasons, correlation metadata, and redaction flags.",
+    okDetail: "The visible Review Details comment omits the M070 aggregate line while the structured-log line formatter exposes counts, bounded reasons, correlation metadata, and redaction flags.",
     failures,
   });
 }
@@ -843,6 +855,7 @@ function buildInvalidArgReport(issue: string): M070S03Report {
       correlationKeyValue: null,
     },
     surfaces: {
+      reviewDetailsLineOmittedFromComment: false,
       reviewDetailsLineAvailable: false,
       reviewDetailsAggregateCountsAvailable: false,
       reviewDetailsReasonsAvailable: false,

--- a/scripts/verify-m070-s05.ts
+++ b/scripts/verify-m070-s05.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 
 import { buildMcpServers } from "../src/execution/mcp/index.ts";
+import { formatCandidateVerificationPublicationEvidenceLine } from "../src/lib/review-details-candidate-verification-formatting.ts";
 import type { ExecutionContext, ExecutionPublishEvent, ExecutionResult } from "../src/execution/types.ts";
 import type { CandidatePublicationPolicyAttempt } from "../src/specialists/candidate-publication-policy.ts";
 import type { CandidateVerificationPublicationEvidenceSummary } from "../src/specialists/candidate-verification-publication-evidence.ts";
@@ -342,7 +343,12 @@ export async function runM070S05Scenario(spec: ScenarioSpec, generatedAt: string
   const directFallbackEvidence = spec.fallbackAfterDenied === true;
   const m070 = evaluateM070VerifierScenario({ scenario: spec.verifierScenario, aggregateEvidence: evidence, publicationMode: { candidateApprovedNonFallback, directFallbackEvidence: false } }, { generatedAt });
   const bodies = visibleBodies(result);
-  const serializedVisible = bodies.join("\n");
+  // PR #206: the M070 aggregate line is a machine diagnostic that no longer
+  // renders in the user-visible Review Details comment. The details-surface
+  // evidence is the exported structured-log line formatter over the
+  // MCP-projected aggregate summary, and the visible comment must stay clean.
+  const m070DetailsLine = formatCandidateVerificationPublicationEvidenceLine(evidence) ?? "";
+  const serializedVisible = [...bodies, m070DetailsLine].join("\n");
   const serializedVerifier = JSON.stringify(m070);
   const rawCanaries = [PROMPT_CANARY, DIFF_CANARY, FINGERPRINT_CANARY, TOOL_PAYLOAD_CANARY, EVIDENCE_PAYLOAD_CANARY, specialistCanary, specialistInlineCanary];
   const baseRow = {
@@ -363,7 +369,8 @@ export async function runM070S05Scenario(spec: ScenarioSpec, generatedAt: string
       evidenceHasCorrelationKey: evidence.metadata.hasCorrelationKey,
     },
     evidenceSurfaces: {
-      reviewDetailsPresent: bodies.some((body) => body.includes("M070 candidate verification publication")),
+      reviewDetailsPresent: m070DetailsLine.includes("M070 candidate verification publication")
+        && !bodies.some((body) => body.includes("M070 candidate verification publication")),
       runtimeLogPresent: result.entries.some((entry) => entry.data?.gate === "m070-candidate-verification-evidence"),
       mcpEvidencePresent: evidenceEvents.length > 0,
     },
@@ -437,7 +444,7 @@ export async function evaluateM070S05Integration(options: { generatedAt?: string
     makeCheck("M070-S05-M070-STATUS-SEMANTICS", allStatusesMatch && positiveRows.every((row) => row.success) && negativeRows.every((row) => !row.success), "Scenario rows match expected M070 verifier status semantics."),
     makeCheck("M070-S05-PUBLICATION-MODE", positivePublish && negativeRejected && directFallbackRejected, "Candidate-approved inline publication is distinguished from denied/direct fallback behavior."),
     makeCheck("M070-S05-CORRELATION-METADATA", successRowsHaveCorrelation, "Successful rows carry delivery, review output, and correlation metadata booleans through context and evidence."),
-    makeCheck("M070-S05-REVIEW-DETAILS-AND-LOGS", surfacesPresent, "Each scenario emits Review Details and runtime log aggregate evidence surfaces."),
+    makeCheck("M070-S05-REVIEW-DETAILS-AND-LOGS", surfacesPresent, "Each scenario emits the structured-log aggregate evidence line and runtime log surfaces while keeping the M070 line out of visible comments."),
     makeCheck("M070-S05-VISIBLE-VOLUME", volumeBounded, "Visible output counts remain locally bounded."),
     makeCheck("M070-S05-REDACTION-BOUNDARY", aggregateOnly, "Verifier JSON and visible surfaces exclude raw candidate/specialist/model/tool/diff/evidence payloads."),
     makeCheck("M070-S05-PACKAGE-WIRING", packageWiring.matches, "package.json exposes verify:m070:s05."),

--- a/scripts/verify-m074-s05.test.ts
+++ b/scripts/verify-m074-s05.test.ts
@@ -57,9 +57,8 @@ describe("verify-m074-s05", () => {
     });
     expect(report.reasonCoverage).toMatchObject({
       eligible: 1,
-      "missing-replacement": 1,
       "duplicate-fix": 1,
-      "max-fixes-exceeded": 1,
+      "max-fixes-exceeded": 2,
       "secret-detected": 1,
       "candidate-denied": 1,
       "line-not-commentable": 1,
@@ -77,10 +76,12 @@ describe("verify-m074-s05", () => {
     });
     expect(report.samePrFixEvidence).toMatchObject({
       eligible: 1,
-      blocked: 5,
-      capped: 1,
+      blocked: 4,
+      capped: 2,
     });
+    expect(report.reasonCoverage["missing-replacement"]).toBeUndefined();
     expect(report.boundedReviewDetails).toMatchObject({
+      visibleValidationTruthLineCount: 0,
       validationTruthLineCount: 1,
       referencesCapped: true,
       reasonCodesCapped: true,
@@ -96,8 +97,8 @@ describe("verify-m074-s05", () => {
     expect(report.boundedReviewDetails.validationTruthLine).toContain("+3 omitted");
     expect(report.boundedReviewDetails.validationTruthLine).toContain("+22 omitted");
     expect(report.visibleVolumeBounds).toMatchObject({
-      maxAddedLines: 1,
-      maxVisibleCharDelta: 1400,
+      maxAddedLines: 0,
+      maxVisibleCharDelta: 0,
       withinLineBound: true,
       withinCharBound: true,
     });
@@ -169,7 +170,7 @@ describe("verify-m074-s05", () => {
     const report = await evaluateM074S05Contract({
       generatedAt: "2026-05-18T18:00:00.000Z",
       readPackageJsonText: async () => `{"scripts":{"${COMMAND_NAME}":"${EXPECTED_PACKAGE_SCRIPT}"}}`,
-      mutateReviewDetailsBody: (body) => body.replace("Review validation truth:", "Validation truth:"),
+      mutateValidationTruthLine: (line) => line.replace("Review validation truth:", "Validation truth:"),
     });
 
     expect(report.success).toBe(false);

--- a/scripts/verify-m074-s05.ts
+++ b/scripts/verify-m074-s05.ts
@@ -13,6 +13,7 @@ import {
   type ValidationTruthStatus,
 } from "../src/review-lifecycle/validation-truth.ts";
 import { formatReviewDetailsSummary } from "../src/lib/review-utils.ts";
+import { formatReviewValidationTruthDetailsLine } from "../src/lib/review-details-validation-formatting.ts";
 import { projectContributorExperienceContract } from "../src/contributor/experience-contract.ts";
 
 export const COMMAND_NAME = "verify:m074:s05" as const;
@@ -66,6 +67,8 @@ export type M074S05Report = {
     readonly reasonCoverage: Partial<Record<SamePrFixEligibilityReasonCode, number>>;
   };
   readonly boundedReviewDetails: {
+    /** Review validation truth lines visible in the user-facing Review Details block (must be 0). */
+    readonly visibleValidationTruthLineCount: number;
     readonly validationTruthLineCount: number;
     readonly validationTruthLine: string;
     readonly totalLines: number;
@@ -105,6 +108,7 @@ export type M074S05EvaluationOptions = {
   readonly mutateValidationEvidence?: (evidence: ValidationTruthEvidence[], records: Record<string, ReviewFindingLifecycleRecord>) => ValidationTruthEvidence[];
   readonly mutateValidationProjection?: (projection: ValidationTruthProjection) => ValidationTruthProjection;
   readonly mutateReviewDetailsBody?: (body: string) => string;
+  readonly mutateValidationTruthLine?: (line: string) => string;
   readonly mutateReportForCanaryCheck?: (report: Omit<M074S05Report, "success" | "statusCode" | "checks" | "issues">) => Omit<M074S05Report, "success" | "statusCode" | "checks" | "issues">;
 };
 
@@ -146,9 +150,11 @@ const REQUIRED_REASONS: readonly ValidationTruthReasonCode[] = [
   "resolved",
 ];
 
+// "missing-replacement" is intentionally absent: candidates without
+// replacement text now publish as prose drafts instead of being blocked,
+// so classifyCandidate never emits that reason code anymore.
 const REQUIRED_FIX_REASONS: readonly SamePrFixEligibilityReasonCode[] = [
   "eligible",
-  "missing-replacement",
   "duplicate-fix",
   "max-fixes-exceeded",
   "secret-detected",
@@ -168,9 +174,11 @@ const CASES: readonly LifecycleExpectation[] = [
   { id: "degraded-evidence", expectedStatus: "degraded", expectedReasons: ["degraded"], shouldResolve: false },
 ] as const;
 
+// The validation-truth diagnostic line moved from the visible Review Details
+// comment to structured logs, so the projection must add NOTHING visible.
 const REVIEW_DETAILS_VOLUME_LIMITS = {
-  maxAddedLines: 1,
-  maxVisibleCharDelta: 1_400,
+  maxAddedLines: 0,
+  maxVisibleCharDelta: 0,
 } as const;
 
 const PR_DIFF = [
@@ -235,7 +243,11 @@ export async function evaluateM074S05Contract(options: M074S05EvaluationOptions 
   const validationProjection = options.mutateValidationProjection?.(validationTruth.projection) ?? validationTruth.projection;
   const baselineReviewDetails = buildReviewDetailsBody(null);
   const reviewDetailsBody = options.mutateReviewDetailsBody?.(buildReviewDetailsBody(validationProjection)) ?? buildReviewDetailsBody(validationProjection);
-  const validationTruthLines = reviewDetailsBody.split("\n").filter((line) => line.includes("Review validation truth:"));
+  const visibleValidationTruthLines = reviewDetailsBody.split("\n").filter((line) => line.includes("Review validation truth:"));
+  const formattedValidationTruthLine = formatReviewValidationTruthDetailsLine(validationProjection);
+  const validationTruthLines = (formattedValidationTruthLine === null ? [] : [formattedValidationTruthLine])
+    .map((line) => options.mutateValidationTruthLine?.(line) ?? line)
+    .filter((line) => line.includes("Review validation truth:"));
   const validationTruthLine = validationTruthLines[0] ?? "";
   const statusByCase = Object.fromEntries(
     CASES.map((item) => [item.id, validationTruth.records.find((record) => record.id === records[item.id]?.id)?.status ?? "degraded"]),
@@ -271,6 +283,7 @@ export async function evaluateM074S05Contract(options: M074S05EvaluationOptions 
       reasonCoverage: fixReasonCoverage,
     },
     boundedReviewDetails: {
+      visibleValidationTruthLineCount: visibleValidationTruthLines.length,
       validationTruthLineCount: validationTruthLines.length,
       validationTruthLine,
       totalLines: reviewDetailsBody.split("\n").length,
@@ -331,17 +344,19 @@ export async function evaluateM074S05Contract(options: M074S05EvaluationOptions 
     {
       id: "reason-code-coverage",
       passed: REQUIRED_REASONS.every((reason) => (reportForChecks.reasonCoverage[reason] ?? 0) > 0)
-        && REQUIRED_FIX_REASONS.every((reason) => (reportForChecks.samePrFixEvidence.reasonCoverage[reason] ?? 0) > 0),
+        && REQUIRED_FIX_REASONS.every((reason) => (reportForChecks.samePrFixEvidence.reasonCoverage[reason] ?? 0) > 0)
+        && (reportForChecks.samePrFixEvidence.reasonCoverage["missing-replacement"] ?? 0) === 0,
       detail: `validationReasons=${REQUIRED_REASONS.filter((reason) => (reportForChecks.reasonCoverage[reason] ?? 0) > 0).join(",")} fixReasons=${REQUIRED_FIX_REASONS.filter((reason) => (reportForChecks.samePrFixEvidence.reasonCoverage[reason] ?? 0) > 0).join(",")}`,
     },
     {
       id: "review-details-wording-and-caps",
-      passed: reportForChecks.boundedReviewDetails.validationTruthLineCount === 1
+      passed: reportForChecks.boundedReviewDetails.visibleValidationTruthLineCount === 0
+        && reportForChecks.boundedReviewDetails.validationTruthLineCount === 1
         && reportForChecks.boundedReviewDetails.wordingPresent
         && reportForChecks.boundedReviewDetails.correlationPresent
         && reportForChecks.boundedReviewDetails.referencesCapped
         && reportForChecks.boundedReviewDetails.reasonCodesCapped,
-      detail: `lineCount=${reportForChecks.boundedReviewDetails.validationTruthLineCount} refs=${reportForChecks.boundedReviewDetails.projectedReferences}+${reportForChecks.boundedReviewDetails.omittedReferences} reasons=${reportForChecks.boundedReviewDetails.projectedReasonCodes}+${reportForChecks.boundedReviewDetails.omittedReasonCodes}`,
+      detail: `visibleLineCount=${reportForChecks.boundedReviewDetails.visibleValidationTruthLineCount} lineCount=${reportForChecks.boundedReviewDetails.validationTruthLineCount} refs=${reportForChecks.boundedReviewDetails.projectedReferences}+${reportForChecks.boundedReviewDetails.omittedReferences} reasons=${reportForChecks.boundedReviewDetails.projectedReasonCodes}+${reportForChecks.boundedReviewDetails.omittedReasonCodes}`,
     },
     {
       id: "visible-volume-bounds",


### PR DESCRIPTION
Fixes the 16 verifier-script test failures left by #206 (telemetry lines moved from the visible Review Details comment to structured logs). Verifiers now derive line evidence from the exported per-line formatters, assert absence from the visible block, and keep every privacy/no-canary check against the surface that actually carries the data.

- `bun test scripts`: 1349 pass / 0 fail
- `bunx tsc --noEmit`: clean
- all six verifier CLIs run end-to-end with exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)