### PR TITLE
fix: restore claim-classification fallback for no-diff reviews

### DIFF
--- a/src/review-orchestration/review-reducer.ts
+++ b/src/review-orchestration/review-reducer.ts
@@ -265,6 +265,18 @@ export async function reduceReviewFindings(input: ReviewReducerInput): Promise<R
       if (finding.claimClassification && !claimClassificationMap.has(finding.commentId)) {
         claimClassificationMap.set(finding.commentId, finding.claimClassification);
       }
+      // NOT redundant with the block above, despite looking like it. classifyClaims
+      // returns an entry for every finding it is given, so `.has(commentId)` is
+      // already true by the time that block runs and it never fires. When there is
+      // no diffContent, fileDiffs is empty, so classifyClaims had nothing to ground
+      // against and its result must not win over a classification the finding
+      // already carries -- this overwrite is the only path that applies it.
+      // Removing this drops rewrite/demotion for pre-classified findings on every
+      // no-diff review path. Covered by "applies suppression, rewrite,
+      // prioritization, and min-confidence gates in handler order".
+      if (finding.claimClassification && !input.diffContent) {
+        claimClassificationMap.set(finding.commentId, finding.claimClassification);
+      }
     }
 
     let externalClaimCount = 0;


### PR DESCRIPTION
Restores a block #218 removed as "redundant". It was not redundant, and removing it silently disabled rewrite and severity-demotion for pre-classified findings on every no-diff review path.

## What was removed and why

Commit `8397735298` ("fix: resolve code review findings — redundant logic and regex escaping") states:

> review-reducer.ts line 268: Remove redundant claimClassification assignment that overwrites value set at line 265 when diffContent is falsy. Single dedup check is sufficient.

That was a **false-positive review finding**. The two blocks do different things:

```ts
if (finding.claimClassification && !claimClassificationMap.has(commentId))  // (1) fill-if-absent
if (finding.claimClassification && !input.diffContent)                      // (2) overwrite when no diff
```

`classifyClaims` returns an entry for **every** finding it is handed, so `claimClassificationMap.has(commentId)` is already `true` by the time (1) runs — **(1) never fires**. Block (2) was the only path that applied a classification the finding already carried.

## Why it matters

It matters precisely when there is no `diffContent`. In that case `fileDiffs` is an empty `Map`, so `classifyClaims` had nothing to ground against — and its ungrounded result must not win over the finding's own classification.

With (2) removed, the reducer produced **zero** `filterRecords` where it should have produced one: pre-classified findings lost their rewrite and severity demotion on every no-diff review path.

## The fix

Restore the block, with a comment explaining why it is not redundant — so the same false positive doesn't get "fixed" again by the next review pass.

## Verification

Fixes the 3 remaining #218 regressions:

```
reduceReviewFindings > applies suppression, rewrite, prioritization, and min-confidence gates in handler order
evaluateM067S03ReviewReducerContract > returns a successful deterministic report for reducer counts, parity, details, fail-open, and graph validation
evaluateM067S03ReviewReducerContract > prints parseable JSON with bounded evidence and no raw finding, diff, prompt, or secret payloads
```

Suite progression across the whole cleanup:

| State | Failures |
| --- | ---: |
| pre-#218 (`4af5f0f7c3`) | 150 |
| `main` after #218 | 185 |
| with #221 (instruction budget) | 43 |
| **with #221 + this PR** | **40** |

Verified by merging this branch onto #221 locally: 40 failures, exactly the 43 from #221 minus these 3. No interaction between the two fixes.

Best reviewed alongside #221 — both came out of triaging #218.

🤖 Generated with [Claude Code](https://claude.com/claude-code)