### PR TITLE
fix: restore repoBudgetSchema — main currently fails to boot

### DIFF
--- a/src/execution/config-schema.ts
+++ b/src/execution/config-schema.ts
@@ -645,6 +645,12 @@ export const modelsSchema = z
   .record(z.string(), z.string())
   .default({});
 
+export const repoBudgetSchema = z
+  .object({
+    targetRemoteRuntimeSeconds: z.number().min(30).max(3600).default(600),
+  })
+  .default({ targetRemoteRuntimeSeconds: 600 });
+
 export const repoConfigSchema = z.object({
   model: z.string().default("claude-sonnet-5"),
   maxTurns: z.number().min(1).max(100).default(40),
@@ -656,6 +662,8 @@ export const repoConfigSchema = z.object({
   defaultModel: z.string().optional(),
   /** Default fallback model for when primary model fails. */
   defaultFallbackModel: z.string().optional(),
+  /** Per-repo execution timeout budget. Overrides timeoutSeconds for ACA runtime. */
+  repoBudget: repoBudgetSchema,
   /**
    * Write-mode gates mention-driven code modifications (branch/commit/push).
    * This is deny-by-default. Enabling this does not affect review-only behavior.


### PR DESCRIPTION
**`main` is currently broken and cannot start.** This restores it.

## What happened

#218 removed `repoBudgetSchema` and the `repoBudget` field from `repoConfigSchema`, but left both consumers in place:

- `src/execution/config.ts:13` imports `repoBudgetSchema` and parses `obj.repoBudget` with it
- `src/execution/executor.ts:622` reads `repoConfig.repoBudget.targetRemoteRuntimeSeconds` to set the ACA execution timeout

So the removal was incomplete, and the result is a module-resolution failure in **production code**, not just tests:

```
$ bun -e 'import("./src/index.ts")'
FAILED: Export named 'repoBudgetSchema' not found in module '.../src/execution/config-schema.ts'
```

Deploying `main` in this state would have crash-looped the orchestrator on boot. It was caught during a pre-deploy verification run.

## Why it wasn't obvious

The break also stopped **690 tests from running** — the entire `createReviewHandler` suite aborted at module load. Because CI's `unit` job is already red with ~135 pre-existing failures, a fatal boot error was camouflaged as "still red, as usual". Test *counts* moved (7766 → 7076 run, 15 → 51 errors) but the pass/fail headline did not make it obvious.

That broken CI baseline is worth fixing separately — it just hid a production-down bug.

## The fix

Restores the two removed declarations exactly. This is the behavior-preserving option: `repoBudget` is live functionality that sets per-repo execution timeouts, so *completing* the removal instead would change production timeout behavior and should be a deliberate, separate change.

## Verification

| | pre-#218 (`4af5f0f7c3`) | `main` (#218) | this PR |
| --- | ---: | ---: | ---: |
| Tests run | 7766 | 7076 | **7766** |
| Errors | 15 | 51 | **15** |
| App entrypoint loads | yes | **no** | **yes** |

`src/index.ts` now loads through to the Postgres connection attempt, which is the expected local outcome without DB access.

## Known follow-up, not addressed here

With the boot fixed, `main` still has **35 test failures beyond the pre-#218 baseline** (150 → 185), all in review-prompt / review-handler / review-reducer assertions — #218 changed `review-prompt.ts` (+55 lines) and `review-reducer.ts` without updating the tests that assert on their output. Those are content assertions rather than crashes, so they are out of scope for this hotfix, but they should be triaged: they may indicate unintended review-output changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)