### PR TITLE
fix: ground critical/major findings against real diff before publish

### DIFF
--- a/src/enforcement/diff-grounding.test.ts
+++ b/src/enforcement/diff-grounding.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from "bun:test";
+import {
+  buildDiffGroundingIndex,
+  enforceDiffGrounding,
+  DIFF_GROUNDING_DOWNGRADE_TARGET,
+} from "./diff-grounding.ts";
+import type { FindingSeverity } from "../knowledge/types.ts";
+
+// A realistic unified diff hunk touching src/foo.cpp lines 10-13 (post-change
+// numbering), with one leading context line at 9.
+const SAMPLE_DIFF = [
+  "diff --git a/src/foo.cpp b/src/foo.cpp",
+  "index 1111111..2222222 100644",
+  "--- a/src/foo.cpp",
+  "+++ b/src/foo.cpp",
+  "@@ -8,3 +9,5 @@ void Foo::Bar()",
+  " context line 9",
+  "+added line 10",
+  "+added line 11",
+  " context line 12",
+  " context line 13",
+].join("\n");
+
+function makeFinding(overrides: {
+  filePath: string;
+  severity: FindingSeverity;
+  startLine?: number;
+  endLine?: number;
+}) {
+  return {
+    filePath: overrides.filePath,
+    severity: overrides.severity,
+    ...(overrides.startLine !== undefined ? { startLine: overrides.startLine } : {}),
+    ...(overrides.endLine !== undefined ? { endLine: overrides.endLine } : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// buildDiffGroundingIndex
+// ---------------------------------------------------------------------------
+describe("buildDiffGroundingIndex", () => {
+  it("indexes context and added lines for a file touched by the diff", () => {
+    const index = buildDiffGroundingIndex(SAMPLE_DIFF);
+    const lines = index.get("src/foo.cpp");
+    expect(lines).toBeDefined();
+    expect(lines?.has(9)).toBe(true);
+    expect(lines?.has(10)).toBe(true);
+    expect(lines?.has(11)).toBe(true);
+    expect(lines?.has(12)).toBe(true);
+    expect(lines?.has(13)).toBe(true);
+    expect(lines?.has(14)).toBe(false);
+  });
+
+  it("returns an empty index for empty/missing diff text", () => {
+    expect(buildDiffGroundingIndex("").size).toBe(0);
+    expect(buildDiffGroundingIndex(null).size).toBe(0);
+    expect(buildDiffGroundingIndex(undefined).size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// enforceDiffGrounding
+// ---------------------------------------------------------------------------
+describe("enforceDiffGrounding", () => {
+  it("passes through a critical finding whose line is inside the diff hunk", () => {
+    const diffLineIndex = buildDiffGroundingIndex(SAMPLE_DIFF);
+    const [result] = enforceDiffGrounding({
+      findings: [makeFinding({ filePath: "src/foo.cpp", severity: "critical", startLine: 10, endLine: 10 })],
+      diffLineIndex,
+    });
+    expect(result?.severity).toBe("critical");
+    expect(result?.groundingChecked).toBe(true);
+    expect(result?.groundingVerified).toBe(true);
+    expect(result?.groundingDowngraded).toBe(false);
+    expect(result?.groundingReason).toBe("grounded");
+  });
+
+  it("passes through a critical finding whose full range is inside the diff hunk", () => {
+    const diffLineIndex = buildDiffGroundingIndex(SAMPLE_DIFF);
+    const [result] = enforceDiffGrounding({
+      findings: [makeFinding({ filePath: "src/foo.cpp", severity: "major", startLine: 10, endLine: 12 })],
+      diffLineIndex,
+    });
+    expect(result?.severity).toBe("major");
+    expect(result?.groundingDowngraded).toBe(false);
+  });
+
+  it("downgrades a critical finding whose cited line is outside every hunk in its file", () => {
+    const diffLineIndex = buildDiffGroundingIndex(SAMPLE_DIFF);
+    const [result] = enforceDiffGrounding({
+      findings: [makeFinding({ filePath: "src/foo.cpp", severity: "critical", startLine: 500, endLine: 500 })],
+      diffLineIndex,
+    });
+    expect(result?.severity).toBe(DIFF_GROUNDING_DOWNGRADE_TARGET);
+    expect(result?.preGroundingSeverity).toBe("critical");
+    expect(result?.groundingChecked).toBe(true);
+    expect(result?.groundingVerified).toBe(false);
+    expect(result?.groundingDowngraded).toBe(true);
+    expect(result?.groundingReason).toBe("line-outside-diff");
+  });
+
+  it("downgrades a major finding whose range partially spills outside the hunk", () => {
+    const diffLineIndex = buildDiffGroundingIndex(SAMPLE_DIFF);
+    const [result] = enforceDiffGrounding({
+      findings: [makeFinding({ filePath: "src/foo.cpp", severity: "major", startLine: 12, endLine: 20 })],
+      diffLineIndex,
+    });
+    expect(result?.groundingDowngraded).toBe(true);
+    expect(result?.groundingReason).toBe("line-outside-diff");
+  });
+
+  it("fails open on a finding citing a file that never appears in the diff (ambiguous, not necessarily hallucinated)", () => {
+    const diffLineIndex = buildDiffGroundingIndex(SAMPLE_DIFF);
+    const [result] = enforceDiffGrounding({
+      findings: [makeFinding({ filePath: "src/other.cpp", severity: "critical", startLine: 5, endLine: 5 })],
+      diffLineIndex,
+    });
+    expect(result?.groundingDowngraded).toBe(false);
+    expect(result?.groundingReason).toBe("file-not-in-diff");
+    expect(result?.severity).toBe("critical");
+  });
+
+  it("never drops a finding -- downgraded findings remain in the output array", () => {
+    const diffLineIndex = buildDiffGroundingIndex(SAMPLE_DIFF);
+    const result = enforceDiffGrounding({
+      findings: [
+        makeFinding({ filePath: "src/foo.cpp", severity: "critical", startLine: 10, endLine: 10 }),
+        makeFinding({ filePath: "src/other.cpp", severity: "critical", startLine: 5, endLine: 5 }),
+      ],
+      diffLineIndex,
+    });
+    expect(result).toHaveLength(2);
+  });
+
+  it("does not check minor/medium findings (leaves them ungrounded but unchanged)", () => {
+    const diffLineIndex = buildDiffGroundingIndex(SAMPLE_DIFF);
+    const [result] = enforceDiffGrounding({
+      findings: [makeFinding({ filePath: "src/other.cpp", severity: "minor", startLine: 999, endLine: 999 })],
+      diffLineIndex,
+    });
+    expect(result?.severity).toBe("minor");
+    expect(result?.groundingChecked).toBe(false);
+    expect(result?.groundingDowngraded).toBe(false);
+    expect(result?.groundingReason).toBe("not-applicable");
+  });
+
+  it("does not check findings without an explicit line citation", () => {
+    const diffLineIndex = buildDiffGroundingIndex(SAMPLE_DIFF);
+    const [result] = enforceDiffGrounding({
+      findings: [makeFinding({ filePath: "src/other.cpp", severity: "critical" })],
+      diffLineIndex,
+    });
+    expect(result?.severity).toBe("critical");
+    expect(result?.groundingChecked).toBe(false);
+    expect(result?.groundingReason).toBe("not-applicable");
+  });
+
+  it("fails open (never downgrades) when no diff text was collected for the review", () => {
+    const diffLineIndex = buildDiffGroundingIndex(undefined);
+    const [result] = enforceDiffGrounding({
+      findings: [makeFinding({ filePath: "src/foo.cpp", severity: "critical", startLine: 999, endLine: 999 })],
+      diffLineIndex,
+    });
+    expect(result?.severity).toBe("critical");
+    expect(result?.groundingChecked).toBe(false);
+    expect(result?.groundingVerified).toBe(true);
+    expect(result?.groundingDowngraded).toBe(false);
+    expect(result?.groundingReason).toBe("no-diff-available");
+  });
+
+  it("treats startLine-only citations as a single-line range", () => {
+    const diffLineIndex = buildDiffGroundingIndex(SAMPLE_DIFF);
+    const [result] = enforceDiffGrounding({
+      findings: [makeFinding({ filePath: "src/foo.cpp", severity: "critical", startLine: 11 })],
+      diffLineIndex,
+    });
+    expect(result?.groundingDowngraded).toBe(false);
+    expect(result?.groundingReason).toBe("grounded");
+  });
+
+  it("preserves unrelated finding fields", () => {
+    const diffLineIndex = buildDiffGroundingIndex(SAMPLE_DIFF);
+    const [result] = enforceDiffGrounding({
+      findings: [{
+        filePath: "src/other.cpp",
+        severity: "critical" as FindingSeverity,
+        startLine: 5,
+        endLine: 5,
+        title: "Some finding",
+        category: "correctness",
+      }],
+      diffLineIndex,
+    });
+    expect(result?.title).toBe("Some finding");
+    expect(result?.category).toBe("correctness");
+  });
+});

--- a/src/enforcement/diff-grounding.ts
+++ b/src/enforcement/diff-grounding.ts
@@ -1,0 +1,158 @@
+import type { FindingSeverity } from "../knowledge/types.ts";
+import { buildPrDiffCommentabilityIndex, type PrDiffCommentabilityIndex } from "../execution/formatter-suggestions.ts";
+
+/**
+ * Diff grounding: a cheap structural fact-check applied to high-severity
+ * findings before publication.
+ *
+ * This does NOT verify that a finding's reasoning is semantically correct
+ * (that would require an expensive, unreliable LLM re-check). It only
+ * verifies that, for a file the collected diff *does* cover, the finding's
+ * cited line actually falls within a diff hunk for that file -- i.e. the
+ * citation is not a hallucinated line number. A cited line missing from an
+ * otherwise-present file is a strong signal that the LLM fabricated (or
+ * mis-transcribed) evidence, so critical/major findings are downgraded
+ * rather than published at face value. Findings are never silently dropped
+ * here -- see same-pr-fix-eligibility.ts for the analogous "never drop,
+ * downgrade or flag instead" precedent.
+ *
+ * A cited file that is entirely absent from the collected diff is treated
+ * as fail-open (not downgraded): findings can legitimately reference a file
+ * outside this delivery's diff slice -- e.g. a previously-published finding
+ * being re-run through enforcement during reconciliation, or a diff
+ * collection scoped to only the incremental commits since the last review.
+ * Only an in-diff file with an out-of-range line is unambiguous evidence of
+ * a hallucinated citation.
+ */
+
+export type DiffGroundingReasonCode =
+  | "not-applicable"
+  | "no-diff-available"
+  | "file-not-in-diff"
+  | "line-outside-diff"
+  | "grounded";
+
+export type DiffGroundingResult = {
+  groundingChecked: boolean;
+  groundingVerified: boolean;
+  groundingDowngraded: boolean;
+  groundingReason: DiffGroundingReasonCode;
+  preGroundingSeverity?: FindingSeverity;
+};
+
+/** Severities whose file:line citation is expensive enough to warrant a grounding check. */
+const GROUNDING_GATED_SEVERITIES: ReadonlySet<FindingSeverity> = new Set(["critical", "major"]);
+
+/** Target severity when a citation cannot be located in the diff. */
+export const DIFF_GROUNDING_DOWNGRADE_TARGET: FindingSeverity = "medium";
+
+export type DiffGroundingFindingInput = {
+  filePath: string;
+  severity: FindingSeverity;
+  startLine?: number;
+  endLine?: number;
+  [key: string]: unknown;
+};
+
+/**
+ * Build the per-file set of diff-visible line numbers (right-hand side /
+ * post-change numbering) used to ground finding citations. Thin wrapper
+ * around the shared PR-diff commentability index so both the same-PR-fix
+ * publication path and this enforcement gate stay in lockstep with a single
+ * parser.
+ */
+export function buildDiffGroundingIndex(diffText: string | null | undefined): PrDiffCommentabilityIndex {
+  return buildPrDiffCommentabilityIndex(diffText ?? "");
+}
+
+/**
+ * Verify that critical/major findings cite a file:line that actually falls
+ * within the collected diff's changed-line ranges. Findings below the
+ * gated severities, findings without an explicit line citation, findings
+ * whose cited file does not appear in the diff at all, and every finding
+ * when no diff text was collected for this review (fail-open -- absence of
+ * evidence is not evidence of hallucination) pass through unchanged.
+ *
+ * Pure function: no side effects, mirrors enforceSeverityFloors.
+ */
+export function enforceDiffGrounding<T extends DiffGroundingFindingInput>(params: {
+  findings: T[];
+  diffLineIndex: PrDiffCommentabilityIndex;
+}): (T & DiffGroundingResult)[] {
+  const { findings, diffLineIndex } = params;
+  const diffAvailable = diffLineIndex.size > 0;
+
+  return findings.map((finding) => {
+    if (!GROUNDING_GATED_SEVERITIES.has(finding.severity)) {
+      return passThrough(finding, "not-applicable");
+    }
+
+    const startLine = normalizeLine(finding.startLine);
+    const endLine = normalizeLine(finding.endLine) ?? startLine;
+    if (!startLine || !endLine) {
+      // No explicit line citation to fact-check.
+      return passThrough(finding, "not-applicable");
+    }
+
+    if (!diffAvailable) {
+      return passThrough(finding, "no-diff-available");
+    }
+
+    const commentableLines = diffLineIndex.get(finding.filePath);
+    if (!commentableLines) {
+      // The file is entirely absent from this delivery's diff slice --
+      // ambiguous (reconciliation of a pre-existing finding, incremental
+      // diff scoping, etc.), not necessarily a hallucination. Fail open.
+      return passThrough(finding, "file-not-in-diff");
+    }
+
+    const lo = Math.min(startLine, endLine);
+    const hi = Math.max(startLine, endLine);
+    for (let line = lo; line <= hi; line += 1) {
+      if (!commentableLines.has(line)) {
+        return downgrade(finding, "line-outside-diff");
+      }
+    }
+
+    return {
+      ...finding,
+      groundingChecked: true,
+      groundingVerified: true,
+      groundingDowngraded: false,
+      groundingReason: "grounded",
+    };
+  });
+}
+
+function passThrough<T extends DiffGroundingFindingInput>(
+  finding: T,
+  reason: DiffGroundingReasonCode,
+): T & DiffGroundingResult {
+  return {
+    ...finding,
+    groundingChecked: false,
+    groundingVerified: true,
+    groundingDowngraded: false,
+    groundingReason: reason,
+  };
+}
+
+function downgrade<T extends DiffGroundingFindingInput>(
+  finding: T,
+  reason: DiffGroundingReasonCode,
+): T & DiffGroundingResult {
+  return {
+    ...finding,
+    severity: DIFF_GROUNDING_DOWNGRADE_TARGET,
+    preGroundingSeverity: finding.severity,
+    groundingChecked: true,
+    groundingVerified: false,
+    groundingDowngraded: true,
+    groundingReason: reason,
+  };
+}
+
+function normalizeLine(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 1) return undefined;
+  return Math.floor(value);
+}

--- a/src/enforcement/index.ts
+++ b/src/enforcement/index.ts
@@ -36,11 +36,41 @@ export {
   IMPORT_ORDER_KEYWORDS,
 } from "./tooling-suppression.ts";
 
+// Diff grounding
+export {
+  enforceDiffGrounding,
+  buildDiffGroundingIndex,
+  DIFF_GROUNDING_DOWNGRADE_TARGET,
+} from "./diff-grounding.ts";
+export type { DiffGroundingReasonCode, DiffGroundingResult } from "./diff-grounding.ts";
+
+// Semantic grounding
+export {
+  enforceSemanticGrounding,
+  buildSemanticGroundingSourceIndex,
+  SEMANTIC_GROUNDING_DOWNGRADE_TARGET,
+} from "./semantic-grounding.ts";
+export type {
+  SemanticGroundingReasonCode,
+  SemanticGroundingResult,
+  SemanticGroundingLLM,
+  SemanticGroundingOptions,
+} from "./semantic-grounding.ts";
+
+import type { Logger } from "pino";
 import type { FindingSeverity } from "../knowledge/types.ts";
 import type { LanguageRulesConfig, EnforcedFinding } from "./types.ts";
 import { detectRepoTooling } from "./tooling-detection.ts";
 import { suppressToolingFindings } from "./tooling-suppression.ts";
 import { enforceSeverityFloors } from "./severity-floors.ts";
+import { enforceDiffGrounding, buildDiffGroundingIndex, type DiffGroundingResult } from "./diff-grounding.ts";
+import {
+  enforceSemanticGrounding,
+  buildSemanticGroundingSourceIndex,
+  type SemanticGroundingLLM,
+  type SemanticGroundingOptions,
+  type SemanticGroundingResult,
+} from "./semantic-grounding.ts";
 
 /**
  * Minimum shape required by the enforcement pipeline.
@@ -60,6 +90,10 @@ type EnforcementFinding = {
  *   1. Detect repo tooling (filesystem scan)
  *   2. Suppress tooling-covered findings
  *   3. Enforce severity floors
+ *   4. Ground critical/major file:line citations against the collected diff
+ *   5. Semantically re-verify critical/major findings that survived step 4
+ *      (opt-in, LLM-backed; no-op unless a `semanticGroundingLLM` and
+ *      `semanticGroundingOptions.enabled: true` are supplied)
  *
  * Fail-open: any error in enforcement logs a warning and returns
  * findings unchanged with default enforcement metadata.
@@ -70,8 +104,17 @@ export async function applyEnforcement(params: {
   filesByCategory: Record<string, string[]>;
   filesByLanguage: Record<string, string[]>;
   languageRules?: LanguageRulesConfig;
-  logger?: { warn: (obj: unknown, msg: string) => void };
-}): Promise<(EnforcementFinding & EnforcedFinding)[]> {
+  /** Raw unified diff text collected for this review, used to ground file:line citations. */
+  diffText?: string | null;
+  /**
+   * Optional LLM used for the semantic grounding re-verification pass (step
+   * 5). When omitted or when `semanticGroundingOptions.enabled` is not
+   * true, the step is a no-op passthrough -- semantic grounding is opt-in.
+   */
+  semanticGroundingLLM?: SemanticGroundingLLM | null;
+  semanticGroundingOptions?: SemanticGroundingOptions;
+  logger?: Logger | { warn: (obj: unknown, msg: string) => void; info?: (obj: unknown, msg: string) => void };
+}): Promise<(EnforcementFinding & EnforcedFinding & DiffGroundingResult & SemanticGroundingResult)[]> {
   try {
     // Step 1: Detect repo tooling (filesystem scan)
     const detectedTooling = await detectRepoTooling(params.workspaceDir, params.logger);
@@ -96,10 +139,36 @@ export async function applyEnforcement(params: {
     // Merge toolingSuppressed from step 2 back into step 3 results.
     // enforceSeverityFloors always sets toolingSuppressed: false because it
     // operates independently; we restore the actual suppression state here.
-    return enforced.map((finding, i) => ({
+    const merged = enforced.map((finding, i) => ({
       ...finding,
       toolingSuppressed: afterTooling[i]?.toolingSuppressed ?? false,
-    })) as (EnforcementFinding & EnforcedFinding)[];
+    }));
+
+    // Step 4: Ground critical/major citations against the collected diff.
+    // Runs last so a hallucinated line reference can pull an elevated
+    // severity back down; it never re-elevates.
+    const diffLineIndex = buildDiffGroundingIndex(params.diffText);
+    const grounded = enforceDiffGrounding({
+      findings: merged as (typeof merged[number] & { severity: FindingSeverity })[],
+      diffLineIndex,
+    });
+
+    // Step 5: Semantically re-verify critical/major findings that survived
+    // structural diff grounding. Opt-in (no-op passthrough when no LLM is
+    // supplied) and bounded (at most a handful of LLM calls per review --
+    // see semantic-grounding.ts for the cap). Runs last for the same reason
+    // as step 4: it can only pull an already-elevated severity back down,
+    // never re-elevate.
+    const sourceIndex = buildSemanticGroundingSourceIndex(params.diffText);
+    const semanticallyGrounded = await enforceSemanticGrounding({
+      findings: grounded as (typeof grounded[number] & { severity: FindingSeverity })[],
+      sourceIndex,
+      llm: params.semanticGroundingLLM,
+      options: params.semanticGroundingOptions,
+      logger: params.logger,
+    });
+
+    return semanticallyGrounded as (EnforcementFinding & EnforcedFinding & DiffGroundingResult & SemanticGroundingResult)[];
   } catch (err) {
     // Fail-open: log warning, return findings unchanged with default metadata
     params.logger?.warn(
@@ -111,6 +180,13 @@ export async function applyEnforcement(params: {
       originalSeverity: f.severity,
       severityElevated: false,
       toolingSuppressed: false,
+      groundingChecked: false,
+      groundingVerified: true,
+      groundingDowngraded: false,
+      groundingReason: "no-diff-available" as const,
+      semanticGroundingChecked: false,
+      semanticGroundingDowngraded: false,
+      semanticGroundingReason: "disabled" as const,
     }));
   }
 }

--- a/src/enforcement/semantic-grounding.test.ts
+++ b/src/enforcement/semantic-grounding.test.ts
@@ -1,0 +1,357 @@
+import { describe, expect, it } from "bun:test";
+import {
+  buildSemanticGroundingSourceIndex,
+  enforceSemanticGrounding,
+  SEMANTIC_GROUNDING_DOWNGRADE_TARGET,
+  type SemanticGroundingLLM,
+} from "./semantic-grounding.ts";
+import type { FindingSeverity } from "../knowledge/types.ts";
+
+// A realistic unified diff hunk touching src/foo.cpp lines 10-13 (post-change
+// numbering), mirroring diff-grounding.test.ts's fixture so both gates agree
+// on what's "in the diff".
+const SAMPLE_DIFF = [
+  "diff --git a/src/foo.cpp b/src/foo.cpp",
+  "index 1111111..2222222 100644",
+  "--- a/src/foo.cpp",
+  "+++ b/src/foo.cpp",
+  "@@ -8,3 +9,5 @@ void Foo::Bar()",
+  " context line 9",
+  "+  m_streaminfo = true;",
+  "+}",
+  " context line 12",
+  " context line 13",
+].join("\n");
+
+function makeFinding(overrides: {
+  filePath: string;
+  severity: FindingSeverity;
+  startLine?: number;
+  endLine?: number;
+  title?: string;
+  groundingChecked?: boolean;
+  groundingVerified?: boolean;
+}) {
+  return {
+    filePath: overrides.filePath,
+    severity: overrides.severity,
+    title: overrides.title ?? "Some finding",
+    groundingChecked: overrides.groundingChecked ?? true,
+    groundingVerified: overrides.groundingVerified ?? true,
+    ...(overrides.startLine !== undefined ? { startLine: overrides.startLine } : {}),
+    ...(overrides.endLine !== undefined ? { endLine: overrides.endLine } : {}),
+  };
+}
+
+/** Stub LLM that always returns a fixed verdict line, recording every call it received. */
+function stubLLM(response: string, calls: Array<{ prompt: string; system: string }> = []): SemanticGroundingLLM {
+  return {
+    generate: async (prompt: string, system: string) => {
+      calls.push({ prompt, system });
+      return response;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// buildSemanticGroundingSourceIndex
+// ---------------------------------------------------------------------------
+describe("buildSemanticGroundingSourceIndex", () => {
+  it("indexes literal source text per post-change line", () => {
+    const index = buildSemanticGroundingSourceIndex(SAMPLE_DIFF);
+    const lines = index.get("src/foo.cpp");
+    expect(lines).toBeDefined();
+    expect(lines?.get(10)).toBe("  m_streaminfo = true;");
+    expect(lines?.get(11)).toBe("}");
+    expect(lines?.get(9)).toBe("context line 9");
+  });
+
+  it("returns an empty index for empty/missing diff text", () => {
+    expect(buildSemanticGroundingSourceIndex("").size).toBe(0);
+    expect(buildSemanticGroundingSourceIndex(null).size).toBe(0);
+    expect(buildSemanticGroundingSourceIndex(undefined).size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// enforceSemanticGrounding
+// ---------------------------------------------------------------------------
+describe("enforceSemanticGrounding", () => {
+  it("is a no-op passthrough when disabled (default)", async () => {
+    const sourceIndex = buildSemanticGroundingSourceIndex(SAMPLE_DIFF);
+    const calls: Array<{ prompt: string; system: string }> = [];
+    const llm = stubLLM("VERDICT: MISMATCH - test", calls);
+
+    const [result] = await enforceSemanticGrounding({
+      findings: [makeFinding({ filePath: "src/foo.cpp", severity: "critical", startLine: 10, endLine: 11 })],
+      sourceIndex,
+      llm,
+      // options omitted -> enabled defaults to false
+    });
+
+    expect(result?.severity).toBe("critical");
+    expect(result?.semanticGroundingChecked).toBe(false);
+    expect(result?.semanticGroundingReason).toBe("disabled");
+    expect(calls).toHaveLength(0);
+  });
+
+  it("is a no-op passthrough when enabled but no LLM is supplied", async () => {
+    const sourceIndex = buildSemanticGroundingSourceIndex(SAMPLE_DIFF);
+    const [result] = await enforceSemanticGrounding({
+      findings: [makeFinding({ filePath: "src/foo.cpp", severity: "critical", startLine: 10, endLine: 11 })],
+      sourceIndex,
+      llm: null,
+      options: { enabled: true },
+    });
+
+    expect(result?.severity).toBe("critical");
+    expect(result?.semanticGroundingChecked).toBe(false);
+    expect(result?.semanticGroundingReason).toBe("disabled");
+  });
+
+  it("downgrades a critical finding whose reasoning the LLM says mismatches the actual code", async () => {
+    const sourceIndex = buildSemanticGroundingSourceIndex(SAMPLE_DIFF);
+    const calls: Array<{ prompt: string; system: string }> = [];
+    const llm = stubLLM("VERDICT: MISMATCH - the brace closes the function correctly, m_streaminfo is reachable", calls);
+
+    const [result] = await enforceSemanticGrounding({
+      findings: [makeFinding({
+        filePath: "src/foo.cpp",
+        severity: "critical",
+        startLine: 10,
+        endLine: 11,
+        title: "Misplaced closing brace makes m_streaminfo=true unreachable",
+      })],
+      sourceIndex,
+      llm,
+      options: { enabled: true },
+    });
+
+    expect(result?.severity).toBe(SEMANTIC_GROUNDING_DOWNGRADE_TARGET);
+    expect(result?.preSemanticGroundingSeverity).toBe("critical");
+    expect(result?.semanticGroundingChecked).toBe(true);
+    expect(result?.semanticGroundingDowngraded).toBe(true);
+    expect(result?.semanticGroundingReason).toBe("mismatch");
+    expect(result?.semanticGroundingJustification).toContain("closes the function correctly");
+
+    // The prompt should carry both the claim and the actual cited source text.
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.prompt).toContain("Misplaced closing brace");
+    expect(calls[0]?.prompt).toContain("m_streaminfo = true;");
+  });
+
+  it("keeps a critical finding whose reasoning the LLM confirms matches the code", async () => {
+    const sourceIndex = buildSemanticGroundingSourceIndex(SAMPLE_DIFF);
+    const llm = stubLLM("VERDICT: MATCH - the code does exactly what the claim describes");
+
+    const [result] = await enforceSemanticGrounding({
+      findings: [makeFinding({ filePath: "src/foo.cpp", severity: "critical", startLine: 10, endLine: 11 })],
+      sourceIndex,
+      llm,
+      options: { enabled: true },
+    });
+
+    expect(result?.severity).toBe("critical");
+    expect(result?.semanticGroundingChecked).toBe(true);
+    expect(result?.semanticGroundingDowngraded).toBe(false);
+    expect(result?.semanticGroundingReason).toBe("matched");
+  });
+
+  it("fails open (keeps original severity) on an UNCERTAIN verdict", async () => {
+    const sourceIndex = buildSemanticGroundingSourceIndex(SAMPLE_DIFF);
+    const llm = stubLLM("VERDICT: UNCERTAIN - not enough context to judge");
+
+    const [result] = await enforceSemanticGrounding({
+      findings: [makeFinding({ filePath: "src/foo.cpp", severity: "major", startLine: 10, endLine: 11 })],
+      sourceIndex,
+      llm,
+      options: { enabled: true },
+    });
+
+    expect(result?.severity).toBe("major");
+    expect(result?.semanticGroundingChecked).toBe(true);
+    expect(result?.semanticGroundingDowngraded).toBe(false);
+    expect(result?.semanticGroundingReason).toBe("uncertain");
+  });
+
+  it("fails open on an unparsable LLM response", async () => {
+    const sourceIndex = buildSemanticGroundingSourceIndex(SAMPLE_DIFF);
+    const llm = stubLLM("I refuse to answer in the requested format.");
+
+    const [result] = await enforceSemanticGrounding({
+      findings: [makeFinding({ filePath: "src/foo.cpp", severity: "critical", startLine: 10, endLine: 11 })],
+      sourceIndex,
+      llm,
+      options: { enabled: true },
+    });
+
+    expect(result?.severity).toBe("critical");
+    expect(result?.semanticGroundingDowngraded).toBe(false);
+    expect(result?.semanticGroundingReason).toBe("uncertain");
+  });
+
+  it("fails open (never downgrades) when the LLM call throws", async () => {
+    const sourceIndex = buildSemanticGroundingSourceIndex(SAMPLE_DIFF);
+    const throwingLLM: SemanticGroundingLLM = {
+      generate: async () => {
+        throw new Error("network timeout");
+      },
+    };
+
+    const [result] = await enforceSemanticGrounding({
+      findings: [makeFinding({ filePath: "src/foo.cpp", severity: "critical", startLine: 10, endLine: 11 })],
+      sourceIndex,
+      llm: throwingLLM,
+      options: { enabled: true },
+      logger: { warn: () => {}, info: () => {} },
+    });
+
+    expect(result?.severity).toBe("critical");
+    expect(result?.semanticGroundingDowngraded).toBe(false);
+    expect(result?.semanticGroundingReason).toBe("llm-error");
+  });
+
+  it("never drops a finding -- downgraded findings remain in the output array", async () => {
+    const sourceIndex = buildSemanticGroundingSourceIndex(SAMPLE_DIFF);
+    const llm = stubLLM("VERDICT: MISMATCH - wrong");
+
+    const results = await enforceSemanticGrounding({
+      findings: [
+        makeFinding({ filePath: "src/foo.cpp", severity: "critical", startLine: 10, endLine: 11 }),
+        makeFinding({ filePath: "src/foo.cpp", severity: "major", startLine: 12, endLine: 12 }),
+      ],
+      sourceIndex,
+      llm,
+      options: { enabled: true },
+    });
+
+    expect(results).toHaveLength(2);
+  });
+
+  it("skips findings that were not verified by diff-grounding (already downgraded or unchecked)", async () => {
+    const sourceIndex = buildSemanticGroundingSourceIndex(SAMPLE_DIFF);
+    const calls: Array<{ prompt: string; system: string }> = [];
+    const llm = stubLLM("VERDICT: MISMATCH - wrong", calls);
+
+    const [result] = await enforceSemanticGrounding({
+      findings: [makeFinding({
+        filePath: "src/foo.cpp",
+        severity: "critical",
+        startLine: 10,
+        endLine: 11,
+        groundingChecked: true,
+        groundingVerified: false, // diff-grounding already downgraded this one
+      })],
+      sourceIndex,
+      llm,
+      options: { enabled: true },
+    });
+
+    expect(result?.semanticGroundingChecked).toBe(false);
+    expect(result?.semanticGroundingReason).toBe("not-applicable");
+    expect(calls).toHaveLength(0);
+  });
+
+  it("does not check minor/medium findings", async () => {
+    const sourceIndex = buildSemanticGroundingSourceIndex(SAMPLE_DIFF);
+    const calls: Array<{ prompt: string; system: string }> = [];
+    const llm = stubLLM("VERDICT: MISMATCH - wrong", calls);
+
+    const [result] = await enforceSemanticGrounding({
+      findings: [makeFinding({ filePath: "src/foo.cpp", severity: "minor", startLine: 10, endLine: 11 })],
+      sourceIndex,
+      llm,
+      options: { enabled: true },
+    });
+
+    expect(result?.severity).toBe("minor");
+    expect(result?.semanticGroundingChecked).toBe(false);
+    expect(result?.semanticGroundingReason).toBe("not-applicable");
+    expect(calls).toHaveLength(0);
+  });
+
+  it("skips findings without reasoning text (empty title)", async () => {
+    const sourceIndex = buildSemanticGroundingSourceIndex(SAMPLE_DIFF);
+    const calls: Array<{ prompt: string; system: string }> = [];
+    const llm = stubLLM("VERDICT: MISMATCH - wrong", calls);
+
+    const [result] = await enforceSemanticGrounding({
+      findings: [makeFinding({ filePath: "src/foo.cpp", severity: "critical", startLine: 10, endLine: 11, title: "" })],
+      sourceIndex,
+      llm,
+      options: { enabled: true },
+    });
+
+    expect(result?.semanticGroundingChecked).toBe(false);
+    expect(result?.semanticGroundingReason).toBe("no-reasoning");
+    expect(calls).toHaveLength(0);
+  });
+
+  it("skips findings whose cited source text is unavailable in the index", async () => {
+    const sourceIndex = buildSemanticGroundingSourceIndex(SAMPLE_DIFF);
+    const calls: Array<{ prompt: string; system: string }> = [];
+    const llm = stubLLM("VERDICT: MISMATCH - wrong", calls);
+
+    const [result] = await enforceSemanticGrounding({
+      findings: [makeFinding({ filePath: "src/other-file-not-in-diff.cpp", severity: "critical", startLine: 10, endLine: 11 })],
+      sourceIndex,
+      llm,
+      options: { enabled: true },
+    });
+
+    expect(result?.semanticGroundingChecked).toBe(false);
+    expect(result?.semanticGroundingReason).toBe("source-unavailable");
+    expect(calls).toHaveLength(0);
+  });
+
+  it("caps the number of findings sent to the LLM at maxFindingsToCheck", async () => {
+    const sourceIndex = buildSemanticGroundingSourceIndex(SAMPLE_DIFF);
+    const calls: Array<{ prompt: string; system: string }> = [];
+    const llm = stubLLM("VERDICT: MATCH - fine", calls);
+
+    const findings = Array.from({ length: 5 }, (_, i) =>
+      makeFinding({ filePath: "src/foo.cpp", severity: "critical", startLine: 10, endLine: 11, title: `Finding ${i}` }));
+
+    const results = await enforceSemanticGrounding({
+      findings,
+      sourceIndex,
+      llm,
+      options: { enabled: true, maxFindingsToCheck: 2 },
+    });
+
+    expect(calls).toHaveLength(2);
+    const checkedCount = results.filter((r) => r.semanticGroundingChecked).length;
+    const budgetExceededCount = results.filter((r) => r.semanticGroundingReason === "budget-exceeded").length;
+    expect(checkedCount).toBe(2);
+    expect(budgetExceededCount).toBe(3);
+    // Budget-exceeded findings are never downgraded -- fail open.
+    for (const result of results) {
+      if (result.semanticGroundingReason === "budget-exceeded") {
+        expect(result.severity).toBe("critical");
+      }
+    }
+  });
+
+  it("preserves unrelated finding fields", async () => {
+    const sourceIndex = buildSemanticGroundingSourceIndex(SAMPLE_DIFF);
+    const llm = stubLLM("VERDICT: MATCH - fine");
+
+    const [result] = await enforceSemanticGrounding({
+      findings: [{
+        filePath: "src/foo.cpp",
+        severity: "critical" as FindingSeverity,
+        startLine: 10,
+        endLine: 11,
+        title: "Some finding",
+        category: "correctness",
+        groundingChecked: true,
+        groundingVerified: true,
+      }],
+      sourceIndex,
+      llm,
+      options: { enabled: true },
+    });
+
+    expect(result?.category).toBe("correctness");
+  });
+});

--- a/src/enforcement/semantic-grounding.ts
+++ b/src/enforcement/semantic-grounding.ts
@@ -1,0 +1,351 @@
+import type { FindingSeverity } from "../knowledge/types.ts";
+import { buildPrDiffLineTextIndex, type PrDiffLineTextIndex } from "../execution/formatter-suggestions.ts";
+import { mapWithConcurrency } from "../lib/concurrency.ts";
+
+/**
+ * Semantic grounding: an optional, cheap LLM re-verification pass applied to
+ * critical/major findings that already survived structural diff grounding
+ * (diff-grounding.ts).
+ *
+ * diff-grounding.ts proves the cited file:line *exists* in the diff -- it
+ * cannot catch a finding whose citation is real but whose prose reasoning
+ * about what the code *does* is simply wrong (e.g. "misplaced closing brace
+ * makes X unreachable" when the brace is actually placed correctly). This
+ * module closes that gap with a single, tightly-scoped LLM call per gated
+ * finding: given the finding's claim and the literal source text at its
+ * cited lines, does the reasoning accurately describe the code?
+ *
+ * Design invariants (mirrors diff-grounding.ts and
+ * review-graph/validation.ts):
+ * - **Never drop.** A mismatch downgrades severity to medium; it never
+ *   removes the finding.
+ * - **Fail open.** Disabled by default (no LLM wired), any missing source
+ *   text, any LLM error, and any "uncertain" verdict all pass the finding
+ *   through unchanged. Only a clear, explicit mismatch downgrades.
+ * - **Bounded cost.** At most `maxFindingsToCheck` findings receive an LLM
+ *   call per review (default 5) -- this is one LLM call per finding, so an
+ *   unbounded fan-out would be expensive on large reviews.
+ * - **Scoped to already-grounded findings.** Only findings that
+ *   diff-grounding.ts verified (`groundingChecked && groundingVerified`)
+ *   are eligible -- there is no point semantically re-checking a citation
+ *   that was already proven fabricated.
+ */
+
+export type SemanticGroundingReasonCode =
+  | "not-applicable"
+  | "disabled"
+  | "no-reasoning"
+  | "source-unavailable"
+  | "budget-exceeded"
+  | "llm-error"
+  | "uncertain"
+  | "mismatch"
+  | "matched";
+
+export type SemanticGroundingResult = {
+  semanticGroundingChecked: boolean;
+  semanticGroundingDowngraded: boolean;
+  semanticGroundingReason: SemanticGroundingReasonCode;
+  semanticGroundingJustification?: string;
+  preSemanticGroundingSeverity?: FindingSeverity;
+};
+
+/** Severities whose reasoning is expensive enough to warrant a semantic re-check. */
+const SEMANTIC_GATED_SEVERITIES: ReadonlySet<FindingSeverity> = new Set(["critical", "major"]);
+
+/** Target severity when the LLM finds the reasoning does not match the actual code. */
+export const SEMANTIC_GROUNDING_DOWNGRADE_TARGET: FindingSeverity = "medium";
+
+/** Default cap on how many findings receive an LLM call per review. */
+const DEFAULT_MAX_FINDINGS_TO_CHECK = 5;
+
+/** Max characters of cited source text sent to the LLM per finding. */
+const DEFAULT_SOURCE_MAX_CHARS = 2000;
+
+export type SemanticGroundingFindingInput = {
+  filePath: string;
+  title: string;
+  severity: FindingSeverity;
+  startLine?: number;
+  endLine?: number;
+  groundingChecked?: boolean;
+  groundingVerified?: boolean;
+  [key: string]: unknown;
+};
+
+/** Minimal LLM interface used by the semantic grounding pass. Same shape as review-graph's ValidationLLM. */
+export type SemanticGroundingLLM = {
+  generate(prompt: string, system: string): Promise<string>;
+};
+
+export type SemanticGroundingOptions = {
+  /** Whether the pass is enabled. Default: false (no-op passthrough). */
+  enabled?: boolean;
+  /** Max findings to send to the LLM per review. Default: 5. */
+  maxFindingsToCheck?: number;
+  /** Max characters of cited source text included in the prompt. Default: 2000. */
+  sourceMaxChars?: number;
+  /** Concurrency for the (rare, small) batch of LLM calls. Default: 3. */
+  concurrency?: number;
+};
+
+/** Build the source-line index from the same PR diff text collected for this review. */
+export function buildSemanticGroundingSourceIndex(diffText: string | null | undefined): PrDiffLineTextIndex {
+  return buildPrDiffLineTextIndex(diffText ?? "");
+}
+
+function normalizeLine(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 1) return undefined;
+  return Math.floor(value);
+}
+
+function extractSourceSnippet(params: {
+  sourceIndex: PrDiffLineTextIndex;
+  filePath: string;
+  startLine: number;
+  endLine: number;
+  maxChars: number;
+}): string | undefined {
+  const { sourceIndex, filePath, startLine, endLine, maxChars } = params;
+  const fileLines = sourceIndex.get(filePath);
+  if (!fileLines) return undefined;
+
+  const lo = Math.min(startLine, endLine);
+  const hi = Math.max(startLine, endLine);
+  const lines: string[] = [];
+  for (let line = lo; line <= hi; line += 1) {
+    const text = fileLines.get(line);
+    if (text === undefined) return undefined;
+    lines.push(`${line}: ${text}`);
+  }
+
+  const snippet = lines.join("\n");
+  return snippet.length > maxChars ? snippet.slice(0, maxChars) + "\n...[truncated]" : snippet;
+}
+
+function buildSemanticGroundingPrompt(params: {
+  claim: string;
+  filePath: string;
+  sourceSnippet: string;
+}): string {
+  return [
+    `A code review flagged the following issue in \`${params.filePath}\`:`,
+    "",
+    `Claim: "${params.claim}"`,
+    "",
+    "Actual source code at the cited lines (post-change, line-numbered):",
+    "```",
+    params.sourceSnippet,
+    "```",
+    "",
+    "Does the claim accurately describe what this code does? Reply with exactly one line in this format:",
+    "VERDICT: <MATCH|MISMATCH|UNCERTAIN> - <one short sentence justification>",
+    "",
+    "Use MISMATCH only when the code clearly contradicts the claim (e.g. the claim describes control flow, a bug, or behavior that the shown lines do not exhibit). Use UNCERTAIN when the snippet lacks enough context to judge confidently. Be conservative: prefer UNCERTAIN over MISMATCH unless the contradiction is clear.",
+  ].join("\n");
+}
+
+const SEMANTIC_GROUNDING_SYSTEM =
+  "You are a precise code-review fact-checker. You verify whether a stated claim about a code snippet is factually consistent with the snippet's actual behavior. You are conservative: absent clear contradiction, you answer UNCERTAIN rather than MISMATCH.";
+
+function parseVerdict(responseText: string): { verdict: "match" | "mismatch" | "uncertain"; justification?: string } {
+  const match = responseText.match(/VERDICT:\s*(MATCH|MISMATCH|UNCERTAIN)\s*-?\s*(.*)/i);
+  if (!match) {
+    return { verdict: "uncertain" };
+  }
+  const raw = match[1]!.toUpperCase();
+  const justification = match[2]?.trim() || undefined;
+  if (raw === "MATCH") return { verdict: "match", justification };
+  if (raw === "MISMATCH") return { verdict: "mismatch", justification };
+  return { verdict: "uncertain", justification };
+}
+
+function passThrough<T extends SemanticGroundingFindingInput>(
+  finding: T,
+  reason: SemanticGroundingReasonCode,
+): T & SemanticGroundingResult {
+  return {
+    ...finding,
+    semanticGroundingChecked: false,
+    semanticGroundingDowngraded: false,
+    semanticGroundingReason: reason,
+  };
+}
+
+function downgrade<T extends SemanticGroundingFindingInput>(
+  finding: T,
+  reason: SemanticGroundingReasonCode,
+  justification?: string,
+): T & SemanticGroundingResult {
+  return {
+    ...finding,
+    severity: SEMANTIC_GROUNDING_DOWNGRADE_TARGET,
+    preSemanticGroundingSeverity: finding.severity,
+    semanticGroundingChecked: true,
+    semanticGroundingDowngraded: true,
+    semanticGroundingReason: reason,
+    ...(justification ? { semanticGroundingJustification: justification } : {}),
+  };
+}
+
+function keep<T extends SemanticGroundingFindingInput>(
+  finding: T,
+  reason: SemanticGroundingReasonCode,
+  justification?: string,
+): T & SemanticGroundingResult {
+  return {
+    ...finding,
+    semanticGroundingChecked: true,
+    semanticGroundingDowngraded: false,
+    semanticGroundingReason: reason,
+    ...(justification ? { semanticGroundingJustification: justification } : {}),
+  };
+}
+
+/**
+ * Run the optional semantic grounding pass.
+ *
+ * Pure orchestration aside from the injected `llm.generate` calls -- no
+ * other side effects. Callers pass a pre-built source index (see
+ * `buildSemanticGroundingSourceIndex`) so the diff is parsed exactly once
+ * per review regardless of how many enforcement steps need it.
+ */
+export async function enforceSemanticGrounding<T extends SemanticGroundingFindingInput>(params: {
+  findings: T[];
+  sourceIndex: PrDiffLineTextIndex;
+  llm: SemanticGroundingLLM | null | undefined;
+  options?: SemanticGroundingOptions;
+  logger?: { warn: (obj: unknown, msg: string) => void; info?: (obj: unknown, msg: string) => void };
+}): Promise<(T & SemanticGroundingResult)[]> {
+  const { findings, sourceIndex, llm } = params;
+  const enabled = params.options?.enabled ?? false;
+  const maxFindingsToCheck = params.options?.maxFindingsToCheck ?? DEFAULT_MAX_FINDINGS_TO_CHECK;
+  const sourceMaxChars = params.options?.sourceMaxChars ?? DEFAULT_SOURCE_MAX_CHARS;
+  const concurrency = params.options?.concurrency ?? 3;
+
+  if (!enabled || !llm) {
+    return findings.map((f) => passThrough(f, "disabled"));
+  }
+
+  // Identify eligible findings: gated severity, structurally grounded by
+  // diff-grounding.ts, has a line citation, and has non-empty reasoning text.
+  type Eligible = { finding: T; originalIndex: number; sourceSnippet: string };
+  const eligible: Eligible[] = [];
+  const results: (T & SemanticGroundingResult)[] = new Array(findings.length);
+
+  for (let i = 0; i < findings.length; i += 1) {
+    const finding = findings[i]!;
+
+    if (!SEMANTIC_GATED_SEVERITIES.has(finding.severity)) {
+      results[i] = passThrough(finding, "not-applicable");
+      continue;
+    }
+
+    if (finding.groundingChecked !== true || finding.groundingVerified !== true) {
+      // Never independently structurally grounded (or already downgraded by
+      // diff-grounding.ts) -- semantic re-verification only makes sense on
+      // top of a real citation.
+      results[i] = passThrough(finding, "not-applicable");
+      continue;
+    }
+
+    const claim = (finding.title ?? "").trim();
+    if (claim.length === 0) {
+      results[i] = passThrough(finding, "no-reasoning");
+      continue;
+    }
+
+    const startLine = normalizeLine(finding.startLine);
+    const endLine = normalizeLine(finding.endLine) ?? startLine;
+    if (!startLine || !endLine) {
+      results[i] = passThrough(finding, "not-applicable");
+      continue;
+    }
+
+    const sourceSnippet = extractSourceSnippet({
+      sourceIndex,
+      filePath: finding.filePath,
+      startLine,
+      endLine,
+      maxChars: sourceMaxChars,
+    });
+    if (!sourceSnippet) {
+      results[i] = passThrough(finding, "source-unavailable");
+      continue;
+    }
+
+    eligible.push({ finding, originalIndex: i, sourceSnippet });
+  }
+
+  const toCheck = eligible.slice(0, maxFindingsToCheck);
+  for (let i = maxFindingsToCheck; i < eligible.length; i += 1) {
+    const entry = eligible[i]!;
+    results[entry.originalIndex] = passThrough(entry.finding, "budget-exceeded");
+  }
+
+  if (toCheck.length === 0) {
+    return results;
+  }
+
+  params.logger?.info?.(
+    {
+      gate: "semantic-grounding",
+      eligibleCount: eligible.length,
+      checkingCount: toCheck.length,
+      capped: eligible.length > maxFindingsToCheck,
+    },
+    "Running semantic grounding re-verification",
+  );
+
+  let mismatchCount = 0;
+  let matchCount = 0;
+  let uncertainCount = 0;
+  let errorCount = 0;
+
+  await mapWithConcurrency(toCheck, concurrency, async (entry) => {
+    const prompt = buildSemanticGroundingPrompt({
+      claim: entry.finding.title,
+      filePath: entry.finding.filePath,
+      sourceSnippet: entry.sourceSnippet,
+    });
+
+    let responseText: string;
+    try {
+      responseText = await llm.generate(prompt, SEMANTIC_GROUNDING_SYSTEM);
+    } catch (err) {
+      errorCount += 1;
+      params.logger?.warn(
+        { gate: "semantic-grounding", err, filePath: entry.finding.filePath },
+        "Semantic grounding LLM call failed (fail-open, keeping finding as-is)",
+      );
+      results[entry.originalIndex] = passThrough(entry.finding, "llm-error");
+      return;
+    }
+
+    const { verdict, justification } = parseVerdict(responseText);
+    if (verdict === "mismatch") {
+      mismatchCount += 1;
+      results[entry.originalIndex] = downgrade(entry.finding, "mismatch", justification);
+    } else if (verdict === "match") {
+      matchCount += 1;
+      results[entry.originalIndex] = keep(entry.finding, "matched", justification);
+    } else {
+      uncertainCount += 1;
+      results[entry.originalIndex] = keep(entry.finding, "uncertain", justification);
+    }
+  });
+
+  params.logger?.info?.(
+    {
+      gate: "semantic-grounding",
+      checkedCount: toCheck.length,
+      mismatchCount,
+      matchCount,
+      uncertainCount,
+      errorCount,
+    },
+    "Semantic grounding re-verification complete",
+  );
+
+  return results;
+}

--- a/src/execution/config.ts
+++ b/src/execution/config.ts
@@ -138,6 +138,12 @@ const graphValidationSchema = z
   })
   .default({ enabled: false });
 
+const semanticGroundingSchema = z
+  .object({
+    enabled: z.boolean().default(false),
+  })
+  .default({ enabled: false });
+
 const repoDoctrineContractSchema = z.object({
   id: z.string().trim().min(1).max(REPO_DOCTRINE_LIMITS.maxIdLength),
   type: z.enum(REPO_DOCTRINE_CONTRACT_TYPES),
@@ -210,6 +216,7 @@ const reviewSchema = z
     prioritization: findingPrioritizationWeightsSchema,
     formatterSuggestions: formatterSuggestionsSchema,
     graphValidation: graphValidationSchema,
+    semanticGrounding: semanticGroundingSchema,
     doctrine: repoDoctrineSchema,
     pathInstructions: z.array(pathInstructionSchema).default([]),
     profile: z.enum(["strict", "balanced", "minimal"]).optional(),
@@ -255,6 +262,7 @@ const reviewSchema = z
       maxSuggestions: 10,
     },
     graphValidation: { enabled: false },
+    semanticGrounding: { enabled: false },
     doctrine: { enabled: false, contracts: [] },
     pathInstructions: [],
     outputLanguage: "en",

--- a/src/execution/formatter-suggestions.ts
+++ b/src/execution/formatter-suggestions.ts
@@ -433,6 +433,71 @@ export function buildPrDiffCommentabilityIndex(prDiffText: string): PrDiffCommen
   return index;
 }
 
+/** Per-file map from post-change line number to the literal source text at that line. */
+export type PrDiffLineTextIndex = Map<string, Map<number, string>>;
+
+/**
+ * Build a per-file, per-line index of literal source text (post-change /
+ * right-hand-side numbering) from a unified PR diff. Shares the same
+ * single-pass parsing approach as `buildPrDiffCommentabilityIndex` (same
+ * header/hunk regexes, same cursor bookkeeping) but retains the line text
+ * instead of only its presence, so callers can pull the actual code at a
+ * cited line without re-parsing the diff with a heavier parser.
+ */
+export function buildPrDiffLineTextIndex(prDiffText: string): PrDiffLineTextIndex {
+  const index: PrDiffLineTextIndex = new Map();
+  let currentPath: string | undefined;
+  let rightCursor: number | undefined;
+
+  for (const line of prDiffText.split(/\r?\n/)) {
+    const diffHeaderMatch = GIT_DIFF_HEADER_RE.exec(line);
+    if (diffHeaderMatch) {
+      currentPath = parseDiffHeaderPath(diffHeaderMatch[2]!);
+      rightCursor = undefined;
+      continue;
+    }
+
+    if (line.startsWith("+++ ")) {
+      currentPath = parseFileHeaderPath(line);
+      rightCursor = undefined;
+      continue;
+    }
+
+    if (line.startsWith("@@")) {
+      const hunkHeaderMatch = PR_HUNK_HEADER_RE.exec(line);
+      rightCursor = hunkHeaderMatch ? Number.parseInt(hunkHeaderMatch[1]!, 10) : undefined;
+      continue;
+    }
+
+    if (!currentPath || rightCursor === undefined) {
+      continue;
+    }
+
+    if (line.startsWith(" ") || line.startsWith("+")) {
+      let pathLines = index.get(currentPath);
+      if (!pathLines) {
+        pathLines = new Map<number, string>();
+        index.set(currentPath, pathLines);
+      }
+      pathLines.set(rightCursor, line.slice(1));
+      rightCursor += 1;
+      continue;
+    }
+
+    if (line.startsWith("-")) {
+      continue;
+    }
+
+    if (line.startsWith("\\ No newline at end of file") || line === "") {
+      continue;
+    }
+
+    rightCursor = undefined;
+  }
+
+  return index;
+}
+
 interface FormatterChangeGroup {
   removed: FormatterDiffLine[];
   added: FormatterDiffLine[];

--- a/src/handlers/mention-explicit-review-publication.test.ts
+++ b/src/handlers/mention-explicit-review-publication.test.ts
@@ -139,6 +139,44 @@ describe("publishExplicitMentionReviewResult", () => {
     expect(call.body).toContain("<!-- kodiai:review-output-key:review-key -->");
   });
 
+  test("never leaks lifecycle telemetry counts into the published APPROVE body, even when non-blocking findings were recorded", async () => {
+    // Regression guard for PR #206: kodiai once published "Decision: APPROVE"
+    // / "Issues: none" in the same comment as an internal telemetry line
+    // reporting non-zero minor findings (severity=...minor:2), contradicting
+    // itself. That telemetry line is now log-only -- verify it never
+    // reappears in the published body, whatever findings were recorded.
+    const harness = createOctokit({});
+    const result = await publishExplicitMentionReviewResult(baseParams({
+      octokit: harness.octokit as never,
+      explicitReviewFindingLifecycleResult: {
+        projection: {
+          schema: "review-finding-lifecycle.v1",
+          status: "normalized",
+          counts: {
+            input: 2,
+            recorded: 2,
+            rejected: 0,
+            unsafeInputFields: 0,
+            status: { detected: 2, open: 2, validated: 0, degraded: 0 },
+            severity: { critical: 0, major: 0, medium: 0, minor: 2 },
+            actionability: { actionable: 0, "needs-human-review": 2, blocked: 0 },
+          },
+          rejectedReasonCodes: [],
+          redaction: { unsafeInputFieldCount: 0 },
+        },
+      } as never,
+    }));
+
+    expect(result.ok).toBe(true);
+    expect(harness.createReview).toHaveBeenCalledTimes(1);
+    const call = harness.createReview.mock.calls[0]![0] as { body: string; event: string };
+    expect(call.event).toBe("APPROVE");
+    expect(call.body).toContain("Decision: APPROVE");
+    expect(call.body).not.toContain("severity=");
+    expect(call.body).not.toContain("actionability=");
+    expect(call.body).not.toContain("needs-human-review");
+  });
+
   test("publishes an approval-shaped comment instead of a pull review when autoApprove is false", async () => {
     const harness = createOctokit({});
     const result = await publishExplicitMentionReviewResult(baseParams({

--- a/src/handlers/review-candidate-publication-preparation.ts
+++ b/src/handlers/review-candidate-publication-preparation.ts
@@ -27,6 +27,7 @@ import type { ReviewReducerRuntime } from "./review-reducer-runtime.ts";
 import { resolveReviewCandidateFindingContext } from "./review-candidate-finding-context.ts";
 import { resolveReviewFeedbackSuppression } from "./review-feedback-suppression.ts";
 import { resolveReviewGraphValidationLLM } from "./review-graph-validation-llm.ts";
+import { resolveReviewSemanticGroundingLLM } from "./review-semantic-grounding-llm.ts";
 import { buildReviewReducerInput } from "./review-reducer-input.ts";
 import { runReviewReducerFailOpen } from "./review-reducer-runtime.ts";
 import { resolveReviewCandidateApprovalContext } from "./review-candidate-approval-context.ts";
@@ -127,6 +128,18 @@ export async function resolveReviewCandidatePublicationPreparation(params: {
     logger: params.logger,
   });
 
+  // Semantic grounding follows the same repo-config opt-in pattern as graph
+  // validation above (review.semanticGrounding.enabled, default false).
+  // Cost stays bounded once enabled because enforcement/semantic-grounding.ts
+  // caps actual LLM calls at maxFindingsToCheck regardless of how many
+  // findings are eligible.
+  const semanticGroundingLLM = resolveReviewSemanticGroundingLLM({
+    enabled: params.config.review.semanticGrounding.enabled,
+    repo: `${params.owner}/${params.repo}`,
+    deliveryId: params.deliveryId,
+    logger: params.logger,
+  });
+
   const reviewReducerInput = buildReviewReducerInput({
     extractedFindings,
     reviewCandidateFindingResult,
@@ -155,6 +168,8 @@ export async function resolveReviewCandidatePublicationPreparation(params: {
     guardrailAuditStore: params.guardrailAuditStore,
     guardrailStrictness: params.config.guardrails?.strictness ?? "standard",
     graphValidationLLM,
+    semanticGroundingLLM,
+    semanticGroundingOptions: { enabled: params.config.review.semanticGrounding.enabled, maxFindingsToCheck: 5 },
     repoDoctrine: params.repoDoctrineReviewSurface,
   });
 

--- a/src/handlers/review-depends-flow.test.ts
+++ b/src/handlers/review-depends-flow.test.ts
@@ -170,7 +170,9 @@ describe("resolveReviewDependsFlow", () => {
     });
     expect(info.mock.calls.at(-1)?.[0]).toMatchObject({
       gate: "depends-review-continue",
-      verdict: "safe",
+      // impact is null here (no workspaceDir was provided) -- the scan never
+      // ran, so the verdict must be "inconclusive", not a confident "safe".
+      verdict: "inconclusive",
       hasSourceChanges: true,
     });
     expect(info.mock.calls.at(-1)?.[1]).toBe(

--- a/src/handlers/review-reducer-input.ts
+++ b/src/handlers/review-reducer-input.ts
@@ -42,6 +42,8 @@ export function buildReviewReducerInput(params: {
   guardrailAuditStore: ReviewReducerInput["guardrailAuditStore"];
   guardrailStrictness: ReviewReducerInput["guardrailStrictness"];
   graphValidationLLM: ReviewReducerInput["graphValidationLLM"];
+  semanticGroundingLLM?: ReviewReducerInput["semanticGroundingLLM"];
+  semanticGroundingOptions?: ReviewReducerInput["semanticGroundingOptions"];
   repoDoctrine: ReviewReducerInput["repoDoctrine"];
 }): ReviewReducerInput {
   const commentSlopFindings = toCommentSlopReducerFindings(
@@ -80,6 +82,8 @@ export function buildReviewReducerInput(params: {
     guardrailAuditStore: params.guardrailAuditStore,
     guardrailStrictness: params.guardrailStrictness,
     graphValidationLLM: params.graphValidationLLM,
+    semanticGroundingLLM: params.semanticGroundingLLM,
+    semanticGroundingOptions: params.semanticGroundingOptions,
     repoDoctrine: params.repoDoctrine,
   };
 }

--- a/src/handlers/review-semantic-grounding-llm.test.ts
+++ b/src/handlers/review-semantic-grounding-llm.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { Logger } from "pino";
+import { resolveReviewSemanticGroundingLLM } from "./review-semantic-grounding-llm.ts";
+
+describe("resolveReviewSemanticGroundingLLM", () => {
+  test("returns null when semantic grounding is disabled (default, mirrors graph validation's opt-in gate)", () => {
+    const logger = {} as Logger;
+    expect(resolveReviewSemanticGroundingLLM({
+      enabled: false,
+      repo: "xbmc/kodiai",
+      deliveryId: "delivery-1",
+      logger,
+    })).toBeNull();
+  });
+
+  test("routes semantic grounding prompts through guardrail classification fallback generation", async () => {
+    const logger = { info: () => undefined } as unknown as Logger;
+    const resolved = {
+      modelId: "claude-haiku",
+      provider: "anthropic",
+      sdk: "ai",
+      fallbackModelId: "claude-haiku-fallback",
+      fallbackProvider: "anthropic",
+    } as const;
+    const resolve = mock(() => resolved);
+    const generateWithFallback = mock(async () => ({ text: "matched" }));
+    const semanticGroundingLLM = resolveReviewSemanticGroundingLLM({
+      enabled: true,
+      repo: "xbmc/kodiai",
+      deliveryId: "delivery-1",
+      logger,
+      createTaskRouter: () => ({ resolve }),
+      generateWithFallback,
+    });
+
+    const text = await semanticGroundingLLM!.generate("prompt", "system");
+
+    expect(text).toBe("matched");
+    expect(resolve).toHaveBeenCalledWith("guardrail.classification");
+    expect(generateWithFallback).toHaveBeenCalledWith({
+      taskType: "guardrail.classification",
+      resolved,
+      system: "system",
+      prompt: "prompt",
+      logger,
+      repo: "xbmc/kodiai",
+      deliveryId: "delivery-1",
+    });
+  });
+});

--- a/src/handlers/review-semantic-grounding-llm.ts
+++ b/src/handlers/review-semantic-grounding-llm.ts
@@ -1,0 +1,70 @@
+import type { Logger } from "pino";
+import { TASK_TYPES } from "../llm/task-types.ts";
+import type { ResolvedModel, TaskRouterConfig } from "../llm/task-router.ts";
+import type { SemanticGroundingLLM } from "../enforcement/index.ts";
+
+type TaskRouter = {
+  resolve(taskType: string): ResolvedModel;
+};
+
+type GenerateWithFallback = (params: {
+  taskType: string;
+  resolved: ResolvedModel;
+  system: string;
+  prompt: string;
+  logger: Logger;
+  repo: string;
+  deliveryId: string;
+}) => Promise<{ text: string }>;
+
+/**
+ * Resolves the LLM used by the semantic grounding re-verification pass
+ * (enforcement/semantic-grounding.ts, step 5 of applyEnforcement).
+ *
+ * Mirrors resolveReviewGraphValidationLLM (review-graph-validation-llm.ts):
+ * same cheap `guardrail.classification` task tier, same
+ * generate/generateWithFallback plumbing, same repo-config opt-in gate
+ * (`review.semanticGrounding.enabled`, default false in .kodiai.yml).
+ *
+ * Unlike diff-grounding (purely structural, zero-cost), semantic grounding
+ * makes a real LLM call per gated finding, so -- exactly like graph
+ * validation -- it stays behind an explicit opt-in rather than running
+ * unconditionally. This also keeps it a no-op in tests that don't opt in,
+ * the same way graph validation's `hasGraphBlastRadius`/`enabled` gate
+ * keeps it inert in the existing test suite. Cost stays bounded once
+ * enabled because semantic-grounding.ts itself caps how many findings
+ * actually trigger an LLM call (`maxFindingsToCheck`, default 5).
+ */
+export function resolveReviewSemanticGroundingLLM(params: {
+  enabled: boolean;
+  repo: string;
+  deliveryId: string;
+  logger: Logger;
+  createTaskRouter?: (config: TaskRouterConfig) => TaskRouter;
+  generateWithFallback?: GenerateWithFallback;
+}): SemanticGroundingLLM | null {
+  if (!params.enabled) {
+    return null;
+  }
+
+  return {
+    generate: async (prompt: string, system: string): Promise<string> => {
+      const createTaskRouter = params.createTaskRouter
+        ?? (await import("../llm/task-router.ts")).createTaskRouter;
+      const generateWithFallback = params.generateWithFallback
+        ?? (await import("../llm/generate.ts")).generateWithFallback;
+      const taskRouter = createTaskRouter({ models: {} });
+      const resolved = taskRouter.resolve(TASK_TYPES.GUARDRAIL_CLASSIFICATION);
+      const genResult = await generateWithFallback({
+        taskType: TASK_TYPES.GUARDRAIL_CLASSIFICATION,
+        resolved,
+        system,
+        prompt,
+        logger: params.logger,
+        repo: params.repo,
+        deliveryId: params.deliveryId,
+      });
+      return genResult.text;
+    },
+  };
+}

--- a/src/handlers/review-structure.test.ts
+++ b/src/handlers/review-structure.test.ts
@@ -947,6 +947,23 @@ describe("review handler structure", () => {
     expect(preparationSource).toContain("./review-graph-validation-llm.ts");
   });
 
+  test("keeps semantic-grounding LLM routing out of the monster handler", () => {
+    const source = readFileSync(new URL("./review.ts", import.meta.url), "utf8");
+    const preparationSource = readFileSync(
+      new URL("./review-candidate-publication-preparation.ts", import.meta.url),
+      "utf8",
+    );
+
+    expect(source).not.toContain("const semanticGroundingLLM = ");
+    expect(source).not.toContain("const { createTaskRouter } = await import(\"../llm/task-router.ts\")");
+    expect(source).not.toContain("const genResult = await generateWithFallback({");
+    expect(source).toContain("resolveReviewCandidatePublicationPreparation");
+    expect(preparationSource).toContain("resolveReviewSemanticGroundingLLM");
+    expect(preparationSource).toContain("./review-semantic-grounding-llm.ts");
+    expect(preparationSource).toContain("enabled: params.config.review.semanticGrounding.enabled");
+    expect(preparationSource).toContain("maxFindingsToCheck: 5");
+  });
+
   test("keeps candidate approval adapter context out of the monster handler", () => {
     const source = readFileSync(new URL("./review.ts", import.meta.url), "utf8");
     const preparationSource = readFileSync(

--- a/src/lib/depends-impact-analyzer.test.ts
+++ b/src/lib/depends-impact-analyzer.test.ts
@@ -248,6 +248,63 @@ describe("findDependencyConsumers", () => {
     const uniquePaths = new Set(result.consumers.map((c) => c.filePath));
     expect(uniquePaths.size).toBe(result.consumers.length);
   });
+
+  test("matches libavcodec/libavformat headers for library ffmpeg (alias-aware)", async () => {
+    // Real xbmc code never includes "ffmpeg" literally -- it includes the
+    // sub-library headers directly (libavcodec/avcodec.h, etc.). A search
+    // for the literal package name alone would find 0 consumers here.
+    const result = await findDependencyConsumers({
+      workspaceDir: "/fake",
+      libraryName: "ffmpeg",
+      octokit: createMockOctokit(),
+      owner: "xbmc",
+      repo: "xbmc",
+      timeBudgetMs: 5000,
+      __runGrepForTests: mockGrepRunner(
+        "xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp:10:#include <libavcodec/avcodec.h>\n" +
+        "xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp:12:#include <libavformat/avformat.h>\n",
+      ),
+      __runCmakeGrepForTests: mockGrepRunner("", 1),
+    });
+
+    expect(result.consumers.length).toBe(2);
+    expect(result.consumers.some((c) => c.filePath.includes("DVDVideoCodecFFmpeg.cpp"))).toBe(true);
+    expect(result.consumers.some((c) => c.filePath.includes("DVDDemuxFFmpeg.cpp"))).toBe(true);
+  });
+
+  test("matches uppercase CMake FFMPEG_LIBRARIES variable for library ffmpeg (case-insensitive)", async () => {
+    const result = await findDependencyConsumers({
+      workspaceDir: "/fake",
+      libraryName: "ffmpeg",
+      octokit: createMockOctokit(),
+      owner: "xbmc",
+      repo: "xbmc",
+      timeBudgetMs: 5000,
+      __runGrepForTests: mockGrepRunner("", 1),
+      __runCmakeGrepForTests: mockGrepRunner(
+        "xbmc/cores/VideoPlayer/CMakeLists.txt:20:target_link_libraries(VideoPlayer PRIVATE ${FFMPEG_LIBRARIES})\n",
+      ),
+    });
+
+    expect(result.consumers.length).toBe(1);
+    expect(result.consumers[0]!.filePath).toBe("xbmc/cores/VideoPlayer/CMakeLists.txt");
+  });
+
+  test("returns 0 consumers for ffmpeg when nothing in the tree references any known alias", async () => {
+    const result = await findDependencyConsumers({
+      workspaceDir: "/fake",
+      libraryName: "ffmpeg",
+      octokit: createMockOctokit(),
+      owner: "xbmc",
+      repo: "xbmc",
+      timeBudgetMs: 5000,
+      __runGrepForTests: mockGrepRunner("", 1),
+      __runCmakeGrepForTests: mockGrepRunner("", 1),
+    });
+
+    expect(result.consumers.length).toBe(0);
+    expect(result.degradationNote).toBeNull();
+  });
 });
 
 // ─── parseCmakeFindModule ────────────────────────────────────────────────────

--- a/src/lib/depends-impact-analyzer.ts
+++ b/src/lib/depends-impact-analyzer.ts
@@ -17,6 +17,40 @@ import { withTimeBudget } from "./usage-analyzer.ts";
 
 const MODULE_CONTENT_FETCH_CONCURRENCY = 4;
 
+// ─── Name Alias Resolution ──────────────────────────────────────────────────
+
+/**
+ * Known mappings for [depends] package names whose upstream package name
+ * doesn't match the identifiers actually used in #include paths / CMake
+ * variables throughout the xbmc source tree.
+ *
+ * The canonical example is "ffmpeg": xbmc never references the literal
+ * string "ffmpeg" in source -- it includes ffmpeg's individual libraries
+ * (libavcodec/avcodec.h, libavformat/avformat.h, ...) and links against the
+ * CMake variable FFMPEG_LIBRARIES. A pattern search for the literal package
+ * name alone returns 0 consumers even though the library is used pervasively.
+ */
+const KNOWN_LIBRARY_ALIASES: Record<string, string[]> = {
+  ffmpeg: [
+    "ffmpeg",
+    "libavcodec",
+    "libavformat",
+    "libavutil",
+    "libavfilter",
+    "libavdevice",
+    "libswscale",
+    "libswresample",
+  ],
+};
+
+function resolveSearchAliases(libraryName: string): string[] {
+  return KNOWN_LIBRARY_ALIASES[libraryName.toLowerCase()] ?? [libraryName];
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 // ─── Types ──────────────────────────────────────────────────────────────────
 
 export type IncludeConsumer = {
@@ -116,18 +150,27 @@ export async function findDependencyConsumers(params: {
   let timeLimitReached = false;
   const seenPaths = new Set<string>();
 
-  const libLower = libraryName.toLowerCase();
+  // Search under all known aliases for this library (e.g. "ffmpeg" also
+  // searches "libavcodec", "libavformat", etc.) so that a dependency whose
+  // upstream package name differs from the identifiers used in source is
+  // still found. Falls back to the literal name when no aliases are known.
+  const searchAliases = resolveSearchAliases(libraryName);
+  const aliasLowerSet = new Set(searchAliases.map((alias) => alias.toLowerCase()));
+  const aliasPattern = searchAliases.map(escapeRegExp).join("|");
 
   try {
     // --- #include pass ---
-    const includePattern = `#include.*[<"]${libraryName}[/.]`;
+    // Case-insensitive: CMake identifiers derived from these names are
+    // conventionally uppercase (e.g. FFMPEG_LIBRARIES) even though #include
+    // paths are lowercase, so a single case-insensitive pass covers both.
+    const includePattern = `#include.*[<"](?:${aliasPattern})[/.]`;
 
     const runIncludeGrep: GrepRunner =
       __runGrepForTests ??
       (async (p) => {
         return await runCommandWithCappedOutput({
           command: "git",
-          args: ["grep", "-rn", "--max-count=100", "-E", p.pattern],
+          args: ["grep", "-rn", "--max-count=100", "-i", "-E", p.pattern],
           cwd: p.workspaceDir,
           timeoutMs: timeBudgetMs,
           maxStdoutBytes: 256 * 1024,
@@ -151,8 +194,10 @@ export async function findDependencyConsumers(params: {
 
       const parsed = parseGrepOutput(stdoutText);
       for (const entry of parsed) {
-        // Filter: the snippet must actually reference this library
-        if (!entry.snippet.toLowerCase().includes(libLower)) continue;
+        // Filter: the snippet must actually reference this library or one
+        // of its known aliases (e.g. "libavcodec" for "ffmpeg")
+        const snippetLower = entry.snippet.toLowerCase();
+        if (![...aliasLowerSet].some((alias) => snippetLower.includes(alias))) continue;
 
         seenPaths.add(entry.filePath);
         consumers.push({
@@ -166,14 +211,18 @@ export async function findDependencyConsumers(params: {
 
     // --- cmake target_link_libraries pass ---
     if (!timeLimitReached) {
-      const cmakePattern = `target_link_libraries.*${libraryName}`;
+      // Case-insensitive: CMake conventionally uppercases variable names
+      // derived from the library (e.g. target_link_libraries(foo ${FFMPEG_LIBRARIES})
+      // or PkgConfig::FFMPEG), which a case-sensitive match on the lowercase
+      // package name would miss entirely.
+      const cmakePattern = `target_link_libraries.*(?:${aliasPattern})`;
 
       const runCmakeGrep: GrepRunner =
         __runCmakeGrepForTests ??
         (async (p) => {
           return await runCommandWithCappedOutput({
             command: "git",
-            args: ["grep", "-rn", "--max-count=100", "-E", p.pattern, "--", p.pathspec ?? "*/CMakeLists.txt"],
+            args: ["grep", "-rn", "--max-count=100", "-i", "-E", p.pattern, "--", p.pathspec ?? "*/CMakeLists.txt"],
             cwd: p.workspaceDir,
             timeoutMs: Math.max(timeBudgetMs / 2, 1000),
             maxStdoutBytes: 256 * 1024,

--- a/src/lib/depends-review-builder.test.ts
+++ b/src/lib/depends-review-builder.test.ts
@@ -204,6 +204,69 @@ describe("computeDependsVerdict", () => {
     expect(verdict.level).toBe("needs-attention");
     expect(verdict.summary).toContain("unavailable");
   });
+
+  // ─── Impact scan confidence (regression: xbmc/xbmc#28832 ffmpeg 9.0 bump) ──
+  //
+  // kodiai previously posted "0 consuming files found" + "Safe to merge" for
+  // a major ffmpeg bump because the pattern search for the literal string
+  // "ffmpeg" found nothing (real usage is via libavcodec/libavformat/...).
+  // A zero-consumer scan must never be reported with "safe" confidence.
+
+  test("returns inconclusive (not safe) when impact scan found 0 consumers", () => {
+    const data = makeSafeData({
+      impact: {
+        consumers: [],
+        transitive: { dependents: [], newDependencies: [], circular: [] },
+        timeLimitReached: false,
+        degradationNote: null,
+      },
+    });
+    const verdict = computeDependsVerdict(data);
+    expect(verdict.level).toBe("inconclusive");
+    expect(verdict.label).toBe("Impact scan inconclusive");
+    expect(verdict.summary).not.toContain("Safe to merge");
+    expect(verdict.summary.toLowerCase()).toContain("does not confirm");
+  });
+
+  test("returns inconclusive when impact scan did not run (null)", () => {
+    const data = makeSafeData({ impact: null, transitive: null });
+    const verdict = computeDependsVerdict(data);
+    expect(verdict.level).toBe("inconclusive");
+    expect(verdict.summary).toContain("did not run");
+  });
+
+  test("returns inconclusive when impact scan errored", () => {
+    const data = makeSafeData({
+      impact: {
+        consumers: [],
+        transitive: { dependents: [], newDependencies: [], circular: [] },
+        timeLimitReached: false,
+        degradationNote: "Impact analysis error: git not found",
+      },
+    });
+    const verdict = computeDependsVerdict(data);
+    expect(verdict.level).toBe("inconclusive");
+    expect(verdict.summary).toContain("git not found");
+  });
+
+  test("returns inconclusive when impact scan timed out with 0 consumers", () => {
+    const data = makeSafeData({
+      impact: {
+        consumers: [],
+        transitive: { dependents: [], newDependencies: [], circular: [] },
+        timeLimitReached: true,
+        degradationNote: null,
+      },
+    });
+    const verdict = computeDependsVerdict(data);
+    expect(verdict.level).toBe("inconclusive");
+    expect(verdict.summary).toContain("timed out");
+  });
+
+  test("stays safe when impact scan found a nonzero (but low) consumer count", () => {
+    const verdict = computeDependsVerdict(makeSafeData());
+    expect(verdict.level).toBe("safe");
+  });
 });
 
 // ─── buildDependsReviewComment ──────────────────────────────────────────────
@@ -252,6 +315,22 @@ describe("buildDependsReviewComment", () => {
     expect(comment).toContain("### Impact Assessment");
     expect(comment).toContain("2 consuming files");
     expect(comment).toContain("Compress.cpp");
+  });
+
+  test("hedges impact assessment wording when 0 consumers found (does not assert safety)", () => {
+    const data = makeSafeData({
+      impact: {
+        consumers: [],
+        transitive: { dependents: [], newDependencies: [], circular: [] },
+        timeLimitReached: false,
+        degradationNote: null,
+      },
+    });
+    const comment = buildDependsReviewComment(data);
+    expect(comment).toContain("Impact scan inconclusive");
+    expect(comment).not.toContain("Safe to merge");
+    expect(comment).toContain("0 consuming files matched");
+    expect(comment.toLowerCase()).toContain("does not confirm the dependency is unused");
   });
 
   test("includes hash verification", () => {

--- a/src/lib/depends-review-builder.ts
+++ b/src/lib/depends-review-builder.ts
@@ -22,7 +22,7 @@ import type { UnifiedRetrievalChunk } from "../knowledge/cross-corpus-rrf.ts";
 // ─── Types ──────────────────────────────────────────────────────────────────
 
 export type DependsVerdict = {
-  level: "safe" | "risky" | "needs-attention";
+  level: "safe" | "risky" | "needs-attention" | "inconclusive";
   emoji: string;
   label: string;
   summary: string;
@@ -61,6 +61,14 @@ export type InlineComment = {
  * - "safe": no breaking changes, no hash mismatches, no new transitive deps, < 5 consumers
  * - "needs-attention": has breaking changes OR new transitive deps OR > 5 consumers OR hash unavailable
  * - "risky": hash mismatch OR breaking changes + many consumers OR patch removals
+ * - "inconclusive": the impact scan did not run, errored, timed out, or found
+ *   zero consuming files with no other corroborating signal. A pattern-based
+ *   #include/CMake search can never *prove* a dependency is unused -- it can
+ *   only fail to find usage, which may mean the search patterns didn't match
+ *   this codebase's naming conventions (e.g. searching for the literal string
+ *   "ffmpeg" finds nothing in code that only references "libavcodec"). Zero
+ *   results must never be reported with the same confidence as a genuinely
+ *   verified "no consumers" result.
  */
 export function computeDependsVerdict(data: DependsReviewData): DependsVerdict {
   const hasHashMismatch = data.hashResults.some(
@@ -78,6 +86,17 @@ export function computeDependsVerdict(data: DependsReviewData): DependsVerdict {
   const hasHashUnavailable = data.hashResults.some(
     (h) => h.result.status === "unavailable",
   );
+
+  // The impact scan is inconclusive when it didn't run at all, hit an error,
+  // timed out before finishing, or ran cleanly but matched zero consuming
+  // files. Zero matches is inherently ambiguous for a pattern-based search:
+  // it cannot distinguish "genuinely unused" from "search patterns didn't
+  // match this codebase's naming conventions for this dependency."
+  const impactScanInconclusive =
+    data.impact === null ||
+    Boolean(data.impact.degradationNote) ||
+    data.impact.timeLimitReached ||
+    data.impact.consumers.length === 0;
 
   // Risky: hash mismatch, or breaking changes + many consumers, or patch removals
   if (hasHashMismatch) {
@@ -144,6 +163,15 @@ export function computeDependsVerdict(data: DependsReviewData): DependsVerdict {
     };
   }
 
+  if (impactScanInconclusive) {
+    return {
+      level: "inconclusive",
+      emoji: "\u{1F50D}",
+      label: "Impact scan inconclusive",
+      summary: buildInconclusiveSummary(data.impact),
+    };
+  }
+
   // Safe
   return {
     level: "safe",
@@ -151,6 +179,20 @@ export function computeDependsVerdict(data: DependsReviewData): DependsVerdict {
     label: "Safe to merge",
     summary: "No breaking changes, hashes verified, limited impact scope.",
   };
+}
+
+/** Builds an honest summary for why the impact scan could not confirm safety. */
+function buildInconclusiveSummary(impact: ImpactResult | null): string {
+  if (impact === null) {
+    return "Impact scan did not run \u2014 unable to determine which files consume this dependency.";
+  }
+  if (impact.degradationNote) {
+    return `Impact scan failed: ${impact.degradationNote}`;
+  }
+  if (impact.timeLimitReached) {
+    return "Impact scan timed out before completing \u2014 results may be incomplete.";
+  }
+  return "0 consuming files matched via #include/CMake pattern search. This does not confirm the dependency is unused \u2014 pattern-based search can miss indirect usage or naming conventions it doesn't cover. Verify manually before merging.";
 }
 
 // ─── Comment Builder ────────────────────────────────────────────────────────
@@ -247,9 +289,18 @@ export function buildDependsReviewComment(data: DependsReviewData): string {
     sections.push("");
 
     const count = data.impact.consumers.length;
-    sections.push(
-      `**${count} consuming file${count !== 1 ? "s" : ""}** found in the codebase.`,
-    );
+    if (count === 0) {
+      sections.push(
+        "**0 consuming files matched** via #include/CMake pattern search. " +
+        "This does not confirm the dependency is unused — the search only covers direct " +
+        "`#include` and `target_link_libraries` patterns and can miss indirect usage or " +
+        "naming conventions it doesn't cover. Verify manually before merging.",
+      );
+    } else {
+      sections.push(
+        `**${count} consuming file${count !== 1 ? "s" : ""}** found in the codebase.`,
+      );
+    }
     sections.push("");
 
     if (count > 0) {

--- a/src/review-orchestration/review-reducer.test.ts
+++ b/src/review-orchestration/review-reducer.test.ts
@@ -71,6 +71,18 @@ describe("buildReviewReducerCounts", () => {
     ], undefined, { minConfidence: 50 })).not.toThrow();
   });
 
+  test("counts grounding-gate downgrades as severity demotions", () => {
+    expect(buildReviewReducerCounts([
+      baseFinding({ commentId: 1, groundingDowngraded: true, preGroundingSeverity: "critical" }),
+      baseFinding({ commentId: 2, semanticGroundingDowngraded: true, preSemanticGroundingSeverity: "major" }),
+      baseFinding({ commentId: 3, severityDemoted: true, preDemotionSeverity: "critical", demotionReason: "external-claim" }),
+      baseFinding({ commentId: 4 }),
+    ], [], { minConfidence: 50 })).toMatchObject({
+      input: 4,
+      severityDemoted: 3,
+    });
+  });
+
   test("counts overlapping filtered states with reducer-visible predicates", () => {
     expect(buildReviewReducerCounts([
       baseFinding({ commentId: 1, suppressed: true, filterAction: "suppressed", confidence: 10 }),

--- a/src/review-orchestration/review-reducer.ts
+++ b/src/review-orchestration/review-reducer.ts
@@ -255,7 +255,7 @@ export function buildReviewReducerCounts(
       lowConfidence += 1;
     }
 
-    if (finding.severityDemoted === true) {
+    if (finding.severityDemoted === true || finding.groundingDowngraded === true || finding.semanticGroundingDowngraded === true) {
       severityDemoted += 1;
     }
 

--- a/src/review-orchestration/review-reducer.ts
+++ b/src/review-orchestration/review-reducer.ts
@@ -1,4 +1,5 @@
 import { applyEnforcement } from "../enforcement/index.ts";
+import type { SemanticGroundingLLM, SemanticGroundingOptions } from "../enforcement/index.ts";
 import type { FeedbackSuppressionResult } from "../feedback/index.ts";
 import { adjustConfidenceForFeedback } from "../feedback/index.ts";
 import { reviewAdapter, type ReviewInput } from "../lib/guardrail/adapters/review-adapter.ts";
@@ -141,6 +142,12 @@ type EnforcedExtractedFinding = ProcessedReviewFinding & {
   severityElevated: boolean;
   toolingSuppressed: boolean;
   enforcementPatternId?: string;
+  groundingDowngraded?: boolean;
+  groundingReason?: string;
+  preGroundingSeverity?: FindingSeverity;
+  semanticGroundingDowngraded?: boolean;
+  semanticGroundingReason?: string;
+  preSemanticGroundingSeverity?: FindingSeverity;
 };
 
 type ReviewGuardrailRunner = (opts: unknown) => Promise<unknown>;
@@ -159,6 +166,14 @@ export type ReviewReducerInput = {
   filesByCategory: Record<string, string[]>;
   filesByLanguage: Record<string, string[]>;
   languageRules?: LanguageRulesConfig;
+  /**
+   * Optional LLM + options for the semantic grounding re-verification pass
+   * (enforcement/semantic-grounding.ts). When omitted, or when
+   * `semanticGroundingOptions.enabled` is not true, the pass is a no-op --
+   * semantic grounding is opt-in, same as graph validation below.
+   */
+  semanticGroundingLLM?: SemanticGroundingLLM | null;
+  semanticGroundingOptions?: SemanticGroundingOptions;
   reviewSuppressions: Array<string | SuppressionPattern>;
   minConfidence: number;
   prioritizationWeights?: FindingPriorityWeights;
@@ -325,8 +340,11 @@ export async function reduceReviewFindings(input: ReviewReducerInput): Promise<R
           filesByCategory: input.filesByCategory,
           filesByLanguage: input.filesByLanguage,
           languageRules: input.languageRules,
+          diffText: input.diffContent,
+          semanticGroundingLLM: input.semanticGroundingLLM,
+          semanticGroundingOptions: input.semanticGroundingOptions,
           logger: input.logger,
-        }) as EnforcedExtractedFinding[]
+        }) as unknown as EnforcedExtractedFinding[]
       : [];
 
     const toolingSuppressedCount = enforcedFindings.filter((finding) => finding.toolingSuppressed).length;
@@ -336,6 +354,38 @@ export async function reduceReviewFindings(input: ReviewReducerInput): Promise<R
       input.logger.info(
         { ...input.baseLog, toolingSuppressedCount, severityElevatedCount },
         "Language enforcement applied",
+      );
+    }
+
+    const groundingDowngradedCount = enforcedFindings.filter((finding) => finding.groundingDowngraded === true).length;
+    if (groundingDowngradedCount > 0) {
+      audit.push({ action: "severity-demoted", source: "enforcement", count: groundingDowngradedCount });
+      input.logger.info(
+        {
+          ...input.baseLog,
+          groundingDowngradedCount,
+          groundingReasons: enforcedFindings
+            .filter((finding) => finding.groundingDowngraded === true)
+            .map((finding) => finding.groundingReason)
+            .slice(0, 20),
+        },
+        "Diff grounding downgraded findings with unverifiable file:line citations",
+      );
+    }
+
+    const semanticGroundingDowngradedCount = enforcedFindings.filter((finding) => finding.semanticGroundingDowngraded === true).length;
+    if (semanticGroundingDowngradedCount > 0) {
+      audit.push({ action: "severity-demoted", source: "enforcement", count: semanticGroundingDowngradedCount });
+      input.logger.info(
+        {
+          ...input.baseLog,
+          semanticGroundingDowngradedCount,
+          semanticGroundingReasons: enforcedFindings
+            .filter((finding) => finding.semanticGroundingDowngraded === true)
+            .map((finding) => finding.semanticGroundingReason)
+            .slice(0, 20),
+        },
+        "Semantic grounding downgraded findings whose reasoning did not match the actual code",
       );
     }
 


### PR DESCRIPTION
## Summary
- Audited kodiai's live reviews on xbmc/xbmc (last 10 real PR reviews) and found a **hallucinated CRITICAL finding** published on xbmc/xbmc#28841 — fabricated brace-nesting claim citing real line numbers but wrong code behavior — plus a false "0 consuming files, safe to merge" claim on an ffmpeg major-version bump PR.
- Adds `src/enforcement/diff-grounding.ts`: structural check that a critical/major finding's cited file:line actually exists in the collected diff. Fails open when the file is entirely absent from this delivery's diff slice (ambiguous — could be reconciliation of a pre-existing finding, or an incrementally-scoped diff); only downgrades on the unambiguous case — file present in diff, cited line not in any hunk.
- Adds `src/enforcement/semantic-grounding.ts`: one cheap LLM call per structurally-grounded finding, checking whether its reasoning actually matches the cited source lines. Downgrades only on a clear mismatch; uncertain/error cases fail open. Capped at 5 findings/review, bounded concurrency 3.
- Wired live via new `review.semanticGrounding.enabled` config field (off by default, mirrors the existing `graphValidation` opt-in pattern) — no cost until a repo opts in.
- Both gates downgrade severity to `medium`, **never drop findings** — matches this codebase's existing fail-open/never-silently-drop convention (same-pr-fix-eligibility.ts precedent).

## Test plan
- [x] `bun test src/enforcement/ src/handlers/ src/review-orchestration/` — 1803 pass, 0 fail
- [x] `bunx tsc --noEmit` — clean
- [x] Verified the diff-grounding regression fix directly: caught 6 test failures from an earlier iteration where `file-not-in-diff` incorrectly downgraded severity-floor-elevated findings sourced from reconciled/pre-existing comments; fixed by fail-opening that case and only downgrading on `line-outside-diff`
- [ ] Manual verification against xbmc/xbmc#28841-style hallucination once `semanticGrounding` is enabled on a real repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)