### PR TITLE
fix: make retry-prompt compaction explicitly opt-in (blocks #221)

### DIFF
--- a/scripts/fixtures/m073-s04-continuation-compaction.json
+++ b/scripts/fixtures/m073-s04-continuation-compaction.json
@@ -15,9 +15,17 @@
       "reusedCheckpointCount": 2,
       "omittedScopeCount": 8,
       "remainingScopeCount": 3,
-      "safetySignalNames": ["budget-window", "cache-hit-safe", "checkpoint-integrity"],
-      "budgetSignalNames": ["remaining-token-budget"],
-      "cacheSignalNames": ["review-derived-prompt"]
+      "safetySignalNames": [
+        "budget-window",
+        "cache-hit-safe",
+        "checkpoint-integrity"
+      ],
+      "budgetSignalNames": [
+        "remaining-token-budget"
+      ],
+      "cacheSignalNames": [
+        "review-derived-prompt"
+      ]
     },
     {
       "caseId": "missing-budget-signal",
@@ -32,7 +40,9 @@
       "reusedCheckpointCount": 0,
       "omittedScopeCount": 0,
       "remainingScopeCount": 9,
-      "missingSignalNames": ["prompt-budget-outcomes"]
+      "missingSignalNames": [
+        "prompt-budget-outcomes"
+      ]
     },
     {
       "caseId": "degraded-cache-signal",
@@ -48,9 +58,16 @@
       "reusedCheckpointCount": 1,
       "omittedScopeCount": 4,
       "remainingScopeCount": 2,
-      "safetySignalNames": ["budget-window"],
-      "budgetSignalNames": ["remaining-token-budget"],
-      "cacheSignalNames": ["retrieval-query-embedding", "cache-ttl"]
+      "safetySignalNames": [
+        "budget-window"
+      ],
+      "budgetSignalNames": [
+        "remaining-token-budget"
+      ],
+      "cacheSignalNames": [
+        "retrieval-query-embedding",
+        "cache-ttl"
+      ]
     },
     {
       "caseId": "no-remaining-scope",
@@ -79,9 +96,15 @@
       "reusedCheckpointCount": 0,
       "omittedScopeCount": 0,
       "remainingScopeCount": 5,
-      "budgetSignalNames": ["prompt-budget.included"],
-      "cacheSignalNames": ["cache.safe-reuse"],
-      "missingSignalNames": ["checkpoint.summary"]
+      "budgetSignalNames": [
+        "prompt-budget.included"
+      ],
+      "cacheSignalNames": [
+        "cache.safe-reuse"
+      ],
+      "missingSignalNames": [
+        "checkpoint.summary"
+      ]
     },
     {
       "caseId": "unsafe-cache-state",
@@ -97,8 +120,13 @@
       "reusedCheckpointCount": 0,
       "omittedScopeCount": 1,
       "remainingScopeCount": 4,
-      "budgetSignalNames": ["prompt-budget.included"],
-      "cacheSignalNames": ["cache.disabled-cache", "cache.safe-reuse"]
+      "budgetSignalNames": [
+        "prompt-budget.included"
+      ],
+      "cacheSignalNames": [
+        "cache.disabled-cache",
+        "cache.safe-reuse"
+      ]
     },
     {
       "caseId": "malformed-prior-state",
@@ -114,9 +142,15 @@
       "reusedCheckpointCount": 0,
       "omittedScopeCount": 2,
       "remainingScopeCount": 6,
-      "budgetSignalNames": ["prompt-budget.included"],
-      "cacheSignalNames": ["cache.safe-reuse"],
-      "missingSignalNames": ["checkpoint.summary"]
+      "budgetSignalNames": [
+        "prompt-budget.included"
+      ],
+      "cacheSignalNames": [
+        "cache.safe-reuse"
+      ],
+      "missingSignalNames": [
+        "checkpoint.summary"
+      ]
     }
   ],
   "continuationCompactionSummary": {
@@ -136,7 +170,8 @@
       "degraded-cache-signal": 1,
       "unsafe-cache-state": 1,
       "malformed-prior-state": 1,
-      "no-remaining-scope": 1
+      "no-remaining-scope": 1,
+      "compaction-disabled": 0
     },
     "fallbackStateCounts": {
       "none": 2,
@@ -147,9 +182,25 @@
     "reusedCheckpointCount": 3,
     "omittedScopeCount": 15,
     "remainingScopeCount": 29,
-    "safetySignalNames": ["budget-window", "cache-hit-safe", "checkpoint-integrity"],
-    "budgetSignalNames": ["prompt-budget.included", "remaining-token-budget"],
-    "cacheSignalNames": ["cache-ttl", "cache.disabled-cache", "cache.safe-reuse", "retrieval-query-embedding", "review-derived-prompt"],
-    "missingSignalNames": ["checkpoint.summary", "prompt-budget-outcomes"]
+    "safetySignalNames": [
+      "budget-window",
+      "cache-hit-safe",
+      "checkpoint-integrity"
+    ],
+    "budgetSignalNames": [
+      "prompt-budget.included",
+      "remaining-token-budget"
+    ],
+    "cacheSignalNames": [
+      "cache-ttl",
+      "cache.disabled-cache",
+      "cache.safe-reuse",
+      "retrieval-query-embedding",
+      "review-derived-prompt"
+    ],
+    "missingSignalNames": [
+      "checkpoint.summary",
+      "prompt-budget-outcomes"
+    ]
   }
 }

--- a/scripts/fixtures/m073-s05-visible-budget.json
+++ b/scripts/fixtures/m073-s05-visible-budget.json
@@ -16,7 +16,8 @@
         "reasonCounts": {
           "within-budget": 0,
           "section-over-budget": 0,
-          "zero-budget": 0
+          "zero-budget": 0,
+          "compaction-disabled": 0
         },
         "totalBudgetTokens": 0,
         "totalIncludedTokens": 0,
@@ -37,7 +38,8 @@
           "incomplete-fingerprint": 0,
           "expired-stale-entry": 0,
           "disabled-cache": 0,
-          "unavailable-retrieval": 0
+          "unavailable-retrieval": 0,
+          "compaction-disabled": 0
         },
         "bookkeepingErrorCount": 0,
         "missingSignalCount": 0,
@@ -58,7 +60,8 @@
           "degraded-cache-signal": 0,
           "unsafe-cache-state": 0,
           "malformed-prior-state": 0,
-          "no-remaining-scope": 0
+          "no-remaining-scope": 0,
+          "compaction-disabled": 0
         },
         "fallbackStateCounts": {
           "none": 0,
@@ -90,7 +93,8 @@
         "reasonCounts": {
           "within-budget": 2,
           "section-over-budget": 2,
-          "zero-budget": 1
+          "zero-budget": 1,
+          "compaction-disabled": 0
         },
         "totalBudgetTokens": 975,
         "totalIncludedTokens": 925,
@@ -111,7 +115,8 @@
           "incomplete-fingerprint": 1,
           "expired-stale-entry": 1,
           "disabled-cache": 1,
-          "unavailable-retrieval": 1
+          "unavailable-retrieval": 1,
+          "compaction-disabled": 0
         },
         "bookkeepingErrorCount": 1,
         "missingSignalCount": 2,
@@ -132,7 +137,8 @@
           "degraded-cache-signal": 0,
           "unsafe-cache-state": 0,
           "malformed-prior-state": 0,
-          "no-remaining-scope": 0
+          "no-remaining-scope": 0,
+          "compaction-disabled": 0
         },
         "fallbackStateCounts": {
           "none": 0,
@@ -164,7 +170,8 @@
         "reasonCounts": {
           "within-budget": 0,
           "section-over-budget": 0,
-          "zero-budget": 0
+          "zero-budget": 0,
+          "compaction-disabled": 0
         },
         "totalBudgetTokens": 0,
         "totalIncludedTokens": 0,
@@ -185,7 +192,8 @@
           "incomplete-fingerprint": 0,
           "expired-stale-entry": 0,
           "disabled-cache": 0,
-          "unavailable-retrieval": 0
+          "unavailable-retrieval": 0,
+          "compaction-disabled": 0
         },
         "bookkeepingErrorCount": 0,
         "missingSignalCount": 0,
@@ -206,7 +214,8 @@
           "degraded-cache-signal": 1,
           "unsafe-cache-state": 1,
           "malformed-prior-state": 1,
-          "no-remaining-scope": 1
+          "no-remaining-scope": 1,
+          "compaction-disabled": 0
         },
         "fallbackStateCounts": {
           "none": 2,
@@ -241,7 +250,8 @@
       "prompt-budget-limited": 1,
       "continuation-compacted": 0,
       "continuation-fallback": 1,
-      "cache-degraded": 0
+      "cache-degraded": 0,
+      "compaction-disabled": 0
     },
     "promptObservationCount": 2,
     "promptSectionCount": 5,

--- a/src/lib/review-continuation-lifecycle.test.ts
+++ b/src/lib/review-continuation-lifecycle.test.ts
@@ -151,6 +151,62 @@ describe("planReviewContinuation", () => {
     });
   });
 
+  test("keeps retry-prompt compaction disabled unless explicitly enabled", async () => {
+    // Compaction has never executed in production: hasCompleteBudgetSignals requires
+    // every prompt budget outcome to be "included", and review-instructions was
+    // permanently "trimmed" under an undersized budget. Raising that budget would
+    // otherwise turn this branch on as a silent side effect, on the retry-after-timeout
+    // path. Pin that it stays off by default even when every other signal is perfect.
+    const mod = await loadLifecycleModule();
+    expect(mod).not.toBeNull();
+
+    const decision = mod!.planReviewContinuation({
+      reviewOutputKey: "review-123",
+      firstPass: makeFirstPass(),
+      checkpoint: makeCheckpoint(),
+      riskScores: makeRiskScores([["src/a.ts", 10], ["src/c.ts", 90]]),
+      timeoutSeconds: 120,
+      hasPublishedInlineFindings: false,
+      isChronicTimeout: false,
+      continuationCompaction: {
+        // deliberately NOT setting compactionEnabled
+        attemptId: "attempt-2",
+        priorAttemptId: "attempt-1",
+        attemptOrdinal: 2,
+        promptBudgetOutcomes: [
+          {
+            sectionName: "review-instructions",
+            sectionPosition: 0,
+            budgetChars: 4000,
+            budgetTokens: 1000,
+            includedChars: 500,
+            includedTokens: 125,
+            trimmedChars: 0,
+            trimmedTokens: 0,
+            status: "included",
+            reason: "within-budget",
+          },
+        ],
+        cacheTelemetryObservations: [
+          { caseId: "cache-1", status: "hit", safetySignalNames: ["cache.fresh"] } as never,
+        ],
+      },
+      estimateContinuationTimeout: () => ({
+        riskLevel: "low",
+        dynamicTimeoutSeconds: 120,
+        reasoning: "test",
+        shouldReduceScope: false,
+      }),
+    });
+
+    expect(decision.decision).toBe("schedule-continuation");
+    const observation = (decision as { continuationCompaction?: Record<string, unknown> }).continuationCompaction;
+    expect(observation?.status).toBe("fallback");
+    expect(observation?.reason).toBe("compaction-disabled");
+    expect(observation?.fallbackState).toBe("fuller-context");
+    expect(observation?.reusedCheckpointCount).toBe(0);
+  });
+
   test("adds compact retry evidence when checkpoint, prompt budget, and cache safety signals are complete", async () => {
     const mod = await loadLifecycleModule();
     expect(mod).not.toBeNull();
@@ -169,6 +225,7 @@ describe("planReviewContinuation", () => {
       hasPublishedInlineFindings: false,
       isChronicTimeout: false,
       continuationCompaction: {
+        compactionEnabled: true,
         attemptId: "attempt-2",
         priorAttemptId: "attempt-1",
         attemptOrdinal: 2,
@@ -246,6 +303,7 @@ describe("planReviewContinuation", () => {
       hasPublishedInlineFindings: false,
       isChronicTimeout: false,
       continuationCompaction: {
+        compactionEnabled: true,
         attemptId: "attempt-2",
         promptBudgetOutcomes: [
           {
@@ -311,6 +369,7 @@ describe("planReviewContinuation", () => {
       hasPublishedInlineFindings: false,
       isChronicTimeout: false,
       continuationCompaction: {
+        compactionEnabled: true,
         attemptId: "attempt-2",
         promptBudgetOutcomes: [
           {
@@ -374,6 +433,7 @@ describe("planReviewContinuation", () => {
       hasPublishedInlineFindings: false,
       isChronicTimeout: false,
       continuationCompaction: {
+        compactionEnabled: true,
         attemptId: "attempt-2",
         promptBudgetOutcomes: [
           {
@@ -437,6 +497,7 @@ describe("planReviewContinuation", () => {
       hasPublishedInlineFindings: false,
       isChronicTimeout: false,
       continuationCompaction: {
+        compactionEnabled: true,
         attemptId: "attempt-2",
         promptBudgetOutcomes: [
           {
@@ -502,6 +563,7 @@ describe("planReviewContinuation", () => {
       hasPublishedInlineFindings: false,
       isChronicTimeout: false,
       continuationCompaction: {
+        compactionEnabled: true,
         attemptId: "attempt-2",
         promptBudgetOutcomes: [
           {

--- a/src/lib/review-continuation-lifecycle.ts
+++ b/src/lib/review-continuation-lifecycle.ts
@@ -24,6 +24,17 @@ export type ContinuationCompactionPlanningSignals = {
   attemptOrdinal?: number;
   promptBudgetOutcomes: readonly PromptBudgetOutcome[];
   cacheTelemetryObservations: readonly ReviewCacheTelemetryObservation[];
+  /**
+   * Opt-in switch for retry-prompt compaction. Defaults to disabled.
+   *
+   * This path has never executed in production: hasCompleteBudgetSignals requires
+   * EVERY prompt budget outcome to be "included", and review-instructions was
+   * permanently "trimmed" under an undersized budget, so every retry fell back to
+   * fuller-context. Fixing that budget would otherwise flip a never-exercised branch
+   * live as a silent side effect -- and on the retry-after-timeout path, where thinner
+   * prior-attempt context is most costly. Enabling it must be deliberate.
+   */
+  compactionEnabled?: boolean;
 };
 
 export type PlanReviewContinuationParams = {
@@ -184,6 +195,7 @@ function buildContinuationCompactionObservation(params: {
   omittedScopeCount: number;
   promptBudgetOutcomes: readonly PromptBudgetOutcome[];
   cacheTelemetryObservations: readonly ReviewCacheTelemetryObservation[];
+  compactionEnabled: boolean;
 }): ContinuationCompactionObservation {
   const budgetSignalNames = deriveBudgetSignalNames(params.promptBudgetOutcomes);
   const cacheSignalNames = deriveCacheSignalNames(params.cacheTelemetryObservations);
@@ -207,6 +219,17 @@ function buildContinuationCompactionObservation(params: {
     omittedScopeCount: params.omittedScopeCount,
     remainingScopeCount: params.continuationFiles.length,
   } as const;
+
+  if (!params.compactionEnabled) {
+    return {
+      ...base,
+      status: "fallback",
+      reason: "compaction-disabled",
+      fallbackState: "fuller-context",
+      budgetSignalNames,
+      cacheSignalNames,
+    };
+  }
 
   if (!params.checkpoint) {
     return {
@@ -380,6 +403,7 @@ export function planReviewContinuation(
         omittedScopeCount: filesAlreadyReviewed.length,
         promptBudgetOutcomes: params.continuationCompaction.promptBudgetOutcomes,
         cacheTelemetryObservations: params.continuationCompaction.cacheTelemetryObservations,
+        compactionEnabled: params.continuationCompaction.compactionEnabled === true,
       })
     : undefined;
 

--- a/src/review-continuation/continuation-compaction.ts
+++ b/src/review-continuation/continuation-compaction.ts
@@ -13,6 +13,9 @@ export const CONTINUATION_COMPACTION_REASONS = [
   "unsafe-cache-state",
   "malformed-prior-state",
   "no-remaining-scope",
+  // Compaction is opt-in. Reported instead of reusing "missing-budget-signal", which
+  // would misdescribe a healthy prompt budget as a missing signal to operators.
+  "compaction-disabled",
 ] as const;
 
 export const CONTINUATION_COMPACTION_FALLBACK_STATES = [
@@ -275,7 +278,7 @@ function validateDecisionSafety(observations: readonly ContinuationCompactionObs
     }
 
     if (observation.status === "fallback") {
-      if (!["missing-checkpoint", "missing-budget-signal", "unsafe-cache-state", "malformed-prior-state"].includes(observation.reason)) {
+      if (!["missing-checkpoint", "missing-budget-signal", "unsafe-cache-state", "malformed-prior-state", "compaction-disabled"].includes(observation.reason)) {
         issues.push(`${prefix} fallback status requires a fail-closed fallback reason.`);
       }
       if (observation.fallbackState !== "fuller-context") issues.push(`${prefix} fallback status requires fallbackState fuller-context.`);


### PR DESCRIPTION
**Retry-prompt compaction has never executed in production, and nothing says so.** This makes that explicit before an unrelated change turns it on by accident.

## The trap

`buildContinuationCompactionObservation` gates the `safe-delta-reuse` path on `hasCompleteBudgetSignals`, which requires **every** prompt budget outcome to be `"included"`:

```ts
const hasCompleteBudgetSignals = params.promptBudgetOutcomes.length > 0
  && params.promptBudgetOutcomes.every((outcome) => outcome.status === "included");
```

`review-instructions` has been permanently `"trimmed"` under an undersized budget, so this has always returned `status: "fallback"`, `reason: "missing-budget-signal"`. The branch is effectively dead code that looks live.

That matters because raising the instruction budget is independently necessary — the same truncation silently strips verdict logic and severity templates from published reviews (#221). But raising it **flips this branch on as a pure side effect**: first-ever production execution, on the retry-after-timeout path, where thinner prior-attempt context is most costly, with no test covering the newly reachable behavior.

Found while re-reviewing #221; it is the reason #221 must not merge first.

## What this does

Gate on an explicit `compactionEnabled` flag defaulting to **false**, so enabling compaction is a deliberate, separately-reviewed change rather than a consequence of a budget constant.

Reports a distinct `"compaction-disabled"` reason rather than reusing `"missing-budget-signal"` — the latter would misdescribe a perfectly healthy prompt budget as a missing signal in operator-facing evidence, which is exactly the truthfulness drift the review guidelines call out.

The flag is threaded as a **parameter**, not read from the environment inside the decision function, so the logic stays unit-testable. An earlier attempt short-circuited inside the function and broke 8 tests plus both golden fixtures by making the decision logic unreachable in its default state.

## Verification

- The six existing `planReviewContinuation` tests that exercise compaction now opt in explicitly — they test the decision logic, not the rollout switch.
- New test pins that compaction stays disabled by default **even when checkpoint, prompt budget, and cache signals are all complete** — i.e. exactly the state that would otherwise flip it live.
- Golden fixtures `m073-s04`/`m073-s05` gain `"compaction-disabled": 0`, since their declared `reasonCounts` must enumerate every reason in the bounded vocabulary.
- Full suite at **185** — identical to `main`. No behavior change in production, which is the point: production has always taken the fallback path.

## Merge order

**Land this before #221.** #221 raises the instruction budget from 18k to 40k, which is what flips `hasCompleteBudgetSignals` to true.

Enabling compaction for real is a separate follow-up: it needs its own tests for the compacted branch, and a decision about whether a post-timeout retry should be reviewing with a one-line checkpoint plus a 400-char summary draft in place of full prior context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)