### PR TITLE
fix: depends-lane impact scan misses ffmpeg consumers, overclaims safety

### DIFF
--- a/src/handlers/review-depends-flow.test.ts
+++ b/src/handlers/review-depends-flow.test.ts
@@ -170,7 +170,9 @@ describe("resolveReviewDependsFlow", () => {
     });
     expect(info.mock.calls.at(-1)?.[0]).toMatchObject({
       gate: "depends-review-continue",
-      verdict: "safe",
+      // impact is null here (no workspaceDir was provided) -- the scan never
+      // ran, so the verdict must be "inconclusive", not a confident "safe".
+      verdict: "inconclusive",
       hasSourceChanges: true,
     });
     expect(info.mock.calls.at(-1)?.[1]).toBe(

--- a/src/lib/depends-impact-analyzer.test.ts
+++ b/src/lib/depends-impact-analyzer.test.ts
@@ -248,6 +248,63 @@ describe("findDependencyConsumers", () => {
     const uniquePaths = new Set(result.consumers.map((c) => c.filePath));
     expect(uniquePaths.size).toBe(result.consumers.length);
   });
+
+  test("matches libavcodec/libavformat headers for library ffmpeg (alias-aware)", async () => {
+    // Real xbmc code never includes "ffmpeg" literally -- it includes the
+    // sub-library headers directly (libavcodec/avcodec.h, etc.). A search
+    // for the literal package name alone would find 0 consumers here.
+    const result = await findDependencyConsumers({
+      workspaceDir: "/fake",
+      libraryName: "ffmpeg",
+      octokit: createMockOctokit(),
+      owner: "xbmc",
+      repo: "xbmc",
+      timeBudgetMs: 5000,
+      __runGrepForTests: mockGrepRunner(
+        "xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp:10:#include <libavcodec/avcodec.h>\n" +
+        "xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp:12:#include <libavformat/avformat.h>\n",
+      ),
+      __runCmakeGrepForTests: mockGrepRunner("", 1),
+    });
+
+    expect(result.consumers.length).toBe(2);
+    expect(result.consumers.some((c) => c.filePath.includes("DVDVideoCodecFFmpeg.cpp"))).toBe(true);
+    expect(result.consumers.some((c) => c.filePath.includes("DVDDemuxFFmpeg.cpp"))).toBe(true);
+  });
+
+  test("matches uppercase CMake FFMPEG_LIBRARIES variable for library ffmpeg (case-insensitive)", async () => {
+    const result = await findDependencyConsumers({
+      workspaceDir: "/fake",
+      libraryName: "ffmpeg",
+      octokit: createMockOctokit(),
+      owner: "xbmc",
+      repo: "xbmc",
+      timeBudgetMs: 5000,
+      __runGrepForTests: mockGrepRunner("", 1),
+      __runCmakeGrepForTests: mockGrepRunner(
+        "xbmc/cores/VideoPlayer/CMakeLists.txt:20:target_link_libraries(VideoPlayer PRIVATE ${FFMPEG_LIBRARIES})\n",
+      ),
+    });
+
+    expect(result.consumers.length).toBe(1);
+    expect(result.consumers[0]!.filePath).toBe("xbmc/cores/VideoPlayer/CMakeLists.txt");
+  });
+
+  test("returns 0 consumers for ffmpeg when nothing in the tree references any known alias", async () => {
+    const result = await findDependencyConsumers({
+      workspaceDir: "/fake",
+      libraryName: "ffmpeg",
+      octokit: createMockOctokit(),
+      owner: "xbmc",
+      repo: "xbmc",
+      timeBudgetMs: 5000,
+      __runGrepForTests: mockGrepRunner("", 1),
+      __runCmakeGrepForTests: mockGrepRunner("", 1),
+    });
+
+    expect(result.consumers.length).toBe(0);
+    expect(result.degradationNote).toBeNull();
+  });
 });
 
 // ─── parseCmakeFindModule ────────────────────────────────────────────────────

--- a/src/lib/depends-impact-analyzer.ts
+++ b/src/lib/depends-impact-analyzer.ts
@@ -17,6 +17,40 @@ import { withTimeBudget } from "./usage-analyzer.ts";
 
 const MODULE_CONTENT_FETCH_CONCURRENCY = 4;
 
+// ─── Name Alias Resolution ──────────────────────────────────────────────────
+
+/**
+ * Known mappings for [depends] package names whose upstream package name
+ * doesn't match the identifiers actually used in #include paths / CMake
+ * variables throughout the xbmc source tree.
+ *
+ * The canonical example is "ffmpeg": xbmc never references the literal
+ * string "ffmpeg" in source -- it includes ffmpeg's individual libraries
+ * (libavcodec/avcodec.h, libavformat/avformat.h, ...) and links against the
+ * CMake variable FFMPEG_LIBRARIES. A pattern search for the literal package
+ * name alone returns 0 consumers even though the library is used pervasively.
+ */
+const KNOWN_LIBRARY_ALIASES: Record<string, string[]> = {
+  ffmpeg: [
+    "ffmpeg",
+    "libavcodec",
+    "libavformat",
+    "libavutil",
+    "libavfilter",
+    "libavdevice",
+    "libswscale",
+    "libswresample",
+  ],
+};
+
+function resolveSearchAliases(libraryName: string): string[] {
+  return KNOWN_LIBRARY_ALIASES[libraryName.toLowerCase()] ?? [libraryName];
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 // ─── Types ──────────────────────────────────────────────────────────────────
 
 export type IncludeConsumer = {
@@ -116,18 +150,27 @@ export async function findDependencyConsumers(params: {
   let timeLimitReached = false;
   const seenPaths = new Set<string>();
 
-  const libLower = libraryName.toLowerCase();
+  // Search under all known aliases for this library (e.g. "ffmpeg" also
+  // searches "libavcodec", "libavformat", etc.) so that a dependency whose
+  // upstream package name differs from the identifiers used in source is
+  // still found. Falls back to the literal name when no aliases are known.
+  const searchAliases = resolveSearchAliases(libraryName);
+  const aliasLowerSet = new Set(searchAliases.map((alias) => alias.toLowerCase()));
+  const aliasPattern = searchAliases.map(escapeRegExp).join("|");
 
   try {
     // --- #include pass ---
-    const includePattern = `#include.*[<"]${libraryName}[/.]`;
+    // Case-insensitive: CMake identifiers derived from these names are
+    // conventionally uppercase (e.g. FFMPEG_LIBRARIES) even though #include
+    // paths are lowercase, so a single case-insensitive pass covers both.
+    const includePattern = `#include.*[<"](?:${aliasPattern})[/.]`;
 
     const runIncludeGrep: GrepRunner =
       __runGrepForTests ??
       (async (p) => {
         return await runCommandWithCappedOutput({
           command: "git",
-          args: ["grep", "-rn", "--max-count=100", "-E", p.pattern],
+          args: ["grep", "-rn", "--max-count=100", "-i", "-E", p.pattern],
           cwd: p.workspaceDir,
           timeoutMs: timeBudgetMs,
           maxStdoutBytes: 256 * 1024,
@@ -151,8 +194,10 @@ export async function findDependencyConsumers(params: {
 
       const parsed = parseGrepOutput(stdoutText);
       for (const entry of parsed) {
-        // Filter: the snippet must actually reference this library
-        if (!entry.snippet.toLowerCase().includes(libLower)) continue;
+        // Filter: the snippet must actually reference this library or one
+        // of its known aliases (e.g. "libavcodec" for "ffmpeg")
+        const snippetLower = entry.snippet.toLowerCase();
+        if (![...aliasLowerSet].some((alias) => snippetLower.includes(alias))) continue;
 
         seenPaths.add(entry.filePath);
         consumers.push({
@@ -166,14 +211,18 @@ export async function findDependencyConsumers(params: {
 
     // --- cmake target_link_libraries pass ---
     if (!timeLimitReached) {
-      const cmakePattern = `target_link_libraries.*${libraryName}`;
+      // Case-insensitive: CMake conventionally uppercases variable names
+      // derived from the library (e.g. target_link_libraries(foo ${FFMPEG_LIBRARIES})
+      // or PkgConfig::FFMPEG), which a case-sensitive match on the lowercase
+      // package name would miss entirely.
+      const cmakePattern = `target_link_libraries.*(?:${aliasPattern})`;
 
       const runCmakeGrep: GrepRunner =
         __runCmakeGrepForTests ??
         (async (p) => {
           return await runCommandWithCappedOutput({
             command: "git",
-            args: ["grep", "-rn", "--max-count=100", "-E", p.pattern, "--", p.pathspec ?? "*/CMakeLists.txt"],
+            args: ["grep", "-rn", "--max-count=100", "-i", "-E", p.pattern, "--", p.pathspec ?? "*/CMakeLists.txt"],
             cwd: p.workspaceDir,
             timeoutMs: Math.max(timeBudgetMs / 2, 1000),
             maxStdoutBytes: 256 * 1024,

--- a/src/lib/depends-review-builder.test.ts
+++ b/src/lib/depends-review-builder.test.ts
@@ -204,6 +204,69 @@ describe("computeDependsVerdict", () => {
     expect(verdict.level).toBe("needs-attention");
     expect(verdict.summary).toContain("unavailable");
   });
+
+  // ─── Impact scan confidence (regression: xbmc/xbmc#28832 ffmpeg 9.0 bump) ──
+  //
+  // kodiai previously posted "0 consuming files found" + "Safe to merge" for
+  // a major ffmpeg bump because the pattern search for the literal string
+  // "ffmpeg" found nothing (real usage is via libavcodec/libavformat/...).
+  // A zero-consumer scan must never be reported with "safe" confidence.
+
+  test("returns inconclusive (not safe) when impact scan found 0 consumers", () => {
+    const data = makeSafeData({
+      impact: {
+        consumers: [],
+        transitive: { dependents: [], newDependencies: [], circular: [] },
+        timeLimitReached: false,
+        degradationNote: null,
+      },
+    });
+    const verdict = computeDependsVerdict(data);
+    expect(verdict.level).toBe("inconclusive");
+    expect(verdict.label).toBe("Impact scan inconclusive");
+    expect(verdict.summary).not.toContain("Safe to merge");
+    expect(verdict.summary.toLowerCase()).toContain("does not confirm");
+  });
+
+  test("returns inconclusive when impact scan did not run (null)", () => {
+    const data = makeSafeData({ impact: null, transitive: null });
+    const verdict = computeDependsVerdict(data);
+    expect(verdict.level).toBe("inconclusive");
+    expect(verdict.summary).toContain("did not run");
+  });
+
+  test("returns inconclusive when impact scan errored", () => {
+    const data = makeSafeData({
+      impact: {
+        consumers: [],
+        transitive: { dependents: [], newDependencies: [], circular: [] },
+        timeLimitReached: false,
+        degradationNote: "Impact analysis error: git not found",
+      },
+    });
+    const verdict = computeDependsVerdict(data);
+    expect(verdict.level).toBe("inconclusive");
+    expect(verdict.summary).toContain("git not found");
+  });
+
+  test("returns inconclusive when impact scan timed out with 0 consumers", () => {
+    const data = makeSafeData({
+      impact: {
+        consumers: [],
+        transitive: { dependents: [], newDependencies: [], circular: [] },
+        timeLimitReached: true,
+        degradationNote: null,
+      },
+    });
+    const verdict = computeDependsVerdict(data);
+    expect(verdict.level).toBe("inconclusive");
+    expect(verdict.summary).toContain("timed out");
+  });
+
+  test("stays safe when impact scan found a nonzero (but low) consumer count", () => {
+    const verdict = computeDependsVerdict(makeSafeData());
+    expect(verdict.level).toBe("safe");
+  });
 });
 
 // ─── buildDependsReviewComment ──────────────────────────────────────────────
@@ -252,6 +315,22 @@ describe("buildDependsReviewComment", () => {
     expect(comment).toContain("### Impact Assessment");
     expect(comment).toContain("2 consuming files");
     expect(comment).toContain("Compress.cpp");
+  });
+
+  test("hedges impact assessment wording when 0 consumers found (does not assert safety)", () => {
+    const data = makeSafeData({
+      impact: {
+        consumers: [],
+        transitive: { dependents: [], newDependencies: [], circular: [] },
+        timeLimitReached: false,
+        degradationNote: null,
+      },
+    });
+    const comment = buildDependsReviewComment(data);
+    expect(comment).toContain("Impact scan inconclusive");
+    expect(comment).not.toContain("Safe to merge");
+    expect(comment).toContain("0 consuming files matched");
+    expect(comment.toLowerCase()).toContain("does not confirm the dependency is unused");
   });
 
   test("includes hash verification", () => {

--- a/src/lib/depends-review-builder.ts
+++ b/src/lib/depends-review-builder.ts
@@ -22,7 +22,7 @@ import type { UnifiedRetrievalChunk } from "../knowledge/cross-corpus-rrf.ts";
 // ─── Types ──────────────────────────────────────────────────────────────────
 
 export type DependsVerdict = {
-  level: "safe" | "risky" | "needs-attention";
+  level: "safe" | "risky" | "needs-attention" | "inconclusive";
   emoji: string;
   label: string;
   summary: string;
@@ -61,6 +61,14 @@ export type InlineComment = {
  * - "safe": no breaking changes, no hash mismatches, no new transitive deps, < 5 consumers
  * - "needs-attention": has breaking changes OR new transitive deps OR > 5 consumers OR hash unavailable
  * - "risky": hash mismatch OR breaking changes + many consumers OR patch removals
+ * - "inconclusive": the impact scan did not run, errored, timed out, or found
+ *   zero consuming files with no other corroborating signal. A pattern-based
+ *   #include/CMake search can never *prove* a dependency is unused -- it can
+ *   only fail to find usage, which may mean the search patterns didn't match
+ *   this codebase's naming conventions (e.g. searching for the literal string
+ *   "ffmpeg" finds nothing in code that only references "libavcodec"). Zero
+ *   results must never be reported with the same confidence as a genuinely
+ *   verified "no consumers" result.
  */
 export function computeDependsVerdict(data: DependsReviewData): DependsVerdict {
   const hasHashMismatch = data.hashResults.some(
@@ -78,6 +86,17 @@ export function computeDependsVerdict(data: DependsReviewData): DependsVerdict {
   const hasHashUnavailable = data.hashResults.some(
     (h) => h.result.status === "unavailable",
   );
+
+  // The impact scan is inconclusive when it didn't run at all, hit an error,
+  // timed out before finishing, or ran cleanly but matched zero consuming
+  // files. Zero matches is inherently ambiguous for a pattern-based search:
+  // it cannot distinguish "genuinely unused" from "search patterns didn't
+  // match this codebase's naming conventions for this dependency."
+  const impactScanInconclusive =
+    data.impact === null ||
+    Boolean(data.impact.degradationNote) ||
+    data.impact.timeLimitReached ||
+    data.impact.consumers.length === 0;
 
   // Risky: hash mismatch, or breaking changes + many consumers, or patch removals
   if (hasHashMismatch) {
@@ -144,6 +163,15 @@ export function computeDependsVerdict(data: DependsReviewData): DependsVerdict {
     };
   }
 
+  if (impactScanInconclusive) {
+    return {
+      level: "inconclusive",
+      emoji: "\u{1F50D}",
+      label: "Impact scan inconclusive",
+      summary: buildInconclusiveSummary(data.impact),
+    };
+  }
+
   // Safe
   return {
     level: "safe",
@@ -151,6 +179,20 @@ export function computeDependsVerdict(data: DependsReviewData): DependsVerdict {
     label: "Safe to merge",
     summary: "No breaking changes, hashes verified, limited impact scope.",
   };
+}
+
+/** Builds an honest summary for why the impact scan could not confirm safety. */
+function buildInconclusiveSummary(impact: ImpactResult | null): string {
+  if (impact === null) {
+    return "Impact scan did not run \u2014 unable to determine which files consume this dependency.";
+  }
+  if (impact.degradationNote) {
+    return `Impact scan failed: ${impact.degradationNote}`;
+  }
+  if (impact.timeLimitReached) {
+    return "Impact scan timed out before completing \u2014 results may be incomplete.";
+  }
+  return "0 consuming files matched via #include/CMake pattern search. This does not confirm the dependency is unused \u2014 pattern-based search can miss indirect usage or naming conventions it doesn't cover. Verify manually before merging.";
 }
 
 // ─── Comment Builder ────────────────────────────────────────────────────────
@@ -247,9 +289,18 @@ export function buildDependsReviewComment(data: DependsReviewData): string {
     sections.push("");
 
     const count = data.impact.consumers.length;
-    sections.push(
-      `**${count} consuming file${count !== 1 ? "s" : ""}** found in the codebase.`,
-    );
+    if (count === 0) {
+      sections.push(
+        "**0 consuming files matched** via #include/CMake pattern search. " +
+        "This does not confirm the dependency is unused — the search only covers direct " +
+        "`#include` and `target_link_libraries` patterns and can miss indirect usage or " +
+        "naming conventions it doesn't cover. Verify manually before merging.",
+      );
+    } else {
+      sections.push(
+        `**${count} consuming file${count !== 1 ? "s" : ""}** found in the codebase.`,
+      );
+    }
     sections.push("");
 
     if (count > 0) {


### PR DESCRIPTION
## Summary
- On real xbmc/xbmc#28832 (`[depends][target] Update ffmpeg to 9.0`), kodiai posted **"0 consuming files found" / "✅ Safe to merge"** for a major-version FFmpeg bump — implausible for a codebase that uses FFmpeg pervasively throughout VideoPlayer/DVDCodecs.
- **Root cause**: `findDependencyConsumers()` in `src/lib/depends-impact-analyzer.ts` grepped for the literal `[depends]` package name (`"ffmpeg"`), but xbmc source never spells it that way — it includes `libavcodec/avcodec.h`, `libavformat/avformat.h`, etc. and links against the CMake variable `FFMPEG_LIBRARIES`. The grep was also case-sensitive, so even a literal `FFMPEG` in CMake wouldn't match. The scan wasn't finding "no consumers" — it was searching for the wrong string entirely.
- Separately, `computeDependsVerdict()` in `src/lib/depends-review-builder.ts` treated a 0-consumer count identically whether the scan never ran, errored, timed out, or matched nothing — collapsing "search failed" and "verified zero consumers" into the same confident "safe" verdict. A pattern-based grep can never *prove* zero usage.

## Fix
- Added a known-alias table (`ffmpeg` → `libavcodec`/`libavformat`/`libavutil`/`libavfilter`/`libavdevice`/`libswscale`/`libswresample`) used to build both the `#include` and `target_link_libraries` grep patterns, and made both passes case-insensitive.
- Added a new `"inconclusive"` verdict level (🔍 "Impact scan inconclusive"), returned whenever the scan didn't run, degraded, timed out, or found 0 consumers — so a failed/incomplete scan is never presented with the same confidence as a genuinely verified empty result. The comment now explicitly tells reviewers to verify manually in that case.

## Test plan
- [x] `bun test src/lib/ src/handlers/` — 2550 pass, 0 fail
- [x] `bunx tsc --noEmit` — clean
- [ ] Manual verification against an xbmc/xbmc-style ffmpeg bump PR once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)