### PR TITLE
Bounded-collection follow-ups from resource hardening review

### DIFF
--- a/src/execution/mcp/ci-status-server.test.ts
+++ b/src/execution/mcp/ci-status-server.test.ts
@@ -139,7 +139,7 @@ describe("createCIStatusServer", () => {
     });
   });
 
-  test("fails closed when workflow pagination never terminates", async () => {
+  test("returns bounded partial results with a truncation flag when pagination never terminates", async () => {
     let calls = 0;
     const octokit = {
       rest: {
@@ -156,8 +156,11 @@ describe("createCIStatusServer", () => {
     const handler = getToolHandler(server, "get_ci_status");
 
     const result = await handler({});
-    expect(result.isError).toBe(true);
-    expect(result.content[0]!.text).toContain("safety limit");
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed.summary.truncated).toBe(true);
+    expect(parsed.summary.total_runs).toBe(10_000);
+    expect(parsed.runs).toHaveLength(10_000);
     expect(calls).toBe(100);
   });
 });

--- a/src/execution/mcp/ci-status-server.ts
+++ b/src/execution/mcp/ci-status-server.ts
@@ -6,21 +6,28 @@ const DEFAULT_PER_PAGE = 100;
 const MAX_PAGES = 100;
 const MAX_RECORDS = DEFAULT_PER_PAGE * MAX_PAGES;
 
+type PagedCollection<T> = { records: T[]; truncated: boolean };
+
+// Returns bounded partial results with a truncation marker instead of failing
+// the whole MCP tool call when a repository has an absurd number of records —
+// partial CI evidence with an explicit "truncated" flag is more useful to the
+// reviewing model than an error.
 async function collectPaged<T>(
   fetchPage: (params: { page: number; per_page: number }) => Promise<T[]>,
-): Promise<T[]> {
+): Promise<PagedCollection<T>> {
   const records: T[] = [];
   for (let page = 1; page <= MAX_PAGES; page += 1) {
     const data = await fetchPage({ page, per_page: DEFAULT_PER_PAGE });
     if (records.length + data.length > MAX_RECORDS) {
-      throw new Error(`GitHub pagination exceeded the ${MAX_RECORDS}-record safety limit`);
+      records.push(...data.slice(0, MAX_RECORDS - records.length));
+      return { records, truncated: true };
     }
     records.push(...data);
     if (data.length < DEFAULT_PER_PAGE) {
-      return records;
+      return { records, truncated: false };
     }
   }
-  throw new Error(`GitHub pagination exceeded the ${MAX_PAGES}-page safety limit`);
+  return { records, truncated: true };
 }
 
 export function createCIStatusServer(
@@ -68,7 +75,7 @@ export function createCIStatusServer(
             });
             const headSha = pr.data.head.sha;
 
-            const runs = await collectPaged(async ({ page, per_page }) => {
+            const { records: runs, truncated: runsTruncated } = await collectPaged(async ({ page, per_page }) => {
               const { data } = await octokit.rest.actions.listWorkflowRunsForRepo({
                 owner,
                 repo,
@@ -79,7 +86,7 @@ export function createCIStatusServer(
               });
               return data.workflow_runs || [];
             });
-            const summary = { total_runs: runs.length, failed: 0, passed: 0, pending: 0 };
+            const summary = { total_runs: runs.length, failed: 0, passed: 0, pending: 0, ...(runsTruncated ? { truncated: true } : {}) };
 
             const processedRuns = runs.map((run) => {
               if (run.status === "completed") {
@@ -127,7 +134,7 @@ export function createCIStatusServer(
           try {
             const octokit = await getOctokit();
 
-            const jobs = await collectPaged(async ({ page, per_page }) => {
+            const { records: jobs, truncated: jobsTruncated } = await collectPaged(async ({ page, per_page }) => {
               const { data } = await octokit.rest.actions.listJobsForWorkflowRun({
                 owner,
                 repo,
@@ -156,7 +163,7 @@ export function createCIStatusServer(
               content: [
                 {
                   type: "text" as const,
-                  text: JSON.stringify({ jobs: processedJobs }),
+                  text: JSON.stringify({ jobs: processedJobs, ...(jobsTruncated ? { truncated: true } : {}) }),
                 },
               ],
             };

--- a/src/knowledge/review-comment-backfill.ts
+++ b/src/knowledge/review-comment-backfill.ts
@@ -577,12 +577,18 @@ export async function backfillReviewComments(opts: BackfillOptions): Promise<Bac
 
     page++;
   }
-  if (page > MAX_REVIEW_COMMENT_PAGES) {
-    throw new Error(`Review comment pagination exceeded the ${MAX_REVIEW_COMMENT_PAGES}-page safety limit`);
+  const pageCapReached = page > MAX_REVIEW_COMMENT_PAGES;
+  if (pageCapReached) {
+    // Graceful stop: per-page sync-state checkpoints are already persisted, so
+    // the next scheduled run resumes from the watermark instead of restarting.
+    logger.warn(
+      { repo, pagesProcessed, totalComments, maxPages: MAX_REVIEW_COMMENT_PAGES },
+      "Review-comment backfill reached the page safety limit; stopping gracefully and leaving backfill incomplete for the next run to resume",
+    );
   }
 
   // Mark backfill complete
-  if (!dryRun && !hadWriteFailures) {
+  if (!dryRun && !hadWriteFailures && !pageCapReached) {
     await store.updateSyncState({
       repo,
       lastSyncedAt: lastCommentDate ?? sinceDate,
@@ -662,15 +668,22 @@ export async function syncSinglePR(opts: SyncSinglePROptions): Promise<{ chunksW
     if (comments.length === 0) break;
 
     allComments.push(...comments);
-    if (allComments.length > MAX_REVIEW_COMMENTS) {
-      throw new Error(`Review comment pagination exceeded the ${MAX_REVIEW_COMMENTS}-comment safety limit`);
+    if (allComments.length >= MAX_REVIEW_COMMENTS) {
+      logger.warn(
+        { repo, prNumber, collected: allComments.length, maxComments: MAX_REVIEW_COMMENTS },
+        "Review comment collection reached the comment safety limit; syncing the bounded prefix",
+      );
+      break;
     }
 
     if (comments.length < 100) break;
     page++;
   }
   if (page > MAX_REVIEW_COMMENT_PAGES) {
-    throw new Error(`Review comment pagination exceeded the ${MAX_REVIEW_COMMENT_PAGES}-page safety limit`);
+    logger.warn(
+      { repo, prNumber, maxPages: MAX_REVIEW_COMMENT_PAGES },
+      "Review comment collection reached the page safety limit; syncing the bounded prefix",
+    );
   }
 
   if (allComments.length === 0) {

--- a/src/lib/bounded-file.ts
+++ b/src/lib/bounded-file.ts
@@ -24,7 +24,12 @@ export async function readTextFileBounded(path: string, maxBytes: number): Promi
       if (done) break;
       const remaining = maxBytes - bytesRead;
       if (value.byteLength > remaining) {
-        throw new BoundedFileTooLargeError(path, maxBytes + 1, maxBytes);
+        // Report the true size where the filesystem can tell us (the stream can
+        // outgrow the initial stat if the file is being appended to), falling
+        // back to the bytes actually observed so far.
+        const statSize = Bun.file(path).size;
+        const observed = bytesRead + value.byteLength;
+        throw new BoundedFileTooLargeError(path, Math.max(statSize, observed), maxBytes);
       }
       chunks.push(value);
       bytesRead += value.byteLength;


### PR DESCRIPTION
The three actionable minor notes from the #205 review:

- CI status MCP tools return bounded partial results with a `truncated` flag instead of failing the tool call past 100 pages/10k records.
- Review-comment backfill stops gracefully at its page/comment caps (warn + preserve checkpoint; next run resumes) instead of throwing after work was checkpointed.
- `BoundedFileTooLargeError` reports the true file size instead of a synthetic `maxBytes+1`.

(The fourth note — oversized `.kodiai.yml` throwing — matches existing invalid-YAML behavior, left as is.)

- `bun test src`: 5805 pass / 0 fail, tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)